### PR TITLE
Add plugin 开发加解密编码工具 v0.1.0

### DIFF
--- a/plugins/developer-codec-tools/.gitignore
+++ b/plugins/developer-codec-tools/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.DS_Store
+*.log*

--- a/plugins/developer-codec-tools/.gitignore
+++ b/plugins/developer-codec-tools/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 .DS_Store
 *.log*
+*.zip
+*.zpx

--- a/plugins/developer-codec-tools/CHANGELOG.md
+++ b/plugins/developer-codec-tools/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## v0.1.0
+
+- 初始发布开发加解密编码工具插件。
+- 支持 Base64、Base64URL、URL、HTML Entity、Unicode escape、Hex、Binary 等编码转换。
+- 支持 MD5、SHA-1、SHA-256、SHA-384、SHA-512、HMAC-SHA256、HMAC-SHA384、HMAC-SHA512。
+- 支持 AES-GCM、AES-CBC 基于口令加密和解密。
+- 支持 JWT 解码和 HS256/HS384/HS512 签名校验。
+- 支持 JSON 格式化、压缩和常用文本转换。

--- a/plugins/developer-codec-tools/README.md
+++ b/plugins/developer-codec-tools/README.md
@@ -1,0 +1,39 @@
+# 开发加解密编码工具
+
+这是一个 ZTools UI 插件，覆盖常用开发场景：
+
+- Base64、Base64URL、URL、HTML Entity、Unicode escape、Hex、Binary
+- JSON 格式化、压缩
+- MD5、SHA-1、SHA-256、SHA-384、SHA-512
+- HMAC-SHA256、HMAC-SHA384、HMAC-SHA512
+- AES-GCM、AES-CBC 基于口令加密和解密
+- JWT 解码、HS256/HS384/HS512 校验
+
+## 导入到 ZTools
+
+1. 打开 ZTools 设置。
+2. 进入「已安装插件」或「开发项目」相关页面。
+3. 选择导入开发中插件，并选择本目录下的 `plugin.json`：
+
+```text
+/Users/pamali/project/developer-codec-tools/plugin.json
+```
+
+## 本地校验
+
+```bash
+npm test
+```
+
+## 开发
+
+```bash
+pnpm install
+pnpm dev
+```
+
+开发服务器默认运行在：
+
+```text
+http://localhost:5178
+```

