### PR TITLE
Update plugin 代码模板 v1.0.4

### DIFF
--- a/plugins/code-snippets/CHANGELOG.md
+++ b/plugins/code-snippets/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 本文件记录「代码模板」插件每次版本更新的内容。
 
+## [1.0.4] - 2026-05-11
+
+### 修复
+
+- 修复复制操作时 `ztools.db.put` 报 `An object could not be cloned` 错误：`handleCopy` 中 `{ ...toRaw(tpl) }` 展开后嵌套属性（如 `tags` 数组）仍为 Vue 响应式代理，Electron `sendSync` 的 `structuredClone` 无法序列化代理对象，改为手动构造纯数据对象
+
 ## [1.0.3] - 2026-05-09
 
 ### 修复

--- a/plugins/code-snippets/package.json
+++ b/plugins/code-snippets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-snippets",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "保存和管理常用代码模板，支持一键复制、搜索过滤、按使用频率排序、导入导出 JSON 文件。",
   "type": "module",
   "scripts": {

--- a/plugins/code-snippets/public/plugin.json
+++ b/plugins/code-snippets/public/plugin.json
@@ -5,7 +5,7 @@
   "description": "保存和管理常用代码模板，支持一键复制、搜索过滤、按使用频率排序、导入导出 JSON 文件。",
   "author": "咖啡八杯",
   "category": "productivity",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "main": "index.html",
   "preload": "preload/services.js",
   "logo": "logo.png",

--- a/plugins/code-snippets/src/Snippets/index.vue
+++ b/plugins/code-snippets/src/Snippets/index.vue
@@ -381,15 +381,9 @@ const handleCopy = (tpl: Template, event?: Event) => {
   const newCount = tpl.usageCount + 1
   const now = new Date().toISOString()
   const doc: Template = {
-    _id: tpl._id,
-    _rev: tpl._rev,
-    name: tpl.name,
-    description: tpl.description,
-    language: tpl.language,
+    ...toRaw(tpl),
     tags: [...tpl.tags],
-    code: tpl.code,
     usageCount: newCount,
-    createdAt: tpl.createdAt,
     updatedAt: now
   }
   if (window.ztools?.db) {

--- a/plugins/code-snippets/src/Snippets/index.vue
+++ b/plugins/code-snippets/src/Snippets/index.vue
@@ -380,7 +380,18 @@ const handleCopy = (tpl: Template, event?: Event) => {
   }
   const newCount = tpl.usageCount + 1
   const now = new Date().toISOString()
-  const doc = { ...toRaw(tpl), usageCount: newCount, updatedAt: now }
+  const doc: Template = {
+    _id: tpl._id,
+    _rev: tpl._rev,
+    name: tpl.name,
+    description: tpl.description,
+    language: tpl.language,
+    tags: [...tpl.tags],
+    code: tpl.code,
+    usageCount: newCount,
+    createdAt: tpl.createdAt,
+    updatedAt: now
+  }
   if (window.ztools?.db) {
     const result = window.ztools.db.put(doc)
     if (result) {


### PR DESCRIPTION
## 插件信息

- **名称**: 代码模板
- **插件ID**: code-snippets
- **版本**: 1.0.4
- **描述**: 保存和管理常用代码模板，支持一键复制、搜索过滤、按使用频率排序、导入导出 JSON 文件。
- **作者**: 咖啡八杯
- **类型**: 更新

## 本次变更

### 修复

- 修复复制操作时 `ztools.db.put` 报 `An object could not be cloned` 错误：`handleCopy` 中 `{ ...toRaw(tpl) }` 展开后嵌套属性（如 `tags` 数组）仍为 Vue 响应式代理，Electron `sendSync` 的 `structuredClone` 无法序列化代理对象，改为手动构造纯数据对象

## 截图 / 演示
<img width="800" height="652" alt="image" src="https://github.com/user-attachments/assets/8cf990bb-2677-4bd9-a5c3-fd5105d39151" />

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/code-snippets/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
