### PR TITLE
Update plugin 剪贴板 v1.2.7

### DIFF
--- a/plugins/clipboard/.vscode/extensions.json
+++ b/plugins/clipboard/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["Vue.volar"]
-}

--- a/plugins/clipboard/public/plugin.json
+++ b/plugins/clipboard/public/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "clipboard",
   "description": "剪贴板",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "main": "index.html",
   "preload": "preload.js",
   "logo": "logo.png",
@@ -12,7 +12,7 @@
     {
       "code": "clipboard",
       "explain": "剪贴板",
-      "cmds": ["剪贴板"]
+      "cmds": ["剪贴板", "clipboard"]
     }
   ],
   "tools": {

--- a/plugins/clipboard/src/App.vue
+++ b/plugins/clipboard/src/App.vue
@@ -173,10 +173,12 @@ const resetSearchAndFocus = async () => {
 watch(activeTab, doReload)
 
 // 当对话框打开时，阻止全局键盘快捷键（如 Enter 粘贴）
+const isAnyModalOpen = computed(() =>
+  showDeleteConfirm.value || showClearConfirm.value || favoriteDialog.value.show
+)
+
 const handleGlobalKeydown = (event) => {
-  if (showDeleteConfirm.value || showClearConfirm.value || favoriteDialog.value.show) {
-    return
-  }
+  if (isAnyModalOpen.value) return
   handleKeydown(event)
 }
 

--- a/plugins/clipboard/src/App.vue
+++ b/plugins/clipboard/src/App.vue
@@ -52,10 +52,18 @@ const copyToClipboard = async (id, shouldPaste = true) => {
   }
 }
 
+const showDeleteConfirm = ref(false)
+const deleteTargetItem = ref(null)
+
+const handleDeleteSelected = (item) => {
+  deleteTargetItem.value = item
+  showDeleteConfirm.value = true
+}
+
 const {
   selectedIndex, clipboardListRef, resetSelection,
   handleKeydown, copySelected, pasteSelected
-} = useSelection(filteredData, tabs, activeTab, copyToClipboard)
+} = useSelection(filteredData, tabs, activeTab, copyToClipboard, handleDeleteSelected)
 
 const { contextMenu, showContextMenu, hideContextMenu } = useContextMenu()
 const { favoriteDialog, openFavoriteDialog, confirmFavorite, cancelFavoriteDialog } = useFavoriteDialog()