--- a/plugins/developer-codec-tools/app.js
+++ b/plugins/developer-codec-tools/app.js
@@ -1,0 +1,313 @@
+import {
+  base64Decode,
+  base64Encode,
+  base64UrlDecode,
+  base64UrlEncode,
+  binaryToBytes,
+  bytesToBinary,
+  bytesToHex,
+  decodeJwt,
+  decryptAes,
+  digestHex,
+  encryptAes,
+  formatJson,
+  hexToBytes,
+  hmacHex,
+  htmlDecode,
+  htmlEncode,
+  minifyJson,
+  textToBytes,
+  bytesToText,
+  unicodeEscapeDecode,
+  unicodeEscapeEncode,
+  urlDecode,
+  urlEncode,
+  verifyJwtHs
+} from './codec.js'
+
+const categories = [
+  {
+    id: 'encoding',
+    label: '编码转换',
+    operations: [
+      op('base64-encode', 'Base64 编码', ({ input }) => base64Encode(input)),
+      op('base64-decode', 'Base64 解码', ({ input }) => base64Decode(input)),
+      op('base64url-encode', 'Base64URL 编码', ({ input }) => base64UrlEncode(input)),
+      op('base64url-decode', 'Base64URL 解码', ({ input }) => base64UrlDecode(input)),
+      op('url-encode', 'URL Component 编码', ({ input }) => urlEncode(input)),
+      op('url-decode', 'URL Component 解码', ({ input }) => urlDecode(input)),
+      op('url-form-decode', 'URL Form 解码', ({ input }) => urlDecode(input, 'form')),
+      op('html-encode', 'HTML Entity 编码', ({ input }) => htmlEncode(input)),
+      op('html-decode', 'HTML Entity 解码', ({ input }) => htmlDecode(input)),
+      op('unicode-encode', 'Unicode escape 编码', ({ input }) => unicodeEscapeEncode(input)),
+      op('unicode-decode', 'Unicode escape 解码', ({ input }) => unicodeEscapeDecode(input)),
+      op('hex-encode', 'Hex 编码 UTF-8', ({ input }) => bytesToHex(textToBytes(input))),
+      op('hex-decode', 'Hex 解码 UTF-8', ({ input }) => bytesToText(hexToBytes(input))),
+      op('binary-encode', 'Binary 编码 UTF-8', ({ input }) => bytesToBinary(textToBytes(input))),
+      op('binary-decode', 'Binary 解码 UTF-8', ({ input }) => bytesToText(binaryToBytes(input)))
+    ]
+  },
+  {
+    id: 'hash',
+    label: '哈希与签名',
+    operations: [
+      op('md5', 'MD5', ({ input }) => digestHex('MD5', input)),
+      op('sha1', 'SHA-1', ({ input }) => digestHex('SHA-1', input)),
+      op('sha256', 'SHA-256', ({ input }) => digestHex('SHA-256', input)),
+      op('sha384', 'SHA-384', ({ input }) => digestHex('SHA-384', input)),
+      op('sha512', 'SHA-512', ({ input }) => digestHex('SHA-512', input)),
+      op('hmac-sha256', 'HMAC-SHA256', ({ input, secret }) => hmacHex('SHA-256', input, secret), {
+        keyLabel: 'HMAC 密钥'
+      }),
+      op('hmac-sha384', 'HMAC-SHA384', ({ input, secret }) => hmacHex('SHA-384', input, secret), {
+        keyLabel: 'HMAC 密钥'
+      }),
+      op('hmac-sha512', 'HMAC-SHA512', ({ input, secret }) => hmacHex('SHA-512', input, secret), {
+        keyLabel: 'HMAC 密钥'
+      })
+    ]
+  },
+  {
+    id: 'crypto',
+    label: '对称加密',
+    operations: [
+      op('aes-gcm-encrypt', 'AES-GCM 加密', ({ input, secret }) => encryptAes(input, secret, 'AES-GCM'), {
+        keyLabel: '口令'
+      }),
+      op('aes-gcm-decrypt', 'AES-GCM 解密', ({ input, secret }) => decryptAes(input, secret), {
+        keyLabel: '口令'
+      }),
+      op('aes-cbc-encrypt', 'AES-CBC 加密', ({ input, secret }) => encryptAes(input, secret, 'AES-CBC'), {
+        keyLabel: '口令'
+      }),
+      op('aes-cbc-decrypt', 'AES-CBC 解密', ({ input, secret }) => decryptAes(input, secret), {
+        keyLabel: '口令'
+      })
+    ]
+  },
+  {
+    id: 'jwt',
+    label: 'JWT',
+    operations: [
+      op('jwt-decode', 'JWT 解码', ({ input }) => JSON.stringify(decodeJwt(input), null, 2)),
+      op(
+        'jwt-verify-hs',
+        'JWT HS 校验',
+        async ({ input, secret }) => {
+          const decoded = decodeJwt(input)
+          const verified = await verifyJwtHs(input, secret)
+          return JSON.stringify({ verified, ...decoded }, null, 2)
+        },
+        { keyLabel: 'JWT Secret' }
+      )
+    ]
+  },
+  {
+    id: 'text',
+    label: '文本转换',
+    operations: [
+      op('json-format', 'JSON 格式化', ({ input }) => formatJson(input)),
+      op('json-minify', 'JSON 压缩', ({ input }) => minifyJson(input)),
+      op('json-stringify', 'JSON 字符串转义', ({ input }) => JSON.stringify(input)),
+      op('json-parse-string', 'JSON 字符串反转义', ({ input }) => JSON.parse(input)),
+      op('upper-case', '转大写', ({ input }) => input.toUpperCase()),
+      op('lower-case', '转小写', ({ input }) => input.toLowerCase()),
+      op('trim-lines', '逐行 Trim', ({ input }) =>
+        input
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .join('\n')
+      ),
+      op('dedupe-lines', '逐行去重', ({ input }) => Array.from(new Set(input.split(/\r?\n/))).join('\n'))
+    ]
+  }
+]
+
+const operationsById = new Map()
+for (const category of categories) {
+  for (const operation of category.operations) operationsById.set(operation.id, operation)
+}
+
+const els = {
+  categoryButtons: Array.from(document.querySelectorAll('.category-item')),
+  operation: document.querySelector('#operation'),
+  keyField: document.querySelector('#keyField'),
+  keyLabel: document.querySelector('#keyLabel'),
+  secretKey: document.querySelector('#secretKey'),
+  input: document.querySelector('#inputText'),
+  output: document.querySelector('#outputText'),
+  run: document.querySelector('#runOperation'),
+  swap: document.querySelector('#swapText'),
+  paste: document.querySelector('#pasteInput'),
+  copy: document.querySelector('#copyOutput'),
+  clear: document.querySelector('#clearAll'),
+  status: document.querySelector('#statusLine'),
+  summary: document.querySelector('#activeSummary')
+}
+
+let activeCategory = 'encoding'
+
+renderOperations(activeCategory)
+bindEvents()
+resizePlugin()
+
+function op(id, label, run, options = {}) {
+  return {
+    id,
+    label,
+    run,
+    keyLabel: options.keyLabel || '',
+    needsKey: !!options.keyLabel
+  }
+}
+
+function bindEvents() {
+  for (const button of els.categoryButtons) {
+    button.addEventListener('click', () => {
+      activeCategory = button.dataset.category
+      renderOperations(activeCategory)
+    })
+  }
+
+  els.operation.addEventListener('change', () => {
+    updateKeyField()
+    setStatus('')
+  })
+  els.run.addEventListener('click', runCurrentOperation)
+  els.swap.addEventListener('click', swapInputOutput)
+  els.copy.addEventListener('click', copyOutput)
+  els.paste.addEventListener('click', pasteInput)
+  els.clear.addEventListener('click', clearAll)
+
+  document.addEventListener('keydown', (event) => {
+    const modifier = event.metaKey || event.ctrlKey
+    if (modifier && event.key === 'Enter') {
+      event.preventDefault()
+      runCurrentOperation()
+    }
+  })
+
+  window.addEventListener('resize', resizePlugin)
+
+  if (window.ztools?.onPluginEnter) {
+    window.ztools.onPluginEnter((action) => {
+      const payload = action?.payload
+      if (typeof payload === 'string' && payload) {
+        els.input.value = payload
+        setStatus('已载入启动文本')
+      }
+      resizePlugin()
+    })
+  }
+}
+
+function renderOperations(categoryId) {
+  const category = categories.find((item) => item.id === categoryId) || categories[0]
+  for (const button of els.categoryButtons) {
+    button.classList.toggle('active', button.dataset.category === category.id)
+  }
+
+  els.operation.innerHTML = ''
+  for (const operation of category.operations) {
+    const option = document.createElement('option')
+    option.value = operation.id
+    option.textContent = operation.label
+    els.operation.append(option)
+  }
+
+  els.summary.textContent = category.label
+  updateKeyField()
+  resizePlugin()
+}
+
+function updateKeyField() {
+  const operation = getCurrentOperation()
+  const needsKey = !!operation?.needsKey
+  els.keyField.classList.toggle('hidden', !needsKey)
+  els.keyLabel.textContent = operation?.keyLabel || '密钥'
+}
+
+async function runCurrentOperation() {
+  const operation = getCurrentOperation()
+  if (!operation) return
+
+  setBusy(true)
+  setStatus('处理中')
+  try {
+    const result = await operation.run({
+      input: els.input.value,
+      secret: els.secretKey.value
+    })
+    els.output.value = typeof result === 'string' ? result : JSON.stringify(result, null, 2)
+    setStatus('完成')
+  } catch (error) {
+    els.output.value = ''
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  } finally {
+    setBusy(false)
+    resizePlugin()
+  }
+}
+
+function swapInputOutput() {
+  const currentOutput = els.output.value
+  els.output.value = els.input.value
+  els.input.value = currentOutput
+  setStatus('已交换')
+}
+
+async function pasteInput() {
+  try {
+    els.input.value = await navigator.clipboard.readText()
+    setStatus('已粘贴')
+  } catch {
+    setStatus('无法读取剪贴板', 'warn')
+  }
+}
+
+async function copyOutput() {
+  if (!els.output.value) {
+    setStatus('没有可复制的结果', 'warn')
+    return
+  }
+
+  try {
+    if (window.ztools?.copyText) {
+      window.ztools.copyText(els.output.value)
+    } else {
+      await navigator.clipboard.writeText(els.output.value)
+    }
+    setStatus('已复制')
+  } catch {
+    setStatus('复制失败', 'error')
+  }
+}
+
+function clearAll() {
+  els.input.value = ''
+  els.output.value = ''
+  setStatus('')
+}
+
+function getCurrentOperation() {
+  return operationsById.get(els.operation.value)
+}
+
+function setBusy(isBusy) {
+  els.run.disabled = isBusy
+  els.run.textContent = isBusy ? '执行中' : '执行'
+}
+
+function setStatus(message, tone = '') {
+  els.status.textContent = message
+  els.status.classList.toggle('error', tone === 'error')
+  els.status.classList.toggle('warn', tone === 'warn')
+}
+
+function resizePlugin() {
+  if (!window.ztools?.setExpendHeight) return
+  window.requestAnimationFrame(() => {
+    const height = Math.min(Math.max(document.documentElement.scrollHeight, 560), 760)
+    window.ztools.setExpendHeight(height)
+  })
+}

--- a/plugins/developer-codec-tools/app.js
+++ b/plugins/developer-codec-tools/app.js
@@ -141,8 +141,7 @@ const els = {
   paste: document.querySelector('#pasteInput'),
   copy: document.querySelector('#copyOutput'),
   clear: document.querySelector('#clearAll'),
-  status: document.querySelector('#statusLine'),
-  summary: document.querySelector('#activeSummary')
+  status: document.querySelector('#statusLine')
 }
 
 let activeCategory = 'encoding'
@@ -215,7 +214,6 @@ function renderOperations(categoryId) {
     els.operation.append(option)
   }
 
-  els.summary.textContent = category.label
   updateKeyField()
   resizePlugin()
 }
