### PR TITLE
Update plugin 哈希计算器 v1.3.2

### DIFF
--- a/plugins/my-hash-tool/LICENSE
+++ b/plugins/my-hash-tool/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Evan Cui
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## 插件信息

- **名称**: 哈希计算器
- **插件ID**: my-hash-tool
- **版本**: 1.3.2
- **描述**: 计算文件或字符 Hash：默认 MD5、SHA1、SHA256，可选 CRC32、SHA384、SHA512
- **作者**: Evan Cui
- **类型**: 更新

## 本次变更

> #213 合并后，`my-hash-tool` 源码中的版本已是 `1.3.2`，但后续 release assets 里仍然是 `my-hash-tool-1.3.1.zip`。我检查后发现该 zip 内部的 `plugin.json` 也是 `1.3.1`，所以应用侧看到的版本没有变化。
> 
> 推测原因是发布流程复用了旧 release asset，而这次插件没有被重新打包。本 PR 在 `plugins/my-hash-tool/` 下新增文件，用于重新触发该插件的构建流程，期望合并后生成 `my-hash-tool-1.3.2.zip`。

=======================================================
- 界面全面重构：设置页改为右侧抽屉，支持 ESC 关闭，主页面内容保持可见。
- 文件模式输入区改为紧凑标签列表，释放更多空间给结果区域。
- 批量进度面板改为内联轻量进度条，取消按钮移至进度条右侧。
- 全部小写/大写操作移至各结果卡片内，按需显示。
- 顶部操作栏精简为算法标注、复制全部结果、设置三个固定元素。
- 清空按钮与重新选择并排，位置更直观。
- 空状态新增图标和操作引导文案。
- Hash 结果行列宽改为自适应，算法名不再截断。
- 配色方案调整为靛蓝系：暖白背景、深靛蓝 accent，暗黑模式同步更新。
- 所有按钮字号统一为 13px，与页面整体排版协调。
- 进度条完成时颜色过渡平滑（蓝→绿加 transition）。
- 弹窗标题去掉「大文件提醒」eyebrow 标签，直接显示标题。

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/my-hash-tool/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
