### PR TITLE
Update plugin 代码模板 v1.0.3

### DIFF
--- a/plugins/code-snippets/CHANGELOG.md
+++ b/plugins/code-snippets/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+本文件记录「代码模板」插件每次版本更新的内容。
+
+## [1.0.3] - 2026-05-09
+
+### 修复
+
+- 修复复制次数（usageCount）切换页面后丢失的问题：`handleCopy` 中 `db.put` 未等待结果确认，`loadTemplates` 重新加载后覆盖了未持久化的修改，现在等待 `put` 成功后再同步更新 UI 状态
+- 使用 `toRaw` 脱除响应式代理，避免传给 `ztools.db` 时序列化问题
+
+## [1.0.2] - 2026-05-07
+
+### 优化
+
+- Shiki 初始化逻辑从 `<script setup>` 移至模块级 `<script>` 块，避免组件重新挂载时重复初始化
+- 清理未使用的变量
+
+## [1.0.1] - 2026-05-07
+
+### 优化
+
+- **内存占用优化**：详情视图用 Shiki 替代 CodeMirror，纯 HTML 输出无编辑器运行时开销
+- 编辑视图 CodeMirror 改为异步懒加载，减少首屏加载
+- Shiki 使用 JS 正则引擎替代 WASM，减少 622KB 加载体积
+- 修复 `darkMedia` 事件监听器在模块顶层执行导致 HMR 累积泄漏
+- 修复 Shiki highlighter 未 `dispose` 的 HMR 泄漏
+- `defineAsyncComponent` 移至模块级避免 HMR 重复创建
+- 添加 `import.meta.hot.dispose` 清理 Shiki 实例
+
+## [1.0.0] - 2026-05-06
+
+### 新增
+
+- 初始版本发布
+- Vue 3 + TypeScript + Vite 项目搭建
+- 模板 CRUD（新建、编辑、删除）
+- 搜索过滤、按使用频率排序
+- 一键复制到剪贴板
+- JSON 导入/导出
+- ElementPlus 组件按需自动导入（unplugin-auto-import + unplugin-vue-components）
+- CodeMirror 语言扩展动态加载，减小首屏体积
+- ZTools 插件清单（plugin.json）与 preload 服务脚本
+- 双运行环境适配：ZTools 生产环境 / 独立浏览器开发环境

--- a/plugins/code-snippets/package.json
+++ b/plugins/code-snippets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-snippets",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "保存和管理常用代码模板，支持一键复制、搜索过滤、按使用频率排序、导入导出 JSON 文件。",
   "type": "module",
   "scripts": {

--- a/plugins/code-snippets/public/plugin.json
+++ b/plugins/code-snippets/public/plugin.json
@@ -5,7 +5,7 @@
   "description": "保存和管理常用代码模板，支持一键复制、搜索过滤、按使用频率排序、导入导出 JSON 文件。",
   "author": "咖啡八杯",
   "category": "productivity",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "index.html",
   "preload": "preload/services.js",
   "logo": "logo.png",

--- a/plugins/code-snippets/src/Snippets/index.vue
+++ b/plugins/code-snippets/src/Snippets/index.vue
@@ -378,16 +378,33 @@ const handleCopy = (tpl: Template, event?: Event) => {
   } else {
     navigator.clipboard?.writeText(tpl.code)
   }
-  tpl.usageCount++
-  const doc = { ...tpl, updatedAt: new Date().toISOString() }
+  const newCount = tpl.usageCount + 1
+  const now = new Date().toISOString()
+  const doc = { ...toRaw(tpl), usageCount: newCount, updatedAt: now }
   if (window.ztools?.db) {
-    window.ztools.db.put(toRaw(doc))
-    loadTemplates()
+    const result = window.ztools.db.put(doc)
+    if (result) {
+      tpl.usageCount = newCount
+      tpl._rev = result.rev
+      tpl.updatedAt = now
+      if (selected.value?._id === tpl._id) {
+        selected.value.usageCount = newCount
+        selected.value._rev = result.rev
+        selected.value.updatedAt = now
+      }
+      loadTemplates()
+    }
   } else {
     const list = localLoad()
     const idx = list.findIndex((t) => t._id === doc._id)
     if (idx >= 0) list[idx] = doc
     localSave(list)
+    tpl.usageCount = newCount
+    tpl.updatedAt = now
+    if (selected.value?._id === tpl._id) {
+      selected.value.usageCount = newCount
+      selected.value.updatedAt = now
+    }
     loadTemplates()
   }
   ElMessage({ message: '已复制到剪贴板', type: 'success', duration: 1000 })


### PR DESCRIPTION
## 插件信息

- **名称**: 代码模板
- **插件ID**: code-snippets
- **版本**: 1.0.3
- **描述**: 保存和管理常用代码模板，支持一键复制、搜索过滤、按使用频率排序、导入导出 JSON 文件。
- **作者**: 咖啡八杯
- **类型**: 更新

## 本次变更

### 修复

- 修复复制次数（usageCount）切换页面后丢失的问题：`handleCopy` 中 `db.put` 未等待结果确认，`loadTemplates` 重新加载后覆盖了未持久化的修改，现在等待 `put` 成功后再同步更新 UI 状态
- 使用 `toRaw` 脱除响应式代理，避免传给 `ztools.db` 时序列化问题

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/code-snippets/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