@@ -307,7 +305,7 @@ function setStatus(message, tone = '') {
 function resizePlugin() {
   if (!window.ztools?.setExpendHeight) return
   window.requestAnimationFrame(() => {
-    const height = Math.min(Math.max(document.documentElement.scrollHeight, 560), 760)
+    const height = Math.min(Math.max(document.documentElement.scrollHeight, 430), 560)
     window.ztools.setExpendHeight(height)
   })
 }

--- a/plugins/developer-codec-tools/codec.js
+++ b/plugins/developer-codec-tools/codec.js
@@ -1,0 +1,502 @@
+const UTF8_ENCODER = new TextEncoder()
+const UTF8_DECODER = new TextDecoder('utf-8', { fatal: false })
+
+const SHA_ALGORITHMS = new Set(['SHA-1', 'SHA-256', 'SHA-384', 'SHA-512'])
+
+export function textToBytes(text) {
+  return UTF8_ENCODER.encode(String(text ?? ''))
+}
+
+export function bytesToText(bytes) {
+  return UTF8_DECODER.decode(toUint8Array(bytes))
+}
+
+export function bytesToHex(bytes) {
+  return Array.from(toUint8Array(bytes), (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+export function hexToBytes(input) {
+  const clean = String(input ?? '')
+    .replace(/0x/gi, '')
+    .replace(/[\s:_-]/g, '')
+  if (!clean) return new Uint8Array()
+  if (!/^[0-9a-f]+$/i.test(clean)) {
+    throw new Error('Hex 输入包含非十六进制字符')
+  }
+  if (clean.length % 2 !== 0) {
+    throw new Error('Hex 输入长度必须为偶数')
+  }
+  const bytes = new Uint8Array(clean.length / 2)
+  for (let i = 0; i < clean.length; i += 2) {
+    bytes[i / 2] = Number.parseInt(clean.slice(i, i + 2), 16)
+  }
+  return bytes
+}
+
+export function bytesToBinary(bytes) {
+  return Array.from(toUint8Array(bytes), (byte) => byte.toString(2).padStart(8, '0')).join(' ')
+}
+
+export function binaryToBytes(input) {
+  const clean = String(input ?? '').replace(/\s+/g, '')
+  if (!clean) return new Uint8Array()
+  if (!/^[01]+$/.test(clean)) {
+    throw new Error('Binary 输入只能包含 0 和 1')
+  }
+  if (clean.length % 8 !== 0) {
+    throw new Error('Binary 输入长度必须是 8 的倍数')
+  }
+  const bytes = new Uint8Array(clean.length / 8)
+  for (let i = 0; i < clean.length; i += 8) {
+    bytes[i / 8] = Number.parseInt(clean.slice(i, i + 8), 2)
+  }
+  return bytes
+}
+
+export function bytesToBase64(bytes) {
+  const normalized = toUint8Array(bytes)
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(normalized).toString('base64')
+  }
+  let binary = ''
+  const chunkSize = 0x8000
+  for (let i = 0; i < normalized.length; i += chunkSize) {
+    binary += String.fromCharCode(...normalized.subarray(i, i + chunkSize))
+  }
+  return btoa(binary)
+}
+
+export function base64ToBytes(input) {
+  const normalized = normalizeBase64(input)
+  if (!normalized) return new Uint8Array()
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(normalized)) {
+    throw new Error('Base64 输入格式无效')
+  }
+  if (typeof Buffer !== 'undefined') {
+    return Uint8Array.from(Buffer.from(normalized, 'base64'))
+  }
+  const binary = atob(normalized)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i)
+  return bytes
+}
+
+export function base64UrlToBytes(input) {
+  return base64ToBytes(String(input ?? '').replace(/-/g, '+').replace(/_/g, '/'))
+}
+
+export function bytesToBase64Url(bytes) {
+  return bytesToBase64(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+export function base64Encode(text) {
+  return bytesToBase64(textToBytes(text))
+}
+
+export function base64Decode(input) {
+  return bytesToText(base64ToBytes(input))
+}
+
+export function base64UrlEncode(text) {
+  return bytesToBase64Url(textToBytes(text))
+}
+
+export function base64UrlDecode(input) {
+  return bytesToText(base64UrlToBytes(input))
+}
+
+export function urlEncode(input, mode = 'component') {
+  const text = String(input ?? '')
+  return mode === 'uri' ? encodeURI(text) : encodeURIComponent(text)
+}
+
+export function urlDecode(input, mode = 'component') {
+  const text = String(input ?? '')
+  const normalized = mode === 'form' ? text.replace(/\+/g, ' ') : text
+  return mode === 'uri' ? decodeURI(normalized) : decodeURIComponent(normalized)
+}
+
+export function htmlEncode(input) {
+  return String(input ?? '').replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case '&':
+        return '&amp;'
+      case '<':
+        return '&lt;'
+      case '>':
+        return '&gt;'
+      case '"':
+        return '&quot;'
+      case "'":
+        return '&#39;'
+      default:
+        return char
+    }
+  })
+}
+
+export function htmlDecode(input) {
+  const text = String(input ?? '')
+  if (typeof document !== 'undefined') {
+    const textarea = document.createElement('textarea')
+    textarea.innerHTML = text
+    return textarea.value
+  }
+  const named = {
+    amp: '&',
+    lt: '<',
+    gt: '>',
+    quot: '"',
+    apos: "'",
+    nbsp: ' '
+  }
+  return text.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (_entity, body) => {
+    const value = String(body)
+    if (value[0] === '#') {
+      const isHex = value[1]?.toLowerCase() === 'x'
+      const codePoint = Number.parseInt(value.slice(isHex ? 2 : 1), isHex ? 16 : 10)
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : _entity
+    }
+    return Object.prototype.hasOwnProperty.call(named, value.toLowerCase())
+      ? named[value.toLowerCase()]
+      : _entity
+  })
+}
+
+export function unicodeEscapeEncode(input, all = false) {
+  return Array.from(String(input ?? ''))
+    .map((char) => {
+      const codePoint = char.codePointAt(0)
+      if (!all && codePoint >= 0x20 && codePoint <= 0x7e) return char
+      if (codePoint <= 0xffff) return `\\u${codePoint.toString(16).padStart(4, '0')}`
+      const high = Math.floor((codePoint - 0x10000) / 0x400) + 0xd800
+      const low = ((codePoint - 0x10000) % 0x400) + 0xdc00
+      return `\\u${high.toString(16)}\\u${low.toString(16)}`
+    })
+    .join('')
+}
+
+export function unicodeEscapeDecode(input) {
+  return String(input ?? '')
+    .replace(/\\u\{([0-9a-f]+)\}/gi, (match, hex) => {
+      const codePoint = Number.parseInt(hex, 16)
+      return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : match
+    })
+    .replace(/\\u([0-9a-f]{4})/gi, (_match, hex) =>
+      String.fromCharCode(Number.parseInt(hex, 16))
+    )
+    .replace(/\\x([0-9a-f]{2})/gi, (_match, hex) =>
+      String.fromCharCode(Number.parseInt(hex, 16))
+    )
+}
+
+export function formatJson(input, spaces = 2) {
+  return JSON.stringify(JSON.parse(String(input ?? '')), null, spaces)
+}
+
+export function minifyJson(input) {
+  return JSON.stringify(JSON.parse(String(input ?? '')))
+}
+
+export function decodeJwt(input) {
+  const token = String(input ?? '').trim()
+  const parts = token.split('.')
+  if (parts.length < 2) throw new Error('JWT 至少需要 header 和 payload 两段')
+
+  const header = parseBase64UrlJson(parts[0], 'header')
+  const payload = parseBase64UrlJson(parts[1], 'payload')
+  return {
+    header,
+    payload,
+    signature: parts[2] || ''
+  }
+}
+
+export async function verifyJwtHs(input, secret) {
+  const token = String(input ?? '').trim()
+  const parts = token.split('.')
+  if (parts.length !== 3) throw new Error('JWT 校验需要完整的三段 token')
+  const decoded = decodeJwt(token)
+  const alg = decoded.header.alg
+  const hash = {
+    HS256: 'SHA-256',
+    HS384: 'SHA-384',
+    HS512: 'SHA-512'
+  }[alg]
+  if (!hash) throw new Error(`仅支持 HS256/HS384/HS512，当前 alg 为 ${alg || '空'}`)
+  const expected = await hmacBytes(hash, `${parts[0]}.${parts[1]}`, secret)
+  const actual = base64UrlToBytes(parts[2])
+  return timingSafeEqual(expected, actual)
+}
+
+export async function digestHex(algorithm, input) {
+  const normalized = String(algorithm).toUpperCase()
+  if (normalized === 'MD5') return md5(input)
+  if (!SHA_ALGORITHMS.has(normalized)) throw new Error(`不支持的摘要算法: ${algorithm}`)
+  const digest = await getSubtle().digest(normalized, textToBytes(input))
+  return bytesToHex(new Uint8Array(digest))
+}
+
+export async function hmacHex(algorithm, input, secret) {
+  return bytesToHex(await hmacBytes(algorithm, input, secret))
+}
+
+export async function encryptAes(input, passphrase, algorithm = 'AES-GCM') {
+  if (!passphrase) throw new Error('密钥不能为空')
+  const normalized = normalizeAesAlgorithm(algorithm)
+  const salt = randomBytes(16)
+  const iv = randomBytes(normalized === 'AES-GCM' ? 12 : 16)
+  const iterations = 120000
+  const key = await deriveAesKey(passphrase, salt, normalized, iterations)
+  const encrypted = await getSubtle().encrypt({ name: normalized, iv }, key, textToBytes(input))
+  return JSON.stringify(
+    {
+      v: 1,
+      alg: normalized,
+      kdf: 'PBKDF2',
+      hash: 'SHA-256',
+      iterations,
+      salt: bytesToBase64Url(salt),
+      iv: bytesToBase64Url(iv),
+      ciphertext: bytesToBase64Url(new Uint8Array(encrypted))
+    },
+    null,
+    2
+  )
+}
+
+export async function decryptAes(input, passphrase) {
+  if (!passphrase) throw new Error('密钥不能为空')
+  const payload = JSON.parse(String(input ?? ''))
+  const algorithm = normalizeAesAlgorithm(payload.alg)
+  const salt = base64UrlToBytes(payload.salt)
+  const iv = base64UrlToBytes(payload.iv)
+  const ciphertext = base64UrlToBytes(payload.ciphertext)
+  const key = await deriveAesKey(passphrase, salt, algorithm, payload.iterations || 120000)
+  const decrypted = await getSubtle().decrypt({ name: algorithm, iv }, key, ciphertext)
+  return bytesToText(new Uint8Array(decrypted))
+}
+
+export function md5(input) {
+  const bytes = textToBytes(input)
+  const wordCount = (((bytes.length + 8) >> 6) + 1) * 16
+  const words = new Uint32Array(wordCount)
+
+  for (let i = 0; i < bytes.length; i += 1) {
+    words[i >> 2] |= bytes[i] << ((i % 4) * 8)
+  }
+  words[bytes.length >> 2] |= 0x80 << ((bytes.length % 4) * 8)
+  const bitLength = bytes.length * 8
+  words[wordCount - 2] = bitLength & 0xffffffff
+  words[wordCount - 1] = Math.floor(bitLength / 0x100000000)
+
+  let a = 0x67452301
+  let b = 0xefcdab89
+  let c = 0x98badcfe
+  let d = 0x10325476
+
+  for (let i = 0; i < words.length; i += 16) {
+    const oldA = a
+    const oldB = b
+    const oldC = c
+    const oldD = d
+
+    a = ff(a, b, c, d, words[i], 7, -680876936)
+    d = ff(d, a, b, c, words[i + 1], 12, -389564586)
+    c = ff(c, d, a, b, words[i + 2], 17, 606105819)
+    b = ff(b, c, d, a, words[i + 3], 22, -1044525330)
+    a = ff(a, b, c, d, words[i + 4], 7, -176418897)
+    d = ff(d, a, b, c, words[i + 5], 12, 1200080426)
+    c = ff(c, d, a, b, words[i + 6], 17, -1473231341)
+    b = ff(b, c, d, a, words[i + 7], 22, -45705983)
+    a = ff(a, b, c, d, words[i + 8], 7, 1770035416)
+    d = ff(d, a, b, c, words[i + 9], 12, -1958414417)
+    c = ff(c, d, a, b, words[i + 10], 17, -42063)
+    b = ff(b, c, d, a, words[i + 11], 22, -1990404162)
+    a = ff(a, b, c, d, words[i + 12], 7, 1804603682)
+    d = ff(d, a, b, c, words[i + 13], 12, -40341101)
+    c = ff(c, d, a, b, words[i + 14], 17, -1502002290)
+    b = ff(b, c, d, a, words[i + 15], 22, 1236535329)
+
+    a = gg(a, b, c, d, words[i + 1], 5, -165796510)
+    d = gg(d, a, b, c, words[i + 6], 9, -1069501632)
+    c = gg(c, d, a, b, words[i + 11], 14, 643717713)
+    b = gg(b, c, d, a, words[i], 20, -373897302)
+    a = gg(a, b, c, d, words[i + 5], 5, -701558691)
+    d = gg(d, a, b, c, words[i + 10], 9, 38016083)
+    c = gg(c, d, a, b, words[i + 15], 14, -660478335)
+    b = gg(b, c, d, a, words[i + 4], 20, -405537848)
+    a = gg(a, b, c, d, words[i + 9], 5, 568446438)
+    d = gg(d, a, b, c, words[i + 14], 9, -1019803690)
+    c = gg(c, d, a, b, words[i + 3], 14, -187363961)
+    b = gg(b, c, d, a, words[i + 8], 20, 1163531501)
+    a = gg(a, b, c, d, words[i + 13], 5, -1444681467)
+    d = gg(d, a, b, c, words[i + 2], 9, -51403784)
+    c = gg(c, d, a, b, words[i + 7], 14, 1735328473)
+    b = gg(b, c, d, a, words[i + 12], 20, -1926607734)
+
+    a = hh(a, b, c, d, words[i + 5], 4, -378558)
+    d = hh(d, a, b, c, words[i + 8], 11, -2022574463)
+    c = hh(c, d, a, b, words[i + 11], 16, 1839030562)
+    b = hh(b, c, d, a, words[i + 14], 23, -35309556)
+    a = hh(a, b, c, d, words[i + 1], 4, -1530992060)
+    d = hh(d, a, b, c, words[i + 4], 11, 1272893353)
+    c = hh(c, d, a, b, words[i + 7], 16, -155497632)
+    b = hh(b, c, d, a, words[i + 10], 23, -1094730640)
+    a = hh(a, b, c, d, words[i + 13], 4, 681279174)
+    d = hh(d, a, b, c, words[i], 11, -358537222)
+    c = hh(c, d, a, b, words[i + 3], 16, -722521979)
+    b = hh(b, c, d, a, words[i + 6], 23, 76029189)
+    a = hh(a, b, c, d, words[i + 9], 4, -640364487)
+    d = hh(d, a, b, c, words[i + 12], 11, -421815835)
+    c = hh(c, d, a, b, words[i + 15], 16, 530742520)
+    b = hh(b, c, d, a, words[i + 2], 23, -995338651)
+
+    a = ii(a, b, c, d, words[i], 6, -198630844)
+    d = ii(d, a, b, c, words[i + 7], 10, 1126891415)
+    c = ii(c, d, a, b, words[i + 14], 15, -1416354905)
+    b = ii(b, c, d, a, words[i + 5], 21, -57434055)
+    a = ii(a, b, c, d, words[i + 12], 6, 1700485571)
+    d = ii(d, a, b, c, words[i + 3], 10, -1894986606)
+    c = ii(c, d, a, b, words[i + 10], 15, -1051523)
+    b = ii(b, c, d, a, words[i + 1], 21, -2054922799)
+    a = ii(a, b, c, d, words[i + 8], 6, 1873313359)
+    d = ii(d, a, b, c, words[i + 15], 10, -30611744)
+    c = ii(c, d, a, b, words[i + 6], 15, -1560198380)
+    b = ii(b, c, d, a, words[i + 13], 21, 1309151649)
+    a = ii(a, b, c, d, words[i + 4], 6, -145523070)
+    d = ii(d, a, b, c, words[i + 11], 10, -1120210379)
+    c = ii(c, d, a, b, words[i + 2], 15, 718787259)
+    b = ii(b, c, d, a, words[i + 9], 21, -343485551)
+
+    a = add32(a, oldA)
+    b = add32(b, oldB)
+    c = add32(c, oldC)
+    d = add32(d, oldD)
+  }
+
+  return [a, b, c, d]
+    .map((word) =>
+      [word & 0xff, (word >>> 8) & 0xff, (word >>> 16) & 0xff, (word >>> 24) & 0xff]
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('')
+    )
+    .join('')
+}
+
+async function hmacBytes(algorithm, input, secret) {
+  if (!secret) throw new Error('密钥不能为空')
+  const normalized = String(algorithm).toUpperCase()
+  if (!SHA_ALGORITHMS.has(normalized)) throw new Error(`不支持的 HMAC 算法: ${algorithm}`)
+  const key = await getSubtle().importKey(
+    'raw',
+    textToBytes(secret),
+    { name: 'HMAC', hash: normalized },
+    false,
+    ['sign']
+  )
+  const signed = await getSubtle().sign('HMAC', key, textToBytes(input))
+  return new Uint8Array(signed)
+}
+
+async function deriveAesKey(passphrase, salt, algorithm, iterations) {
+  const baseKey = await getSubtle().importKey('raw', textToBytes(passphrase), 'PBKDF2', false, [
+    'deriveKey'
+  ])
+  return getSubtle().deriveKey(
+    {
+      name: 'PBKDF2',
+      salt,
+      iterations,
+      hash: 'SHA-256'
+    },
+    baseKey,
+    {
+      name: algorithm,
+      length: 256
+    },
+    false,
+    ['encrypt', 'decrypt']
+  )
+}
+
+function parseBase64UrlJson(value, label) {
+  try {
+    return JSON.parse(base64UrlDecode(value))
+  } catch (error) {
+    throw new Error(`JWT ${label} 解析失败: ${error.message}`)
+  }
+}
+
+function normalizeBase64(input) {
+  const clean = String(input ?? '').replace(/\s+/g, '')
+  if (!clean) return ''
+  return clean.padEnd(clean.length + ((4 - (clean.length % 4)) % 4), '=')
+}
+
+function normalizeAesAlgorithm(algorithm) {
+  const normalized = String(algorithm ?? '').toUpperCase()
+  if (normalized === 'AES-GCM' || normalized === 'AES-CBC') return normalized
+  throw new Error(`不支持的 AES 算法: ${algorithm}`)
+}
+
+function randomBytes(length) {
+  const bytes = new Uint8Array(length)
+  getCrypto().getRandomValues(bytes)
+  return bytes
+}
+
+function getCrypto() {
+  if (globalThis.crypto) return globalThis.crypto
+  throw new Error('当前运行环境不支持 Web Crypto')
+}
+
+function getSubtle() {
+  const cryptoRef = getCrypto()
+  if (!cryptoRef.subtle) throw new Error('当前运行环境不支持 crypto.subtle')
+  return cryptoRef.subtle
+}
+
+function toUint8Array(bytes) {
+  if (bytes instanceof Uint8Array) return bytes
+  if (ArrayBuffer.isView(bytes)) {
+    return new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+  }
+  if (bytes instanceof ArrayBuffer) return new Uint8Array(bytes)
+  return Uint8Array.from(bytes ?? [])
+}
+
+function timingSafeEqual(left, right) {
+  if (left.length !== right.length) return false
+  let diff = 0
+  for (let i = 0; i < left.length; i += 1) diff |= left[i] ^ right[i]
+  return diff === 0
+}
+
+function add32(a, b) {
+  return (a + b) | 0
+}
+
+function rotateLeft(value, shift) {
+  return (value << shift) | (value >>> (32 - shift))
+}
+
+function cmn(q, a, b, x, s, t) {
+  return add32(rotateLeft(add32(add32(a, q), add32(x, t)), s), b)
+}
+
+function ff(a, b, c, d, x, s, t) {
+  return cmn((b & c) | (~b & d), a, b, x, s, t)
+}
+
+function gg(a, b, c, d, x, s, t) {
+  return cmn((b & d) | (c & ~d), a, b, x, s, t)
+}
+
+function hh(a, b, c, d, x, s, t) {
+  return cmn(b ^ c ^ d, a, b, x, s, t)
+}
+
+function ii(a, b, c, d, x, s, t) {
+  return cmn(c ^ (b | ~d), a, b, x, s, t)
+}

