### PR TITLE
Add plugin ZTools CLI E2E Demo v0.2.0

### DIFF
--- a/plugins/ztools-cli-e2e-demo/.gitignore
+++ b/plugins/ztools-cli-e2e-demo/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env*

--- a/plugins/ztools-cli-e2e-demo/CHANGELOG.md
+++ b/plugins/ztools-cli-e2e-demo/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## 0.2.0 - 2026-04-25
+
+- E2E test: validate auto-generated commit title with multiple subjects
+- E2E test: confirm CHANGELOG.md auto-injection into PR description
+- Add a fake API surface to test bullet-list formatting
+
+## 0.1.2
+
+- Earlier round of testing
+
+## 0.1.0
+
+- Initial demo

--- a/plugins/ztools-cli-e2e-demo/README.md
+++ b/plugins/ztools-cli-e2e-demo/README.md
@@ -1,0 +1,4 @@
+# ZTools CLI E2E Demo
+
+This is a throwaway plugin used to verify that `ztools publish` works end-to-end.
+It will be reverted/closed once verification completes.

--- a/plugins/ztools-cli-e2e-demo/index.js
+++ b/plugins/ztools-cli-e2e-demo/index.js
@@ -1,0 +1,5 @@
+console.log('hello from ztools cli demo v0.1.1 — incremental update')
+// reviewer suggestion: clarify log message
+// author concurrent change: also tweak entry message
+// fake feature 1
+// fake feature 2

--- a/plugins/ztools-cli-e2e-demo/plugin.json
+++ b/plugins/ztools-cli-e2e-demo/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "ztools-cli-e2e-demo",
+  "title": "ZTools CLI E2E Demo",
+  "description": "End-to-end demo to validate ztools-plugin-cli publish flow. Safe to close.",
+  "author": "lzx8589561 <lzx8589561@gmail.com>",
+  "version": "0.2.0"
+}


### PR DESCRIPTION
## 插件信息

- **名称**: ZTools CLI E2E Demo
- **插件ID**: ztools-cli-e2e-demo
- **版本**: 0.2.0
- **描述**: End-to-end demo to validate ztools-plugin-cli publish flow. Safe to close.
- **作者**: lzx8589561 <lzx8589561@gmail.com>
- **类型**: 新增

## 本次变更

- E2E test: validate auto-generated commit title with multiple subjects
- E2E test: confirm CHANGELOG.md auto-injection into PR description
- Add a fake API surface to test bullet-list formatting

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [ ] plugin.json 的 name / title / version / description / author 字段均已检查
- [ ] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [ ] 本次 PR 的 diff 仅涉及 `plugins/ztools-cli-e2e-demo/` 目录
- [ ] 本地 `ztools publish` 已成功跑通
- [ ] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
