### PR TITLE
Update plugin 邪恶的熊 v1.0.0

### DIFF
--- a/plugins/bad-bear/package.json
+++ b/plugins/bad-bear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bad-bear",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "轻松分享你的ZTools插件",
   "type": "module",
   "scripts": {

--- a/plugins/bad-bear/src/app/useMarketRiskDialog.ts
+++ b/plugins/bad-bear/src/app/useMarketRiskDialog.ts
@@ -33,6 +33,14 @@ const MARKET_RISK_ITEMS = [
     label: '禁止上传有版权风险、破解付费的插件，本应用只是为了方便大家分享插件！',
   },
   {
+    key: 'technical-exchange-only',
+    label: '插件内容仅供技术交流与学习参考，下载后请在 24 小时内删除，请勿用于商业用途或其他侵权场景。',
+  },
+  {
+    key: 'infringement-contact',
+    label: '如发现插件内容涉及侵权或其他违规问题，请联系 admin@ydys.cc 处理。',
+  },
+  {
     key: 'no-data-retention-guarantee',
     label: '本市场是玩票性质的插件市场，不对任何数据存留做保证，随时跑路。',
   },


### PR DESCRIPTION
## 插件信息

- **名称**: 邪恶的熊
- **插件ID**: bad-bear
- **版本**: 1.0.0
- **描述**: 轻松分享你的ZTools插件
- **作者**: 皮皮虾我们走
- **类型**: 更新

## 本次变更

- init
- init: 初始化
- chore: 修复重启后丢失问题
- chore: 移除注入相关功能
- chore: 新增github流程
- feat: 插件上传相关功能完善
- feat: 实现密码变更功能
- refactor: 重构代码结构
- chore: 添加商店版本检查
- chore: 调整项目按钮大小
- chore: 添加登陆注册的验证码
- chore: 主题获取调整
- feat: 完善插件市场详情展示与上传体验
- refactor: 插件市场接入 ztools-ui 并统一主题适配
- refactor: 精简插件市场详情交互并补齐宿主能力
- feat: 增加插件市场风险确认并统一相关弹窗交互
- refactor: 插件市场改为按平台流式加载并优化刷新状态
- refactor: 插件市场统一历史版本状态与全局弹窗
- feat: 插件市场记录安装 hash 并优化更新检查
- feat: 优化插件市场上传与设置交互
- feat: 优化插件市场上传进度展示
- feat: 新增内部 API 授权引导弹窗并优化账号面板交互
- docs: 简化 README 并移除侧边栏标题
- refactor: 移除冗余通用组件并统一使用 ztools-ui
- chore: 补充插件市场风险提示文案

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [ ] plugin.json 的 name / title / version / description / author 字段均已检查
- [ ] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [ ] 本次 PR 的 diff 仅涉及 `plugins/bad-bear/` 目录
- [ ] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [ ] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