--- a/plugins/developer-codec-tools/index.html
+++ b/plugins/developer-codec-tools/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>开发加解密编码工具</title>
+    <link rel="stylesheet" href="./styles.css" />
+  </head>
+  <body>
+    <main class="tool-shell">
+      <section class="topbar" aria-label="工具栏">
+        <div class="brand">
+          <img class="brand-icon" src="./logo.svg" alt="" />
+          <div>
+            <h1>开发加解密编码工具</h1>
+            <p id="activeSummary">编码转换</p>
+          </div>
+        </div>
+        <div class="top-actions">
+          <button id="copyOutput" class="ghost-button" type="button">复制结果</button>
+          <button id="clearAll" class="ghost-button" type="button">清空</button>
+        </div>
+      </section>
+
+      <section class="workspace">
+        <aside class="category-list" aria-label="分类">
+          <button class="category-item active" type="button" data-category="encoding">编码</button>
+          <button class="category-item" type="button" data-category="hash">哈希</button>
+          <button class="category-item" type="button" data-category="crypto">加密</button>
+          <button class="category-item" type="button" data-category="jwt">JWT</button>
+          <button class="category-item" type="button" data-category="text">文本</button>
+        </aside>
+
+        <section class="panel">
+          <div class="control-grid">
+            <label class="field">
+              <span>操作</span>
+              <select id="operation"></select>
+            </label>
+            <label class="field key-field hidden" id="keyField">
+              <span id="keyLabel">密钥</span>
+              <input id="secretKey" type="text" autocomplete="off" spellcheck="false" />
+            </label>
+          </div>
+
+          <div class="editor-grid">
+            <label class="editor-block">
+              <span>输入</span>
+              <textarea id="inputText" spellcheck="false"></textarea>
+            </label>
+            <label class="editor-block">
+              <span>输出</span>
+              <textarea id="outputText" spellcheck="false" readonly></textarea>
+            </label>
+          </div>
+
+          <div class="action-row">
+            <button id="runOperation" class="primary-button" type="button">执行</button>
+            <button id="swapText" class="secondary-button" type="button">交换</button>
+            <button id="pasteInput" class="secondary-button" type="button">粘贴</button>
+          </div>
+
+          <div id="statusLine" class="status-line" role="status"></div>
+        </section>
+      </section>
+    </main>
+
+    <script type="module" src="./app.js"></script>
+  </body>
+</html>