@@ -68,9 +76,6 @@ const handleContextMenu = (event, item) => {
 const handleFavoriteConfirm = async (remark) => {
   await confirmFavorite(addFavorite, remark)
 }
-
-const showDeleteConfirm = ref(false)
-const deleteTargetItem = ref(null)
 
 const handleDeleteItem = () => {
   deleteTargetItem.value = contextMenu.value.item
@@ -167,8 +172,16 @@ const resetSearchAndFocus = async () => {
 // ---- 监听 & 生命周期 ----
 watch(activeTab, doReload)
 
+// 当对话框打开时，阻止全局键盘快捷键（如 Enter 粘贴）
+const handleGlobalKeydown = (event) => {
+  if (showDeleteConfirm.value || showClearConfirm.value || favoriteDialog.value.show) {
+    return
+  }
+  handleKeydown(event)
+}
+
 onMounted(async () => {
-  window.addEventListener('keydown', handleKeydown)
+  window.addEventListener('keydown', handleGlobalKeydown)
   window.addEventListener('click', hideContextMenu)
 
   await loadFavorites()
@@ -187,7 +200,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
-  window.removeEventListener('keydown', handleKeydown)
+  window.removeEventListener('keydown', handleGlobalKeydown)
   window.removeEventListener('click', hideContextMenu)
 })
 </script>

--- a/plugins/clipboard/src/components/ConfirmDialog.vue
+++ b/plugins/clipboard/src/components/ConfirmDialog.vue
@@ -9,18 +9,20 @@ const props = defineProps({
 
 const emit = defineEmits(['confirm', 'cancel'])
 const dialogContentRef = ref(null)
+let focusableEls = []
 
-const trapFocus = (e) => {
+const updateFocusableEls = () => {
   const el = dialogContentRef.value
   if (!el) return
-  const focusable = el.querySelectorAll(
+  focusableEls = Array.from(el.querySelectorAll(
     'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-  )
-  if (focusable.length === 0) return
+  ))
+}
 
-  const first = focusable[0]
-  const last = focusable[focusable.length - 1]
-
+const trapFocus = (e) => {
+  if (focusableEls.length === 0) return
+  const first = focusableEls[0]
+  const last = focusableEls[focusableEls.length - 1]
   if (e.shiftKey && document.activeElement === first) {
     e.preventDefault()
     last.focus()
@@ -51,10 +53,12 @@ watch(() => props.show, (visible) => {
   if (visible) {
     window.addEventListener('keydown', handleKeydown)
     nextTick(() => {
+      updateFocusableEls()
       dialogContentRef.value?.querySelector('.btn-confirm')?.focus()
     })
   } else {
     window.removeEventListener('keydown', handleKeydown)
+    focusableEls = []
   }
 })
 

--- a/plugins/clipboard/src/components/ConfirmDialog.vue
+++ b/plugins/clipboard/src/components/ConfirmDialog.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, nextTick, onUnmounted } from 'vue'
 
 const props = defineProps({
   show: { type: Boolean, default: false },
@@ -8,11 +8,64 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['confirm', 'cancel'])
+const dialogContentRef = ref(null)
+
+const trapFocus = (e) => {
+  const el = dialogContentRef.value
+  if (!el) return
+  const focusable = el.querySelectorAll(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  )
+  if (focusable.length === 0) return
+
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault()
+    last.focus()
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault()
+    first.focus()
+  }
+}
+
+const handleKeydown = (e) => {
+  if (e.key === 'Tab') {
+    trapFocus(e)
+    return
+  }
+  if (e.key === 'Enter') {
+    // 如果用户通过 Tab 聚焦到了某个按钮，让按钮原生 Enter 行为触发点击
+    if (document.activeElement?.tagName === 'BUTTON') {
+      return
+    }
+    e.preventDefault()
+    emit('confirm')
+  } else if (e.key === 'Escape') {
+    emit('cancel')
+  }
+}
+
+watch(() => props.show, (visible) => {
+  if (visible) {
+    window.addEventListener('keydown', handleKeydown)
+    nextTick(() => {
+      dialogContentRef.value?.querySelector('.btn-confirm')?.focus()
+    })
+  } else {
+    window.removeEventListener('keydown', handleKeydown)
+  }
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown)
+})
 </script>
 
 <template>
   <div v-if="show" class="dialog-overlay" @click="emit('cancel')">
-    <div class="dialog-content" @click.stop>
+    <div ref="dialogContentRef" class="dialog-content" @click.stop>
       <div class="dialog-header">
         <h3>{{ title }}</h3>
         <button class="dialog-close" @click="emit('cancel')">✕</button>

--- a/plugins/clipboard/src/components/FavoriteDialog.vue
+++ b/plugins/clipboard/src/components/FavoriteDialog.vue
@@ -11,18 +11,20 @@ const emit = defineEmits(['confirm', 'cancel'])
 const remark = ref('')
 const dialogContentRef = ref(null)
 const remarkInputRef = ref(null)
+let focusableEls = []
 
-const trapFocus = (e) => {
+const updateFocusableEls = () => {
   const el = dialogContentRef.value
   if (!el) return
-  const focusable = el.querySelectorAll(
+  focusableEls = Array.from(el.querySelectorAll(
     'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-  )
-  if (focusable.length === 0) return
+  ))
+}
 
-  const first = focusable[0]
-  const last = focusable[focusable.length - 1]
-
+const trapFocus = (e) => {
+  if (focusableEls.length === 0) return
+  const first = focusableEls[0]
+  const last = focusableEls[focusableEls.length - 1]
   if (e.shiftKey && document.activeElement === first) {
     e.preventDefault()
     last.focus()
@@ -59,10 +61,12 @@ watch(() => props.show, (val) => {
     remark.value = ''
     window.addEventListener('keydown', handleKeydown)
     nextTick(() => {
+      updateFocusableEls()
       remarkInputRef.value?.focus()
     })
   } else {
     window.removeEventListener('keydown', handleKeydown)
+    focusableEls = []
   }
 })
 

--- a/plugins/clipboard/src/components/FavoriteDialog.vue
+++ b/plugins/clipboard/src/components/FavoriteDialog.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch } from 'vue'
+import { ref, watch, nextTick, onUnmounted } from 'vue'
 
 const props = defineProps({
   show: { type: Boolean, default: false },
@@ -9,12 +9,65 @@ const props = defineProps({
 const emit = defineEmits(['confirm', 'cancel'])
 
 const remark = ref('')
+const dialogContentRef = ref(null)
+const remarkInputRef = ref(null)
+
+const trapFocus = (e) => {
+  const el = dialogContentRef.value
+  if (!el) return
+  const focusable = el.querySelectorAll(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  )
+  if (focusable.length === 0) return
+
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault()
+    last.focus()
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault()
+    first.focus()
+  }
+}
+
+const handleKeydown = (e) => {
+  if (e.key === 'Tab') {
+    trapFocus(e)
+    return
+  }
+  if (e.key === 'Enter') {
+    // 如果用户通过 Tab 聚焦到了某个按钮，让按钮原生 Enter 行为触发点击
+    if (document.activeElement?.tagName === 'BUTTON') {
+      return
+    }
+    // 如果聚焦在输入框且已有 @keyup.enter，这里 let it pass through
+    // 否则直接提交
+    if (document.activeElement?.tagName !== 'INPUT') {
+      e.preventDefault()
+      emit('confirm', remark.value)
+    }
+  } else if (e.key === 'Escape') {
+    emit('cancel')
+  }
+}
 
 // 弹窗打开时重置备注
 watch(() => props.show, (val) => {
   if (val) {
     remark.value = ''
+    window.addEventListener('keydown', handleKeydown)
+    nextTick(() => {
+      remarkInputRef.value?.focus()
+    })
+  } else {
+    window.removeEventListener('keydown', handleKeydown)
   }
+})
+
+onUnmounted(() => {
+  window.removeEventListener('keydown', handleKeydown)
 })
 
 const handleConfirm = () => {
@@ -24,7 +77,7 @@ const handleConfirm = () => {
 
 <template>
   <div v-if="show" class="dialog-overlay" @click="emit('cancel')">
-    <div class="dialog-content" @click.stop>
+    <div ref="dialogContentRef" class="dialog-content" @click.stop>
       <div class="dialog-header">
         <h3>添加收藏</h3>
         <button class="dialog-close" @click="emit('cancel')">✕</button>
@@ -41,6 +94,7 @@ const handleConfirm = () => {
         <div class="dialog-field">
           <label>备注</label>
           <input
+            ref="remarkInputRef"
             v-model="remark"
             type="text"
             placeholder="请输入备注(可选)"

--- a/plugins/clipboard/src/components/SideBar.vue
+++ b/plugins/clipboard/src/components/SideBar.vue
@@ -9,11 +9,7 @@ const emit = defineEmits(['copy', 'paste', 'clear'])
       <button class="sidebar-btn copy-btn" @click="emit('copy')" data-tooltip="仅复制">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc. -->
           <path d="M480 400L288 400C279.2 400 272 392.8 272 384L272 128C272 119.2 279.2 112 288 112L421.5 112C425.7 112 429.8 113.7 432.8 116.7L491.3 175.2C494.3 178.2 496 182.3 496 186.5L496 384C496 392.8 488.8 400 480 400zM288 448L480 448C515.3 448 544 419.3 544 384L544 186.5C544 169.5 537.3 153.2 525.3 141.2L466.7 82.7C454.7 70.7 438.5 64 421.5 64L288 64C252.7 64 224 92.7 224 128L224 384C224 419.3 252.7 448 288 448zM160 192C124.7 192 96 220.7 96 256L96 512C96 547.3 124.7 576 160 576L352 576C387.3 576 416 547.3 416 512L416 496L368 496L368 512C368 520.8 360.8 528 352 528L160 528C151.2 528 144 520.8 144 512L144 256C144 247.2 151.2 240 160 240L176 240L176 192L160 192z"
-            fill="currentColor"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round" />
+            fill="currentColor" />
         </svg>
       </button>
 
@@ -21,11 +17,7 @@ const emit = defineEmits(['copy', 'paste', 'clear'])
       <button class="sidebar-btn paste-btn" @click="emit('paste')" data-tooltip="复制并粘贴">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc. -->
           <path d="M128 112L352 112C360.8 112 368 119.2 368 128L368 176L416 176L416 128C416 92.7 387.3 64 352 64L128 64C92.7 64 64 92.7 64 128L64 448C64 483.3 92.7 512 128 512L240 512L240 464L128 464C119.2 464 112 456.8 112 448L112 128C112 119.2 119.2 112 128 112zM304 184C304 170.7 293.3 160 280 160L168 160C154.7 160 144 170.7 144 184C144 197.3 154.7 208 168 208L273.6 208C282.4 199.4 292.6 192.2 303.8 186.9C303.9 186 304 185 304 184zM512 528L352 528C343.2 528 336 520.8 336 512L336 288C336 279.2 343.2 272 352 272L453.5 272C457.7 272 461.8 273.7 464.8 276.7L523.3 335.2C526.3 338.2 528 342.3 528 346.5L528 512C528 520.8 520.8 528 512 528zM288 288L288 512C288 547.3 316.7 576 352 576L512 576C547.3 576 576 547.3 576 512L576 346.5C576 329.5 569.3 313.2 557.3 301.2L498.8 242.7C486.8 230.7 470.5 224 453.5 224L352 224C316.7 224 288 252.7 288 288z"
-            fill="currentColor"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round" />
+            fill="currentColor" />
         </svg>
       </button>
     </div>

--- a/plugins/clipboard/src/components/SideBar.vue
+++ b/plugins/clipboard/src/components/SideBar.vue
@@ -6,29 +6,26 @@ const emit = defineEmits(['copy', 'paste', 'clear'])
   <div class="sidebar">
     <div class="sidebar-actions">
       <!-- 复制按钮 -->
-      <button class="sidebar-btn copy-btn" @click="emit('copy')" data-tooltip="复制">
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"
+      <button class="sidebar-btn copy-btn" @click="emit('copy')" data-tooltip="仅复制">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc. -->
+          <path d="M480 400L288 400C279.2 400 272 392.8 272 384L272 128C272 119.2 279.2 112 288 112L421.5 112C425.7 112 429.8 113.7 432.8 116.7L491.3 175.2C494.3 178.2 496 182.3 496 186.5L496 384C496 392.8 488.8 400 480 400zM288 448L480 448C515.3 448 544 419.3 544 384L544 186.5C544 169.5 537.3 153.2 525.3 141.2L466.7 82.7C454.7 70.7 438.5 64 421.5 64L288 64C252.7 64 224 92.7 224 128L224 384C224 419.3 252.7 448 288 448zM160 192C124.7 192 96 220.7 96 256L96 512C96 547.3 124.7 576 160 576L352 576C387.3 576 416 547.3 416 512L416 496L368 496L368 512C368 520.8 360.8 528 352 528L160 528C151.2 528 144 520.8 144 512L144 256C144 247.2 151.2 240 160 240L176 240L176 192L160 192z"
+            fill="currentColor"
             stroke="currentColor"
             stroke-width="2"
             stroke-linecap="round"
-            stroke-linejoin="round"/>
-          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"/>
+            stroke-linejoin="round" />
         </svg>
       </button>
 
       <!-- 粘贴按钮 -->
-      <button class="sidebar-btn paste-btn" @click="emit('paste')" data-tooltip="粘贴">
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z"
+      <button class="sidebar-btn paste-btn" @click="emit('paste')" data-tooltip="复制并粘贴">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 640"><!--!Font Awesome Free v7.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc. -->
+          <path d="M128 112L352 112C360.8 112 368 119.2 368 128L368 176L416 176L416 128C416 92.7 387.3 64 352 64L128 64C92.7 64 64 92.7 64 128L64 448C64 483.3 92.7 512 128 512L240 512L240 464L128 464C119.2 464 112 456.8 112 448L112 128C112 119.2 119.2 112 128 112zM304 184C304 170.7 293.3 160 280 160L168 160C154.7 160 144 170.7 144 184C144 197.3 154.7 208 168 208L273.6 208C282.4 199.4 292.6 192.2 303.8 186.9C303.9 186 304 185 304 184zM512 528L352 528C343.2 528 336 520.8 336 512L336 288C336 279.2 343.2 272 352 272L453.5 272C457.7 272 461.8 273.7 464.8 276.7L523.3 335.2C526.3 338.2 528 342.3 528 346.5L528 512C528 520.8 520.8 528 512 528zM288 288L288 512C288 547.3 316.7 576 352 576L512 576C547.3 576 576 547.3 576 512L576 346.5C576 329.5 569.3 313.2 557.3 301.2L498.8 242.7C486.8 230.7 470.5 224 453.5 224L352 224C316.7 224 288 252.7 288 288z"
+            fill="currentColor"
             stroke="currentColor"
             stroke-width="2"
             stroke-linecap="round"
-            stroke-linejoin="round"/>
+            stroke-linejoin="round" />
         </svg>
       </button>
     </div>
@@ -41,11 +38,11 @@ const emit = defineEmits(['copy', 'paste', 'clear'])
             stroke="currentColor"
             stroke-width="2"
             stroke-linecap="round"
-            stroke-linejoin="round"/>
+            stroke-linejoin="round" />
           <path d="M10 11v6M14 11v6"
             stroke="currentColor"
             stroke-width="2"
-            stroke-linecap="round"/>
+            stroke-linecap="round" />
         </svg>
       </button>
     </div>

--- a/plugins/clipboard/src/composables/useSelection.js
+++ b/plugins/clipboard/src/composables/useSelection.js
@@ -5,8 +5,9 @@ import { ref } from 'vue'
  * @param {import('vue').ComputedRef<Array>} tabs
  * @param {import('vue').Ref<string>} activeTab
  * @param {Function} copyToClipboard - (id, shouldPaste) => Promise
+ * @param {Function} [onDeleteItem] - (item) => void, called when Delete key is pressed on a selected item
  */
-export function useSelection(filteredData, tabs, activeTab, copyToClipboard) {
+export function useSelection(filteredData, tabs, activeTab, copyToClipboard, onDeleteItem) {
   const selectedIndex = ref(0)
   const clipboardListRef = ref(null)
 
@@ -88,6 +89,15 @@ export function useSelection(filteredData, tabs, activeTab, copyToClipboard) {
       const selectedItem = filteredData.value[selectedIndex.value]
       if (selectedItem) {
         copyToClipboard(selectedItem.id)
+      }
+    }
+
+    // Delete 键删除选中项
+    if (event.key === 'Delete') {
+      event.preventDefault()
+      const selectedItem = filteredData.value[selectedIndex.value]
+      if (selectedItem && onDeleteItem) {
+        onDeleteItem(selectedItem)
       }
     }
   }


### PR DESCRIPTION
## 插件信息

- **名称**: 剪贴板
- **插件ID**: clipboard
- **版本**: 1.2.7
- **描述**: 剪贴板
- **作者**: N/A
- **类型**: 更新

## 本次变更

### 新增
- **Delete 键删除**: 选中剪贴板项目后按 Delete 键会弹出删除确认对话框，与右键菜单的删除操作一致。
- **回车键确认操作**: 对话框打开时，按回车键确认当前操作（删除确认等同于点击"确定"，收藏对话框提交备注并收藏）。
- **Escape 取消**: 按 Escape 键关闭当前对话框。
- **对话框焦点锁定**: 确认对话框和收藏对话框打开时，Tab 循环锁定在对话框内，防止焦点逃逸到遮罩层后面。对话框弹出时自动聚焦确认按钮或备注输入框。
- **智能按钮处理**: 当通过 Tab 聚焦到对话框中的某个按钮时，按回车键触发该按钮的原生点击行为——例如 Tab 切换到"取消"按钮后按回车，会正常取消而不是删除。
### 变更
- **侧边栏图标**: 将复制和粘贴按钮的 SVG 图标替换为 Font Awesome 图标，视觉更清晰。工具提示从"复制"/"粘贴"改为"仅复制"/"复制并粘贴"，名称更能准确表达实际行为。
- **全局键盘防护**: 当对话框（删除确认、清空确认或收藏对话框）打开时，全局键盘快捷键（方向键切换、回车复制等）会被抑制，避免干扰对话框操作。

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [X] plugin.json 的 name / title / version / description / author 字段均已检查
- [X] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [X] 本次 PR 的 diff 仅涉及 `plugins/clipboard/` 目录
- [X] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [X] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