--- a/plugins/developer-codec-tools/index.html
+++ b/plugins/developer-codec-tools/index.html
@@ -8,28 +8,21 @@
   </head>
   <body>
     <main class="tool-shell">
-      <section class="topbar" aria-label="工具栏">
-        <div class="brand">
-          <img class="brand-icon" src="./logo.svg" alt="" />
-          <div>
-            <h1>开发加解密编码工具</h1>
-            <p id="activeSummary">编码转换</p>
+      <section class="workspace">
+        <div class="toolbar" aria-label="工具栏">
+          <nav class="category-list" aria-label="分类">
+            <button class="category-item active" type="button" data-category="encoding">编码</button>
+            <button class="category-item" type="button" data-category="hash">哈希</button>
+            <button class="category-item" type="button" data-category="crypto">加密</button>
+            <button class="category-item" type="button" data-category="jwt">JWT</button>
+            <button class="category-item" type="button" data-category="text">文本</button>
+          </nav>
+
+          <div class="top-actions">
+            <button id="copyOutput" class="ghost-button" type="button">复制结果</button>
+            <button id="clearAll" class="ghost-button" type="button">清空</button>
           </div>
         </div>
-        <div class="top-actions">
-          <button id="copyOutput" class="ghost-button" type="button">复制结果</button>
-          <button id="clearAll" class="ghost-button" type="button">清空</button>
-        </div>
-      </section>
-
-      <section class="workspace">
-        <aside class="category-list" aria-label="分类">
-          <button class="category-item active" type="button" data-category="encoding">编码</button>
-          <button class="category-item" type="button" data-category="hash">哈希</button>
-          <button class="category-item" type="button" data-category="crypto">加密</button>
-          <button class="category-item" type="button" data-category="jwt">JWT</button>
-          <button class="category-item" type="button" data-category="text">文本</button>
-        </aside>
 
         <section class="panel">
           <div class="control-grid">

--- a/plugins/developer-codec-tools/logo.svg
+++ b/plugins/developer-codec-tools/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Developer codec tools">
+  <rect width="128" height="128" rx="24" fill="#18202b"/>
+  <path d="M35 42 17 64l18 22" fill="none" stroke="#63d6c5" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="m93 42 18 22-18 22" fill="none" stroke="#f2b84b" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M72 28 56 100" fill="none" stroke="#f5f7fb" stroke-width="10" stroke-linecap="round"/>
+</svg>

--- a/plugins/developer-codec-tools/package.json
+++ b/plugins/developer-codec-tools/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "developer-codec-tools",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1",
+    "build": "vite build --base ./ && node scripts/copy-dist-assets.mjs",
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "vite": "^7.3.0"
+  }
+}

--- a/plugins/developer-codec-tools/plugin.json
+++ b/plugins/developer-codec-tools/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "developer-codec-tools",
+  "title": "开发加解密编码工具",
+  "description": "常用开发加密、解密、哈希、HMAC、JWT、编码和文本转换工具",
+  "author": "Pamali",
+  "version": "0.1.0",
+  "main": "index.html",
+  "logo": "logo.svg",
+  "development": {
+    "main": "http://localhost:5178"
+  },
+  "pluginSetting": {
+    "single": true,
+    "backgroundRunning": false
+  },
+  "features": [
+    {
+      "code": "codec-tools",
+      "explain": "加密解密与编码转换",
+      "icon": "logo.svg",
+      "cmds": [
+        "加密解密",
+        "编码转换",
+        "哈希计算",
+        "JWT 解析",
+        "Base64",
+        "URL 编码",
+        "开发工具",
+        "Codec Tools",
+        "Crypto Tools"
+      ]
+    }
+  ]
+}

--- a/plugins/developer-codec-tools/pnpm-lock.yaml
+++ b/plugins/developer-codec-tools/pnpm-lock.yaml
@@ -1,0 +1,654 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      vite:
+        specifier: ^7.3.0
+        version: 7.3.3
+
+packages:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    resolution: {integrity: sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    resolution: {integrity: sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    resolution: {integrity: sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    resolution: {integrity: sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    resolution: {integrity: sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    resolution: {integrity: sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    resolution: {integrity: sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    resolution: {integrity: sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    resolution: {integrity: sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    resolution: {integrity: sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    resolution: {integrity: sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.60.3:
+    resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  vite@7.3.3:
+    resolution: {integrity: sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@rollup/rollup-android-arm-eabi@4.60.3':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.3':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.3':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  nanoid@3.3.12: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.3:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.3
+      '@rollup/rollup-android-arm64': 4.60.3
+      '@rollup/rollup-darwin-arm64': 4.60.3
+      '@rollup/rollup-darwin-x64': 4.60.3
+      '@rollup/rollup-freebsd-arm64': 4.60.3
+      '@rollup/rollup-freebsd-x64': 4.60.3
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.3
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.3
+      '@rollup/rollup-linux-arm64-gnu': 4.60.3
+      '@rollup/rollup-linux-arm64-musl': 4.60.3
+      '@rollup/rollup-linux-loong64-gnu': 4.60.3
+      '@rollup/rollup-linux-loong64-musl': 4.60.3
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.3
+      '@rollup/rollup-linux-ppc64-musl': 4.60.3
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.3
+      '@rollup/rollup-linux-riscv64-musl': 4.60.3
+      '@rollup/rollup-linux-s390x-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-gnu': 4.60.3
+      '@rollup/rollup-linux-x64-musl': 4.60.3
+      '@rollup/rollup-openbsd-x64': 4.60.3
+      '@rollup/rollup-openharmony-arm64': 4.60.3
+      '@rollup/rollup-win32-arm64-msvc': 4.60.3
+      '@rollup/rollup-win32-ia32-msvc': 4.60.3
+      '@rollup/rollup-win32-x64-gnu': 4.60.3
+      '@rollup/rollup-win32-x64-msvc': 4.60.3
+      fsevents: 2.3.3
+
+  source-map-js@1.2.1: {}
+
+  tinyglobby@0.2.16:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  vite@7.3.3:
+    dependencies:
+      esbuild: 0.27.7
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.14
+      rollup: 4.60.3
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      fsevents: 2.3.3

--- a/plugins/developer-codec-tools/pnpm-workspace.yaml
+++ b/plugins/developer-codec-tools/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/plugins/developer-codec-tools/scripts/copy-dist-assets.mjs
+++ b/plugins/developer-codec-tools/scripts/copy-dist-assets.mjs
@@ -1,0 +1,13 @@
+import { mkdir, readFile, writeFile, copyFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const root = resolve(import.meta.dirname, '..')
+const dist = resolve(root, 'dist')
+
+await mkdir(dist, { recursive: true })
+
+const pluginJson = JSON.parse(await readFile(resolve(root, 'plugin.json'), 'utf-8'))
+delete pluginJson.development
+
+await writeFile(resolve(dist, 'plugin.json'), `${JSON.stringify(pluginJson, null, 2)}\n`, 'utf-8')
+await copyFile(resolve(root, 'logo.svg'), resolve(dist, 'logo.svg'))

--- a/plugins/developer-codec-tools/styles.css
+++ b/plugins/developer-codec-tools/styles.css
@@ -11,7 +11,7 @@
   --accent-soft: #d9f1ef;
   --warn: #b86b00;
   --danger: #b42318;
-  --shadow: 0 14px 34px rgba(18, 32, 44, 0.1);
+  --shadow: 0 8px 22px rgba(18, 32, 44, 0.08);
   font-family:
     Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
@@ -29,7 +29,7 @@
     --accent-soft: #173f42;
     --warn: #f2b84b;
     --danger: #ff8a7a;
-    --shadow: 0 18px 38px rgba(0, 0, 0, 0.28);
+    --shadow: 0 10px 24px rgba(0, 0, 0, 0.24);
   }
 }
 
@@ -39,15 +39,15 @@
 
 html,
 body {
-  min-height: 100%;
   margin: 0;
+  min-height: 100%;
 }
 
 body {
   background: var(--bg);
   color: var(--text);
-  font-size: 14px;
-  line-height: 1.45;
+  font-size: 13px;
+  line-height: 1.35;
 }
 
 button,
@@ -69,68 +69,35 @@ button:disabled {
 
 .tool-shell {
   min-height: 100vh;
-  padding: 16px;
-}
-
-.topbar {
-  align-items: center;
-  display: flex;
-  gap: 14px;
-  justify-content: space-between;
-  margin: 0 auto 12px;
-  max-width: 1120px;
-}
-
-.brand {
-  align-items: center;
-  display: flex;
-  gap: 12px;
-  min-width: 0;
-}
-
-.brand-icon {
-  flex: 0 0 auto;
-  height: 42px;
-  width: 42px;
-}
-
-.brand h1 {
-  font-size: 18px;
-  font-weight: 720;
-  line-height: 1.2;
-  margin: 0;
-}
-
-.brand p {
-  color: var(--muted);
-  margin: 2px 0 0;
-}
-
-.top-actions,
-.action-row {
-  align-items: center;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
+  padding: 8px;
 }
 
 .workspace {
   display: grid;
-  gap: 12px;
-  grid-template-columns: 128px minmax(0, 1fr);
+  gap: 8px;
   margin: 0 auto;
-  max-width: 1120px;
+  max-width: 980px;
+}
+
+.toolbar {
+  align-items: center;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-width: 0;
 }
 
 .category-list {
-  align-self: start;
+  align-items: center;
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: 8px;
   box-shadow: var(--shadow);
   display: grid;
   gap: 4px;
-  padding: 6px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  min-width: 0;
+  padding: 4px;
 }
 
 .category-item {
@@ -138,9 +105,13 @@ button:disabled {
   border: 0;
   border-radius: 6px;
   color: var(--muted);
-  min-height: 38px;
-  padding: 0 12px;
-  text-align: left;
+  height: 30px;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0 8px;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .category-item.active {
@@ -149,34 +120,41 @@ button:disabled {
   font-weight: 700;
 }
 
+.top-actions,
+.action-row {
+  align-items: center;
+  display: flex;
+  gap: 6px;
+}
+
 .panel {
   background: var(--panel);
   border: 1px solid var(--line);
   border-radius: 8px;
   box-shadow: var(--shadow);
   display: grid;
-  gap: 12px;
+  gap: 8px;
   min-width: 0;
-  padding: 14px;
+  padding: 8px;
 }
 
 .control-grid {
   display: grid;
-  gap: 10px;
-  grid-template-columns: minmax(240px, 1fr) minmax(220px, 0.85fr);
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) minmax(150px, 0.55fr);
 }
 
 .field,
 .editor-block {
   display: grid;
-  gap: 6px;
+  gap: 4px;
   min-width: 0;
 }
 
 .field span,
 .editor-block span {
   color: var(--muted);
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 680;
 }
 
@@ -194,24 +172,25 @@ select:focus,
 input:focus,
 textarea:focus {
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 select,
 input {
-  height: 38px;
-  padding: 0 10px;
+  height: 32px;
+  padding: 0 9px;
 }
 
 .editor-grid {
   display: grid;
-  gap: 10px;
+  gap: 8px;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
 }
 
 textarea {
-  min-height: 318px;
-  padding: 10px;
+  height: 210px;
+  min-height: 180px;
+  padding: 8px;
   resize: vertical;
   tab-size: 2;
   white-space: pre-wrap;
@@ -224,8 +203,9 @@ textarea {
   border: 1px solid transparent;
   border-radius: 6px;
   font-weight: 700;
-  min-height: 36px;
-  padding: 0 14px;
+  height: 32px;
+  padding: 0 11px;
+  white-space: nowrap;
 }
 
 .primary-button {
@@ -249,14 +229,14 @@ textarea {
 }
 
 .ghost-button {
-  background: transparent;
+  background: var(--panel);
   border-color: var(--line);
   color: var(--text);
 }
 
 .status-line {
   color: var(--muted);
-  min-height: 22px;
+  min-height: 18px;
 }
 
 .status-line.error {
@@ -271,27 +251,24 @@ textarea {
   display: none;
 }
 
-@media (max-width: 820px) {
-  .tool-shell {
-    padding: 12px;
-  }
-
-  .topbar {
+@media (max-width: 620px) {
+  .toolbar {
     align-items: stretch;
-    flex-direction: column;
-  }
-
-  .workspace {
     grid-template-columns: 1fr;
   }
 
-  .category-list {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+  .top-actions {
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 520px) {
+  .tool-shell {
+    padding: 6px;
   }
 
-  .category-item {
-    padding: 0 8px;
-    text-align: center;
+  .category-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .control-grid,
@@ -300,16 +277,7 @@ textarea {
   }
 
   textarea {
-    min-height: 220px;
-  }
-}
-
-@media (max-width: 460px) {
-  .category-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .brand h1 {
-    font-size: 16px;
+    height: 150px;
+    min-height: 130px;
   }
 }

--- a/plugins/developer-codec-tools/styles.css
+++ b/plugins/developer-codec-tools/styles.css
@@ -1,0 +1,315 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f4f6f8;
+  --panel: #ffffff;
+  --panel-soft: #eef2f4;
+  --text: #17202a;
+  --muted: #637083;
+  --line: #d8e0e6;
+  --accent: #0f8b8d;
+  --accent-strong: #0a6f71;
+  --accent-soft: #d9f1ef;
+  --warn: #b86b00;
+  --danger: #b42318;
+  --shadow: 0 14px 34px rgba(18, 32, 44, 0.1);
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #11161d;
+    --panel: #1a222d;
+    --panel-soft: #202b37;
+    --text: #edf2f7;
+    --muted: #9ba8b7;
+    --line: #314050;
+    --accent: #49c5b6;
+    --accent-strong: #76d8cc;
+    --accent-soft: #173f42;
+    --warn: #f2b84b;
+    --danger: #ff8a7a;
+    --shadow: 0 18px 38px rgba(0, 0, 0, 0.28);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+  margin: 0;
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.45;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button,
+select {
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.tool-shell {
+  min-height: 100vh;
+  padding: 16px;
+}
+
+.topbar {
+  align-items: center;
+  display: flex;
+  gap: 14px;
+  justify-content: space-between;
+  margin: 0 auto 12px;
+  max-width: 1120px;
+}
+
+.brand {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  min-width: 0;
+}
+
+.brand-icon {
+  flex: 0 0 auto;
+  height: 42px;
+  width: 42px;
+}
+
+.brand h1 {
+  font-size: 18px;
+  font-weight: 720;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.brand p {
+  color: var(--muted);
+  margin: 2px 0 0;
+}
+
+.top-actions,
+.action-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.workspace {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 128px minmax(0, 1fr);
+  margin: 0 auto;
+  max-width: 1120px;
+}
+
+.category-list {
+  align-self: start;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 4px;
+  padding: 6px;
+}
+
+.category-item {
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--muted);
+  min-height: 38px;
+  padding: 0 12px;
+  text-align: left;
+}
+
+.category-item.active {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.control-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(240px, 1fr) minmax(220px, 0.85fr);
+}
+
+.field,
+.editor-block {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.field span,
+.editor-block span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 680;
+}
+
+select,
+input,
+textarea {
+  background: var(--panel-soft);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--text);
+  outline: none;
+}
+
+select:focus,
+input:focus,
+textarea:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 20%, transparent);
+}
+
+select,
+input {
+  height: 38px;
+  padding: 0 10px;
+}
+
+.editor-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+}
+
+textarea {
+  min-height: 318px;
+  padding: 10px;
+  resize: vertical;
+  tab-size: 2;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.primary-button,
+.secondary-button,
+.ghost-button {
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font-weight: 700;
+  min-height: 36px;
+  padding: 0 14px;
+}
+
+.primary-button {
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.primary-button:hover {
+  background: var(--accent-strong);
+}
+
+.secondary-button {
+  background: var(--panel-soft);
+  border-color: var(--line);
+  color: var(--text);
+}
+
+.secondary-button:hover,
+.ghost-button:hover {
+  border-color: var(--accent);
+}
+
+.ghost-button {
+  background: transparent;
+  border-color: var(--line);
+  color: var(--text);
+}
+
+.status-line {
+  color: var(--muted);
+  min-height: 22px;
+}
+
+.status-line.error {
+  color: var(--danger);
+}
+
+.status-line.warn {
+  color: var(--warn);
+}
+
+.hidden {
+  display: none;
+}
+
+@media (max-width: 820px) {
+  .tool-shell {
+    padding: 12px;
+  }
+
+  .topbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .category-list {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .category-item {
+    padding: 0 8px;
+    text-align: center;
+  }
+
+  .control-grid,
+  .editor-grid {
+    grid-template-columns: 1fr;
+  }
+
+  textarea {
+    min-height: 220px;
+  }
+}
+
+@media (max-width: 460px) {
+  .category-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .brand h1 {
+    font-size: 16px;
+  }
+}

--- a/plugins/developer-codec-tools/test/codec.test.mjs
+++ b/plugins/developer-codec-tools/test/codec.test.mjs
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {
+  base64Decode,
+  base64Encode,
+  base64UrlDecode,
+  base64UrlEncode,
+  binaryToBytes,
+  bytesToBinary,
+  bytesToHex,
+  bytesToText,
+  decodeJwt,
+  digestHex,
+  formatJson,
+  hexToBytes,
+  hmacHex,
+  htmlDecode,
+  htmlEncode,
+  md5,
+  minifyJson,
+  textToBytes,
+  unicodeEscapeDecode,
+  unicodeEscapeEncode,
+  urlDecode,
+  urlEncode,
+  verifyJwtHs
+} from '../codec.js'
+
+test('base64 handles utf-8 text', () => {
+  const text = 'hello 你好'
+  assert.equal(base64Decode(base64Encode(text)), text)
+})
+
+test('base64url handles utf-8 text', () => {
+  const text = 'a/b+c? 你好'
+  const encoded = base64UrlEncode(text)
+  assert.equal(encoded.includes('+'), false)
+  assert.equal(encoded.includes('/'), false)
+  assert.equal(base64UrlDecode(encoded), text)
+})
+
+test('hex and binary roundtrip utf-8 bytes', () => {
+  const text = 'dev 工具'
+  const hex = bytesToHex(textToBytes(text))
+  assert.equal(bytesToText(hexToBytes(hex)), text)
+
+  const binary = bytesToBinary(textToBytes(text))
+  assert.equal(bytesToText(binaryToBytes(binary)), text)
+})
+
+test('url and html conversion', () => {
+  const urlText = 'name=张三&role=dev tool'
+  assert.equal(urlDecode(urlEncode(urlText)), urlText)
+
+  const html = '<a title="x&y">hi</a>'
+  assert.equal(htmlDecode(htmlEncode(html)), html)
+})
+
+test('unicode escape conversion', () => {
+  const encoded = unicodeEscapeEncode('hello 你好')
+  assert.equal(encoded, 'hello \\u4f60\\u597d')
+  assert.equal(unicodeEscapeDecode(encoded), 'hello 你好')
+})
+
+test('json format and minify', () => {
+  const compact = '{"b":2,"a":1}'
+  assert.equal(formatJson(compact), '{\n  "b": 2,\n  "a": 1\n}')
+  assert.equal(minifyJson(formatJson(compact)), compact)
+})
+
+test('md5 and sha256 digest', async () => {
+  assert.equal(md5('abc'), '900150983cd24fb0d6963f7d28e17f72')
+  assert.equal(await digestHex('MD5', 'abc'), '900150983cd24fb0d6963f7d28e17f72')
+  assert.equal(
+    await digestHex('SHA-256', 'abc'),
+    'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+  )
+})
+
+test('hmac sha256', async () => {
+  assert.equal(
+    await hmacHex('SHA-256', 'abc', 'secret'),
+    '9946dad4e00e913fc8be8e5d3f7e110a4a9e832f83fb09c345285d78638d8a0e'
+  )
+})
+
+test('jwt decode and hs256 verify', async () => {
+  const token =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjMiLCJuYW1lIjoiSm9obiJ9.GjA3qJod-V7bWgXvYQNZRynF7HeINz_x1fpbKHRzMSo'
+  const decoded = decodeJwt(token)
+  assert.equal(decoded.header.alg, 'HS256')
+  assert.equal(decoded.payload.name, 'John')
+  assert.equal(await verifyJwtHs(token, 'secret'), true)
+  assert.equal(await verifyJwtHs(token, 'wrong'), false)
+})

--- a/plugins/developer-codec-tools/vite.config.js
+++ b/plugins/developer-codec-tools/vite.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  server: {
+    host: '127.0.0.1',
+    port: 5178,
+    strictPort: true
+  },
+  preview: {
+    host: '127.0.0.1',
+    port: 4178,
+    strictPort: true
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true
+  }
+})


### PR DESCRIPTION
## 插件信息

- **名称**: 开发加解密编码工具
- **插件ID**: developer-codec-tools
- **版本**: 0.1.0
- **描述**: 常用开发加密、解密、哈希、HMAC、JWT、编码和文本转换工具
- **作者**: Pamali
- **类型**: 新增

## 本次变更

- 初始发布开发加解密编码工具插件。
- 支持 Base64、Base64URL、URL、HTML Entity、Unicode escape、Hex、Binary 等编码转换。
- 支持 MD5、SHA-1、SHA-256、SHA-384、SHA-512、HMAC-SHA256、HMAC-SHA384、HMAC-SHA512。
- 支持 AES-GCM、AES-CBC 基于口令加密和解密。
- 支持 JWT 解码和 HS256/HS384/HS512 签名校验。
- 支持 JSON 格式化、压缩和常用文本转换。

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [ ] plugin.json 的 name / title / version / description / author 字段均已检查
- [ ] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [ ] 本次 PR 的 diff 仅涉及 `plugins/developer-codec-tools/` 目录
- [ ] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [ ] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
