### PR TITLE
feat: 添加图片拼接插件

### DIFF
--- a/plugins/image-stitch/app.js
+++ b/plugins/image-stitch/app.js
@@ -1,0 +1,690 @@
+(function () {
+  const state = {
+    images: [],
+    stash: [],
+    direction: 'vertical',
+    align: 'center',
+    resizeMode: 'enlarge',
+    spacing: 0,
+    padding: 0,
+    bgColor: 'transparent',
+    format: 'png',
+    quality: 0.92
+  };
+
+  const $ = (sel) => document.querySelector(sel);
+  const canvas = $('#canvas');
+  const ctx = canvas.getContext('2d');
+  let isDraggingInternal = false;
+  let dragFromIdx = -1;
+
+  function init() {
+    bindEvents();
+    ztools.setExpendHeight(600);
+    ztools.onPluginEnter(({ code, payload }) => {
+      if (code === 'image-stitch-files' && payload) {
+        const files = Array.isArray(payload) ? payload : [payload];
+        files.forEach((f) => addImageFromPath(typeof f === 'string' ? f : f.path));
+      } else if (code === 'image-stitch-img' && payload) {
+        addImageFromDataURL(payload);
+      }
+    });
+  }
+
+  function bindEvents() {
+    $('#btn-add').addEventListener('click', openFilePicker);
+    $('#btn-paste').addEventListener('click', pasteFromClipboard);
+    $('#btn-clear').addEventListener('click', clearAll);
+    $('#btn-reverse').addEventListener('click', reverseOrder);
+    $('#btn-stash').addEventListener('click', stashCurrent);
+    $('#btn-save').addEventListener('click', saveImage);
+    $('#btn-copy').addEventListener('click', copyToClipboard);
+
+    document.querySelectorAll('input[name="direction"]').forEach((el) => {
+      el.addEventListener('change', (e) => {
+        state.direction = e.target.value;
+        updateAlignOptions();
+        render();
+      });
+    });
+
+    $('#align').addEventListener('change', (e) => {
+      state.align = e.target.value;
+      render();
+    });
+
+    $('#resize-mode').addEventListener('change', (e) => {
+      state.resizeMode = e.target.value;
+      updateAlignVisibility();
+      render();
+    });
+
+    $('#spacing').addEventListener('input', (e) => {
+      state.spacing = parseInt(e.target.value);
+      $('#spacing-value').textContent = state.spacing + 'px';
+      render();
+    });
+
+    $('#padding').addEventListener('input', (e) => {
+      state.padding = parseInt(e.target.value);
+      $('#padding-value').textContent = state.padding + 'px';
+      render();
+    });
+
+    document.querySelectorAll('.color-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.color-btn').forEach((b) => b.classList.remove('active'));
+        btn.classList.add('active');
+        state.bgColor = btn.dataset.color;
+        render();
+      });
+    });
+
+    $('#custom-color').addEventListener('input', (e) => {
+      document.querySelectorAll('.color-btn').forEach((b) => b.classList.remove('active'));
+      state.bgColor = e.target.value;
+      render();
+    });
+
+    $('#format').addEventListener('change', (e) => {
+      state.format = e.target.value;
+      const showQuality = e.target.value !== 'png';
+      $('#quality-group').style.display = showQuality ? '' : 'none';
+      render();
+    });
+
+    $('#quality').addEventListener('input', (e) => {
+      state.quality = parseInt(e.target.value) / 100;
+      $('#quality-value').textContent = e.target.value + '%';
+    });
+
+    const previewArea = $('#preview-area');
+    previewArea.addEventListener('dragover', (e) => {
+      if (isDraggingInternal) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+    });
+    previewArea.addEventListener('drop', (e) => {
+      if (isDraggingInternal) return;
+      if (handleStashDrop(e)) return;
+      handleDrop(e);
+    });
+
+    const imageList = $('#image-list');
+    imageList.addEventListener('dragover', (e) => {
+      if (isDraggingInternal) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        startAutoScroll(imageList, e.clientY);
+        return;
+      }
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+    });
+    imageList.addEventListener('dragleave', (e) => {
+      if (isDraggingInternal && !imageList.contains(e.relatedTarget)) {
+        const rect = imageList.getBoundingClientRect();
+        if (e.clientY < rect.top) {
+          startAutoScroll(imageList, e.clientY);
+          applyDragShifts(0);
+        } else if (e.clientY > rect.bottom) {
+          startAutoScroll(imageList, e.clientY);
+          applyDragShifts(state.images.length - 1);
+        }
+      }
+    });
+
+    document.addEventListener('dragover', (e) => {
+      if (!isDraggingInternal) return;
+      const rect = imageList.getBoundingClientRect();
+      if (e.clientY < rect.top) {
+        startAutoScroll(imageList, e.clientY);
+        applyDragShifts(0);
+      } else if (e.clientY > rect.bottom) {
+        startAutoScroll(imageList, e.clientY);
+        applyDragShifts(state.images.length - 1);
+      }
+    });
+    imageList.addEventListener('drop', (e) => {
+      stopAutoScroll();
+      if (isDraggingInternal) {
+        e.preventDefault();
+        const fromIdx = dragFromIdx;
+        const toIdx = lastShiftTarget;
+        isDraggingInternal = false;
+        dragFromIdx = -1;
+        clearDragShifts();
+        if (fromIdx >= 0 && toIdx >= 0 && fromIdx !== toIdx) {
+          const [moved] = state.images.splice(fromIdx, 1);
+          state.images.splice(toIdx, 0, moved);
+          updateUI();
+          render();
+        }
+        return;
+      }
+      if (handleStashDrop(e)) return;
+      handleDrop(e);
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (e.ctrlKey || e.metaKey) {
+        if (e.key === 'a') { e.preventDefault(); openFilePicker(); }
+        if (e.key === 'd') { e.preventDefault(); clearAll(); }
+        if (e.key === 's') { e.preventDefault(); saveImage(); }
+        if (e.key === 'v') { e.preventDefault(); pasteFromClipboard(); }
+      }
+    });
+  }
+
+  function handleDrop(e) {
+    e.preventDefault();
+    const files = e.dataTransfer.files;
+    if (!files.length) return;
+    for (const file of files) {
+      if (file.type.startsWith('image/')) {
+        const filePath = ztools.getPathForFile ? ztools.getPathForFile(file) : null;
+        if (filePath) {
+          addImageFromPath(filePath);
+        } else {
+          addImageFromFile(file);
+        }
+      }
+    }
+  }
+
+  function openFilePicker() {
+    const result = ztools.showOpenDialog({
+      title: '选择图片',
+      filters: [{ name: '图片', extensions: ['png', 'jpg', 'jpeg', 'gif', 'bmp', 'webp', 'svg'] }],
+      properties: ['openFile', 'multiSelections']
+    });
+    if (result && result.length) {
+      result.forEach((p) => addImageFromPath(p));
+    }
+  }
+
+  function pasteFromClipboard() {
+    const files = ztools.getCopyedFiles();
+    if (files && files.length) {
+      files.forEach((f) => {
+        if (/\.(png|jpe?g|gif|bmp|webp|svg)$/i.test(f)) {
+          addImageFromPath(f);
+        }
+      });
+      return;
+    }
+    navigator.clipboard.read().then((items) => {
+      for (const item of items) {
+        const imageType = item.types.find((t) => t.startsWith('image/'));
+        if (imageType) {
+          item.getType(imageType).then((blob) => {
+            const reader = new FileReader();
+            reader.onload = () => addImageFromDataURL(reader.result);
+            reader.readAsDataURL(blob);
+          });
+        }
+      }
+    }).catch(() => {});
+  }
+
+  function addImageFromPath(filePath) {
+    const img = new Image();
+    img.onload = () => {
+      state.images.push({ img, name: filePath.split(/[/\\]/).pop(), width: img.naturalWidth, height: img.naturalHeight });
+      updateUI();
+      render();
+    };
+    img.src = filePath.startsWith('file://') ? filePath : 'file:///' + filePath.replace(/\\/g, '/');
+  }
+
+  function addImageFromFile(file) {
+    const reader = new FileReader();
+    reader.onload = () => addImageFromDataURL(reader.result, file.name);
+    reader.readAsDataURL(file);
+  }
+
+  function addImageFromDataURL(dataURL, name) {
+    const img = new Image();
+    img.onload = () => {
+      state.images.push({ img, name: name || '粘贴图片', width: img.naturalWidth, height: img.naturalHeight });
+      updateUI();
+      render();
+    };
+    img.src = dataURL;
+  }
+
+  function clearAll() {
+    state.images = [];
+    updateUI();
+    render();
+  }
+
+  function reverseOrder() {
+    if (state.images.length < 2) return;
+    state.images.reverse();
+    updateUI();
+    render();
+  }
+
+  function updateAlignVisibility() {
+    const show = state.resizeMode === 'none';
+    $('#align-group').style.display = show ? '' : 'none';
+  }
+
+  function updateAlignOptions() {
+    const alignEl = $('#align');
+    const opts = alignEl.options;
+    if (state.direction === 'vertical') {
+      opts[0].textContent = '左对齐';
+      opts[1].textContent = '居中';
+      opts[2].textContent = '右对齐';
+    } else {
+      opts[0].textContent = '顶部对齐';
+      opts[1].textContent = '居中';
+      opts[2].textContent = '底部对齐';
+    }
+  }
+
+  function updateUI() {
+    const list = $('#image-list');
+    const hint = $('#empty-hint');
+
+    list.querySelectorAll('.image-item').forEach((el) => el.remove());
+
+    if (state.images.length === 0) {
+      hint.style.display = '';
+      return;
+    }
+    hint.style.display = 'none';
+
+    state.images.forEach((item, idx) => {
+      const div = document.createElement('div');
+      div.className = 'image-item';
+      div.draggable = true;
+      div.dataset.index = idx;
+
+      const thumb = document.createElement('img');
+      thumb.src = item.img.src;
+
+      const info = document.createElement('span');
+      info.className = 'image-info';
+      info.textContent = `${item.name} (${item.width}×${item.height})`;
+      info.title = info.textContent;
+
+      const remove = document.createElement('button');
+      remove.className = 'image-remove';
+      remove.textContent = '×';
+      remove.addEventListener('click', () => {
+        state.images.splice(idx, 1);
+        updateUI();
+        render();
+      });
+
+      div.appendChild(thumb);
+      div.appendChild(info);
+      div.appendChild(remove);
+
+      div.addEventListener('dragstart', (e) => {
+        isDraggingInternal = true;
+        dragFromIdx = idx;
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', idx);
+        requestAnimationFrame(() => div.classList.add('dragging'));
+      });
+      div.addEventListener('dragend', () => {
+        div.classList.remove('dragging');
+        stopAutoScroll();
+        if (isDraggingInternal && dragFromIdx >= 0 && lastShiftTarget >= 0 && dragFromIdx !== lastShiftTarget) {
+          const fromIdx = dragFromIdx;
+          const toIdx = lastShiftTarget;
+          isDraggingInternal = false;
+          dragFromIdx = -1;
+          clearDragShifts();
+          const [moved] = state.images.splice(fromIdx, 1);
+          state.images.splice(toIdx, 0, moved);
+          updateUI();
+          render();
+          return;
+        }
+        isDraggingInternal = false;
+        clearDragShifts();
+        dragFromIdx = -1;
+      });
+      div.addEventListener('dragover', (e) => {
+        if (!isDraggingInternal) return;
+        e.preventDefault();
+        e.stopPropagation();
+        e.dataTransfer.dropEffect = 'move';
+        applyDragShifts(idx);
+      });
+      div.addEventListener('drop', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!isDraggingInternal) return;
+        const fromIdx = dragFromIdx;
+        const toIdx = idx;
+        isDraggingInternal = false;
+        dragFromIdx = -1;
+        clearDragShifts();
+        if (fromIdx !== toIdx && fromIdx >= 0) {
+          const [moved] = state.images.splice(fromIdx, 1);
+          state.images.splice(toIdx, 0, moved);
+          updateUI();
+          render();
+        }
+      });
+
+      list.appendChild(div);
+    });
+  }
+
+  let lastShiftTarget = -1;
+  let autoScrollTimer = null;
+
+  function startAutoScroll(listEl, clientY) {
+    stopAutoScroll();
+    const rect = listEl.getBoundingClientRect();
+    const edgeZone = 40;
+    const topDist = clientY - rect.top;
+    const bottomDist = rect.bottom - clientY;
+
+    let speed = 0;
+    if (clientY < rect.top) {
+      speed = -Math.max(4, Math.min(12, (rect.top - clientY) / 5));
+    } else if (clientY > rect.bottom) {
+      speed = Math.max(4, Math.min(12, (clientY - rect.bottom) / 5));
+    } else if (topDist < edgeZone && listEl.scrollTop > 0) {
+      speed = -Math.max(2, (edgeZone - topDist) / 3);
+    } else if (bottomDist < edgeZone && listEl.scrollTop < listEl.scrollHeight - listEl.clientHeight) {
+      speed = Math.max(2, (edgeZone - bottomDist) / 3);
+    }
+
+    if (speed !== 0) {
+      autoScrollTimer = setInterval(() => {
+        listEl.scrollTop += speed;
+      }, 16);
+    }
+  }
+
+  function stopAutoScroll() {
+    if (autoScrollTimer) {
+      clearInterval(autoScrollTimer);
+      autoScrollTimer = null;
+    }
+  }
+
+  function applyDragShifts(hoverIdx) {
+    if (hoverIdx === lastShiftTarget) return;
+    lastShiftTarget = hoverIdx;
+    const items = document.querySelectorAll('.image-item');
+    const itemHeight = items[0] ? items[0].offsetHeight + 2 : 40;
+    items.forEach((el) => {
+      const idx = parseInt(el.dataset.index);
+      if (idx === dragFromIdx) return;
+      let shift = 0;
+      if (dragFromIdx < hoverIdx) {
+        if (idx > dragFromIdx && idx <= hoverIdx) shift = -itemHeight;
+      } else if (dragFromIdx > hoverIdx) {
+        if (idx >= hoverIdx && idx < dragFromIdx) shift = itemHeight;
+      }
+      el.style.transform = shift ? `translateY(${shift}px)` : '';
+    });
+  }
+
+  function clearDragShifts() {
+    lastShiftTarget = -1;
+    document.querySelectorAll('.image-item').forEach((el) => {
+      el.style.transform = '';
+    });
+  }
+
+  function render() {
+    if (state.images.length === 0) {
+      canvas.style.display = 'none';
+      $('#preview-placeholder').style.display = '';
+      return;
+    }
+    canvas.style.display = '';
+    $('#preview-placeholder').style.display = 'none';
+
+    const { direction, align, resizeMode, spacing, padding, bgColor, images } = state;
+
+    // 计算每张图片的绘制尺寸
+    const drawSizes = computeDrawSizes(images, direction, resizeMode);
+
+    let totalWidth, totalHeight;
+
+    if (direction === 'vertical') {
+      totalWidth = Math.max(...drawSizes.map((s) => s.w)) + padding * 2;
+      totalHeight = drawSizes.reduce((sum, s) => sum + s.h, 0) + spacing * (images.length - 1) + padding * 2;
+    } else {
+      totalWidth = drawSizes.reduce((sum, s) => sum + s.w, 0) + spacing * (images.length - 1) + padding * 2;
+      totalHeight = Math.max(...drawSizes.map((s) => s.h)) + padding * 2;
+    }
+
+    canvas.width = totalWidth;
+    canvas.height = totalHeight;
+
+    if (bgColor === 'transparent') {
+      ctx.clearRect(0, 0, totalWidth, totalHeight);
+    } else {
+      ctx.fillStyle = bgColor;
+      ctx.fillRect(0, 0, totalWidth, totalHeight);
+    }
+
+    let offset = padding;
+    for (let i = 0; i < images.length; i++) {
+      const item = images[i];
+      const size = drawSizes[i];
+      let x, y;
+      if (direction === 'vertical') {
+        y = offset;
+        if (align === 'start') x = padding;
+        else if (align === 'end') x = totalWidth - padding - size.w;
+        else x = (totalWidth - size.w) / 2;
+        offset += size.h + spacing;
+      } else {
+        x = offset;
+        if (align === 'start') y = padding;
+        else if (align === 'end') y = totalHeight - padding - size.h;
+        else y = (totalHeight - size.h) / 2;
+        offset += size.w + spacing;
+      }
+      ctx.drawImage(item.img, x, y, size.w, size.h);
+    }
+  }
+
+  function computeDrawSizes(images, direction, resizeMode) {
+    if (resizeMode === 'none') {
+      return images.map((img) => ({ w: img.width, h: img.height }));
+    }
+
+    if (direction === 'vertical') {
+      // 纵向拼接 → 统一宽度
+      let targetWidth;
+      const widths = images.map((i) => i.width);
+      if (resizeMode === 'enlarge') {
+        targetWidth = Math.max(...widths);
+      } else {
+        targetWidth = Math.min(...widths);
+      }
+      return images.map((img) => {
+        const scale = targetWidth / img.width;
+        return { w: targetWidth, h: Math.round(img.height * scale) };
+      });
+    } else {
+      // 横向拼接 → 统一高度
+      let targetHeight;
+      const heights = images.map((i) => i.height);
+      if (resizeMode === 'enlarge') {
+        targetHeight = Math.max(...heights);
+      } else {
+        targetHeight = Math.min(...heights);
+      }
+      return images.map((img) => {
+        const scale = targetHeight / img.height;
+        return { w: Math.round(img.width * scale), h: targetHeight };
+      });
+    }
+  }
+
+  function getOutputMimeType() {
+    const map = { png: 'image/png', jpeg: 'image/jpeg', webp: 'image/webp' };
+    return map[state.format] || 'image/png';
+  }
+
+  function saveImage() {
+    if (state.images.length === 0) return;
+    const ext = state.format === 'jpeg' ? 'jpg' : state.format;
+    const result = ztools.showSaveDialog({
+      title: '保存拼接图片',
+      defaultPath: `拼接图片.${ext}`,
+      filters: [{ name: '图片', extensions: [ext] }]
+    });
+    if (!result) return;
+
+    const dataURL = canvas.toDataURL(getOutputMimeType(), state.quality);
+    const base64 = dataURL.split(',')[1];
+    try {
+      const fs = require('fs');
+      fs.writeFileSync(result, Buffer.from(base64, 'base64'));
+      ztools.showNotification('图片已保存');
+      ztools.shellShowItemInFolder(result);
+    } catch (err) {
+      ztools.showNotification('保存失败: ' + err.message);
+    }
+  }
+
+  function copyToClipboard() {
+    if (state.images.length === 0) return;
+    const dataURL = canvas.toDataURL('image/png');
+    ztools.copyImage(dataURL);
+    ztools.showNotification('已复制到剪贴板');
+  }
+
+  function stashCurrent() {
+    if (state.images.length === 0) return;
+
+    const skipConfirm = ztools.dbGet ? ztools.dbGet('stash-skip-confirm') : localStorage.getItem('stash-skip-confirm');
+    if (skipConfirm) {
+      doStash();
+      return;
+    }
+
+    showStashConfirm();
+  }
+
+  function showStashConfirm() {
+    const overlay = document.createElement('div');
+    overlay.className = 'confirm-overlay';
+    const dialog = document.createElement('div');
+    dialog.className = 'confirm-dialog';
+    dialog.innerHTML = `
+      <div class="confirm-title">暂存拼接结果</div>
+      <div class="confirm-body">将当前拼接结果保存为缩略图，放在预览区上方。<br>暂存后当前工作区会清空，你可以继续拼接新的图片，之后把暂存的图片拖回列表再次拼接。</div>
+      <label class="confirm-checkbox"><input type="checkbox" id="stash-no-ask">下次不再提醒</label>
+      <div class="confirm-actions">
+        <button class="btn" id="stash-cancel">取消</button>
+        <button class="btn btn-stash" id="stash-ok">确认暂存</button>
+      </div>
+    `;
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    requestAnimationFrame(() => overlay.classList.add('visible'));
+
+    document.getElementById('stash-cancel').addEventListener('click', () => {
+      overlay.classList.remove('visible');
+      setTimeout(() => overlay.remove(), 150);
+    });
+    document.getElementById('stash-ok').addEventListener('click', () => {
+      const noAsk = document.getElementById('stash-no-ask').checked;
+      if (noAsk) {
+        if (ztools.dbPut) ztools.dbPut('stash-skip-confirm', true);
+        else localStorage.setItem('stash-skip-confirm', '1');
+      }
+      overlay.classList.remove('visible');
+      setTimeout(() => overlay.remove(), 150);
+      doStash();
+    });
+  }
+
+  function doStash() {
+    const dataURL = canvas.toDataURL('image/png');
+    const img = new Image();
+    img.onload = () => {
+      state.stash.push({
+        img,
+        dataURL,
+        name: `暂存 ${state.stash.length + 1}`,
+        width: canvas.width,
+        height: canvas.height
+      });
+      updateStashUI();
+      state.images = [];
+      updateUI();
+      render();
+    };
+    img.src = dataURL;
+  }
+
+  function updateStashUI() {
+    const shelf = $('#stash-shelf');
+    const container = $('#stash-items');
+    container.innerHTML = '';
+
+    if (state.stash.length === 0) {
+      shelf.style.display = 'none';
+      return;
+    }
+    shelf.style.display = '';
+
+    state.stash.forEach((item, idx) => {
+      const div = document.createElement('div');
+      div.className = 'stash-item';
+      div.draggable = true;
+      div.title = `${item.name} (${item.width}×${item.height})`;
+
+      const img = document.createElement('img');
+      img.src = item.dataURL;
+
+      const remove = document.createElement('button');
+      remove.className = 'stash-remove';
+      remove.textContent = '×';
+      remove.addEventListener('click', (e) => {
+        e.stopPropagation();
+        state.stash.splice(idx, 1);
+        updateStashUI();
+      });
+
+      div.appendChild(img);
+      div.appendChild(remove);
+
+      div.addEventListener('dragstart', (e) => {
+        e.dataTransfer.effectAllowed = 'copy';
+        e.dataTransfer.setData('application/x-stash-index', idx);
+        div.style.opacity = '0.5';
+      });
+      div.addEventListener('dragend', () => {
+        div.style.opacity = '';
+      });
+
+      container.appendChild(div);
+    });
+  }
+
+  function handleStashDrop(e) {
+    const stashIdx = e.dataTransfer.getData('application/x-stash-index');
+    if (stashIdx === '') return false;
+    e.preventDefault();
+    const idx = parseInt(stashIdx);
+    const item = state.stash[idx];
+    if (!item) return true;
+    state.images.push({ img: item.img, name: item.name, width: item.width, height: item.height });
+    updateUI();
+    render();
+    return true;
+  }
+
+  init();
+})();

--- a/plugins/image-stitch/app.js
+++ b/plugins/image-stitch/app.js
@@ -169,6 +169,7 @@
     });
 
     document.addEventListener('keydown', (e) => {
+      if ((e.ctrlKey || e.metaKey) && ['INPUT', 'TEXTAREA', 'SELECT'].includes(e.target.tagName)) return;
       if (e.ctrlKey || e.metaKey) {
         if (e.key === 'a') { e.preventDefault(); openFilePicker(); }
         if (e.key === 'd') { e.preventDefault(); clearAll(); }
@@ -239,7 +240,12 @@
     img.onerror = () => {
       ztools.showNotification('加载图片失败: ' + filePath.split(/[/\\]/).pop());
     };
-    img.src = filePath.startsWith('file://') ? filePath : 'file:///' + filePath.replace(/\\/g, '/');
+    if (filePath.startsWith('file://')) {
+      img.src = filePath;
+    } else {
+      const formatted = filePath.replace(/\\/g, '/');
+      img.src = formatted.startsWith('/') ? 'file://' + formatted : 'file:///' + formatted;
+    }
   }
 
   function addImageFromFile(file) {
@@ -376,9 +382,10 @@
 
   let lastShiftTarget = -1;
   let autoScrollTimer = null;
+  let autoScrollSpeed = 0;
+  let autoScrollList = null;
 
   function startAutoScroll(listEl, clientY) {
-    stopAutoScroll();
     const rect = listEl.getBoundingClientRect();
     const edgeZone = 40;
     const topDist = clientY - rect.top;
@@ -395,10 +402,17 @@
       speed = Math.max(2, (edgeZone - bottomDist) / 3);
     }
 
+    autoScrollSpeed = speed;
+    autoScrollList = listEl;
+
     if (speed !== 0) {
-      autoScrollTimer = setInterval(() => {
-        listEl.scrollTop += speed;
-      }, 16);
+      if (!autoScrollTimer) {
+        autoScrollTimer = setInterval(() => {
+          if (autoScrollList) autoScrollList.scrollTop += autoScrollSpeed;
+        }, 16);
+      }
+    } else {
+      stopAutoScroll();
     }
   }
 
@@ -407,6 +421,8 @@
       clearInterval(autoScrollTimer);
       autoScrollTimer = null;
     }
+    autoScrollSpeed = 0;
+    autoScrollList = null;
   }
 
   function applyDragShifts(hoverIdx) {
@@ -456,6 +472,12 @@
     } else {
       totalWidth = drawSizes.reduce((sum, s) => sum + s.w, 0) + spacing * (images.length - 1) + padding * 2;
       totalHeight = Math.max(...drawSizes.map((s) => s.h)) + padding * 2;
+    }
+
+    const MAX_CANVAS_SIZE = 16384;
+    if (totalWidth > MAX_CANVAS_SIZE || totalHeight > MAX_CANVAS_SIZE) {
+      ztools.showNotification(`拼接尺寸过大 (${totalWidth}×${totalHeight})，请减少图片或使用"缩小大图"模式`);
+      return;
     }
 
     canvas.width = totalWidth;
@@ -611,22 +633,28 @@
   }
 
   function doStash() {
-    const dataURL = canvas.toDataURL('image/png');
-    const img = new Image();
-    img.onload = () => {
-      state.stash.push({
-        img,
-        dataURL,
-        name: `暂存 ${state.stash.length + 1}`,
-        width: canvas.width,
-        height: canvas.height
-      });
-      updateStashUI();
-      state.images = [];
-      updateUI();
-      render();
-    };
-    img.src = dataURL;
+    canvas.toBlob((blob) => {
+      if (!blob) {
+        ztools.showNotification('暂存失败: 无法生成图片数据');
+        return;
+      }
+      const url = URL.createObjectURL(blob);
+      const img = new Image();
+      img.onload = () => {
+        state.stash.push({
+          img,
+          dataURL: url,
+          name: `暂存 ${state.stash.length + 1}`,
+          width: canvas.width,
+          height: canvas.height
+        });
+        updateStashUI();
+        state.images = [];
+        updateUI();
+        render();
+      };
+      img.src = url;
+    }, 'image/png');
   }
 
   function updateStashUI() {
@@ -681,9 +709,13 @@
     const idx = parseInt(stashIdx);
     const item = state.stash[idx];
     if (!item) return true;
-    state.images.push({ img: item.img, name: item.name, width: item.width, height: item.height });
-    updateUI();
-    render();
+    const img = new Image();
+    img.onload = () => {
+      state.images.push({ img, name: item.name, width: item.width, height: item.height });
+      updateUI();
+      render();
+    };
+    img.src = item.dataURL;
     return true;
   }
 

--- a/plugins/image-stitch/app.js
+++ b/plugins/image-stitch/app.js
@@ -143,6 +143,8 @@
       } else if (e.clientY > rect.bottom) {
         startAutoScroll(imageList, e.clientY);
         applyDragShifts(state.images.length - 1);
+      } else if (!imageList.contains(e.target)) {
+        stopAutoScroll();
       }
     });
     imageList.addEventListener('drop', (e) => {
@@ -234,6 +236,9 @@
       updateUI();
       render();
     };
+    img.onerror = () => {
+      ztools.showNotification('加载图片失败: ' + filePath.split(/[/\\]/).pop());
+    };
     img.src = filePath.startsWith('file://') ? filePath : 'file:///' + filePath.replace(/\\/g, '/');
   }
 
@@ -249,6 +254,9 @@
       state.images.push({ img, name: name || '粘贴图片', width: img.naturalWidth, height: img.naturalHeight });
       updateUI();
       render();
+    };
+    img.onerror = () => {
+      ztools.showNotification('加载图片数据失败');
     };
     img.src = dataURL;
   }
@@ -334,18 +342,6 @@
       div.addEventListener('dragend', () => {
         div.classList.remove('dragging');
         stopAutoScroll();
-        if (isDraggingInternal && dragFromIdx >= 0 && lastShiftTarget >= 0 && dragFromIdx !== lastShiftTarget) {
-          const fromIdx = dragFromIdx;
-          const toIdx = lastShiftTarget;
-          isDraggingInternal = false;
-          dragFromIdx = -1;
-          clearDragShifts();
-          const [moved] = state.images.splice(fromIdx, 1);
-          state.images.splice(toIdx, 0, moved);
-          updateUI();
-          render();
-          return;
-        }
         isDraggingInternal = false;
         clearDragShifts();
         dragFromIdx = -1;
@@ -544,7 +540,12 @@
     if (!result) return;
 
     const dataURL = canvas.toDataURL(getOutputMimeType(), state.quality);
-    const base64 = dataURL.split(',')[1];
+    const parts = dataURL.split(',');
+    if (parts.length < 2 || !parts[1]) {
+      ztools.showNotification('保存失败: 图片尺寸过大，无法生成数据');
+      return;
+    }
+    const base64 = parts[1];
     try {
       const fs = require('fs');
       fs.writeFileSync(result, Buffer.from(base64, 'base64'));

--- a/plugins/image-stitch/index.html
+++ b/plugins/image-stitch/index.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>图片拼接</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="app">
+    <div class="toolbar">
+      <div class="toolbar-left">
+        <button id="btn-add" class="btn btn-primary" title="添加图片 (Ctrl+A)">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M8 2v12M2 8h12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+          添加图片
+        </button>
+        <button id="btn-paste" class="btn" title="从剪贴板粘贴">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M5 2H3a1 1 0 00-1 1v11a1 1 0 001 1h10a1 1 0 001-1V3a1 1 0 00-1-1h-2M5 2a2 2 0 014 0M5 2h4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          粘贴
+        </button>
+        <button id="btn-clear" class="btn btn-danger" title="清空 (Ctrl+D)">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M2 4h12M5 4V3a1 1 0 011-1h4a1 1 0 011 1v1M6 7v5M10 7v5M3 4l1 10a1 1 0 001 1h6a1 1 0 001-1l1-10" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          清空
+        </button>
+        <button id="btn-reverse" class="btn" title="翻转顺序">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none"><path d="M4 2v12M12 2v12M4 8l3-3M4 8l3 3M12 8l-3-3M12 8l-3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          翻转
+        </button>
+      </div>
+      <div class="toolbar-right">
+        <button id="btn-copy" class="btn" title="复制到剪贴板">复制</button>
+        <button id="btn-stash" class="btn btn-stash" title="暂存当前拼接结果">暂存</button>
+        <button id="btn-save" class="btn btn-primary" title="保存 (Ctrl+S)">保存</button>
+      </div>
+    </div>
+
+    <div class="main-content">
+      <div class="sidebar">
+        <div class="image-list" id="image-list">
+          <div class="empty-hint" id="empty-hint">
+            拖拽图片到此处<br>或点击上方"添加图片"
+          </div>
+        </div>
+
+        <div class="settings-panel">
+          <div class="setting-row">
+            <label>方向</label>
+            <div class="radio-group">
+              <label class="radio-label"><input type="radio" name="direction" value="vertical" checked>纵向</label>
+              <label class="radio-label"><input type="radio" name="direction" value="horizontal">横向</label>
+            </div>
+          </div>
+          <div class="setting-row">
+            <label>尺寸</label>
+            <select id="resize-mode">
+              <option value="enlarge" selected>放大小图</option>
+              <option value="shrink">缩小大图</option>
+              <option value="none">不统一</option>
+            </select>
+          </div>
+          <div class="setting-row" id="align-group" style="display:none">
+            <label>对齐</label>
+            <select id="align">
+              <option value="start">顶部对齐</option>
+              <option value="center" selected>居中</option>
+              <option value="end">底部对齐</option>
+            </select>
+          </div>
+          <div class="setting-row">
+            <label>间距</label>
+            <input type="range" id="spacing" min="0" max="100" value="0">
+            <span id="spacing-value" class="range-value">0px</span>
+          </div>
+          <div class="setting-row">
+            <label>边距</label>
+            <input type="range" id="padding" min="0" max="100" value="0">
+            <span id="padding-value" class="range-value">0px</span>
+          </div>
+          <div class="setting-row">
+            <label>背景</label>
+            <div class="color-options">
+              <button class="color-btn active" data-color="transparent" title="透明">
+                <span class="transparent-pattern"></span>
+              </button>
+              <button class="color-btn" data-color="#ffffff" title="白色">
+                <span style="background:#fff"></span>
+              </button>
+              <button class="color-btn" data-color="#000000" title="黑色">
+                <span style="background:#000"></span>
+              </button>
+              <input type="color" id="custom-color" value="#ffffff" title="自定义颜色">
+            </div>
+          </div>
+          <div class="setting-row">
+            <label>格式</label>
+            <select id="format">
+              <option value="png">PNG</option>
+              <option value="jpeg">JPEG</option>
+              <option value="webp">WebP</option>
+            </select>
+          </div>
+          <div class="setting-row" id="quality-group" style="display:none">
+            <label>质量</label>
+            <input type="range" id="quality" min="10" max="100" value="92">
+            <span id="quality-value" class="range-value">92%</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="preview-container">
+        <div class="stash-shelf" id="stash-shelf" style="display:none">
+          <div class="stash-items" id="stash-items"></div>
+        </div>
+        <div class="preview-area" id="preview-area">
+          <div class="preview-placeholder" id="preview-placeholder">
+            <svg width="64" height="64" viewBox="0 0 64 64" fill="none"><rect x="4" y="12" width="24" height="40" rx="2" stroke="currentColor" stroke-width="2"/><rect x="36" y="12" width="24" height="40" rx="2" stroke="currentColor" stroke-width="2"/><path d="M28 32h8M32 28v8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            <p>添加图片开始拼接</p>
+          </div>
+          <canvas id="canvas" style="display:none"></canvas>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/plugins/image-stitch/index.html
+++ b/plugins/image-stitch/index.html
@@ -53,8 +53,8 @@
           <div class="setting-row">
             <label>尺寸</label>
             <select id="resize-mode">
-              <option value="enlarge" selected>放大小图</option>
-              <option value="shrink">缩小大图</option>
+              <option value="enlarge" selected>扩小图</option>
+              <option value="shrink">缩大图</option>
               <option value="none">不统一</option>
             </select>
           </div>

--- a/plugins/image-stitch/logo.svg
+++ b/plugins/image-stitch/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="20" fill="#0e639c"/>
+  <rect x="24" y="16" width="34" height="44" rx="4" fill="#fff" opacity="0.9"/>
+  <rect x="24" y="68" width="34" height="44" rx="4" fill="#fff" opacity="0.9"/>
+  <rect x="70" y="16" width="34" height="96" rx="4" fill="#fff" opacity="0.6"/>
+  <path d="M41 56v16" stroke="#fff" stroke-width="3" stroke-linecap="round"/>
+  <path d="M35 62h12" stroke="#fff" stroke-width="3" stroke-linecap="round" opacity="0.6"/>
+</svg>

--- a/plugins/image-stitch/plugin.json
+++ b/plugins/image-stitch/plugin.json
@@ -1,0 +1,43 @@
+{
+  "name": "image-stitch",
+  "title": "图片拼接",
+  "description": "将多张图片拼接为一张长图，支持横向/纵向拼接、间距和背景色设置",
+  "author": "Ethan0x0000",
+  "version": "1.0.0",
+  "main": "index.html",
+  "logo": "logo.svg",
+  "features": [
+    {
+      "code": "image-stitch",
+      "explain": "图片拼接",
+      "icon": "logo.svg",
+      "cmds": ["图片拼接", "拼图", "image stitch"]
+    },
+    {
+      "code": "image-stitch-files",
+      "explain": "拼接图片文件",
+      "icon": "logo.svg",
+      "cmds": [
+        {
+          "type": "files",
+          "label": "拼接图片",
+          "fileType": "file",
+          "match": "/\\.(png|jpe?g|gif|bmp|webp|svg)$/i",
+          "minLength": 1,
+          "maxLength": 99
+        }
+      ]
+    },
+    {
+      "code": "image-stitch-img",
+      "explain": "拼接剪贴板图片",
+      "icon": "logo.svg",
+      "cmds": [
+        {
+          "type": "img",
+          "label": "拼接图片"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/image-stitch/style.css
+++ b/plugins/image-stitch/style.css
@@ -223,18 +223,12 @@ select {
   background: var(--bg-elevated);
   color: var(--text-primary);
   font-size: 12px;
-  text-align: center;
-  text-align-last: center;
   outline: none;
   transition: border-color var(--transition);
   appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 5l3 3 3-3' stroke='%23999' fill='none' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
   background-position: right 8px center;
-}
-
-select option {
-  text-align: center;
 }
 
 select:hover {

--- a/plugins/image-stitch/style.css
+++ b/plugins/image-stitch/style.css
@@ -1,0 +1,645 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+:root {
+  --bg-base: #181818;
+  --bg-surface: #1f1f1f;
+  --bg-elevated: #282828;
+  --bg-hover: #323232;
+  --bg-active: #3a3a3a;
+  --border: rgba(255, 255, 255, 0.06);
+  --border-hover: rgba(255, 255, 255, 0.12);
+  --text-primary: #f0f0f0;
+  --text-secondary: #a0a0a0;
+  --text-tertiary: #666;
+  --accent: #4da6ff;
+  --accent-hover: #6bb5ff;
+  --accent-bg: rgba(77, 166, 255, 0.1);
+  --accent-border: rgba(77, 166, 255, 0.3);
+  --danger: #f85149;
+  --danger-bg: rgba(248, 81, 73, 0.1);
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 8px 32px rgba(0, 0, 0, 0.5);
+  --transition: 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  font-size: 13px;
+  color: var(--text-primary);
+  background: var(--bg-base);
+  height: 100vh;
+  overflow: hidden;
+  user-select: none;
+  -webkit-font-smoothing: antialiased;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+/* ─── Toolbar ─── */
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  backdrop-filter: blur(8px);
+}
+
+.toolbar-left, .toolbar-right {
+  display: flex;
+  gap: 8px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition);
+  white-space: nowrap;
+}
+
+.btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-hover);
+  box-shadow: var(--shadow-sm);
+}
+
+.btn:active {
+  transform: scale(0.96);
+  background: var(--bg-active);
+}
+
+.btn-primary {
+  background: var(--accent);
+  border-color: transparent;
+  color: #000;
+  font-weight: 600;
+}
+
+.btn-primary:hover {
+  background: var(--accent-hover);
+  border-color: transparent;
+  box-shadow: 0 2px 8px rgba(77, 166, 255, 0.3);
+}
+
+.btn-primary:active {
+  background: var(--accent);
+}
+
+.btn-stash {
+  background: rgba(63, 185, 80, 0.12);
+  border-color: rgba(63, 185, 80, 0.3);
+  color: #3fb950;
+  font-weight: 600;
+}
+
+.btn-stash:hover {
+  background: rgba(63, 185, 80, 0.2);
+  border-color: rgba(63, 185, 80, 0.5);
+  box-shadow: 0 2px 8px rgba(63, 185, 80, 0.2);
+}
+
+.btn-danger:hover {
+  background: var(--danger-bg);
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+/* ─── Sidebar ─── */
+.main-content {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+.sidebar {
+  width: 260px;
+  padding: 12px;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  flex-shrink: 0;
+  gap: 10px;
+}
+
+.settings-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.setting-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 28px;
+}
+
+.setting-row > label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  width: 36px;
+  flex-shrink: 0;
+  letter-spacing: 0.3px;
+}
+
+.setting-row > select,
+.setting-row > .radio-group,
+.setting-row > .color-options {
+  flex: 1;
+}
+
+.setting-row > input[type="range"] {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ─── Radio / Toggle Buttons ─── */
+.radio-group {
+  display: flex;
+  gap: 0;
+  background: var(--bg-base);
+  border-radius: var(--radius-sm);
+  padding: 2px;
+  border: 1px solid var(--border);
+}
+
+.radio-label {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  padding: 5px 8px;
+  border-radius: 4px;
+  transition: all var(--transition);
+  color: var(--text-secondary);
+}
+
+.radio-label:has(input:checked) {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.radio-label input[type="radio"] {
+  display: none;
+}
+
+/* ─── Select ─── */
+select {
+  width: 100%;
+  padding: 7px 28px 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  font-size: 12px;
+  text-align: center;
+  text-align-last: center;
+  outline: none;
+  transition: border-color var(--transition);
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 5l3 3 3-3' stroke='%23999' fill='none' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+}
+
+select option {
+  text-align: center;
+}
+
+select:hover {
+  border-color: var(--border-hover);
+}
+
+select:focus {
+  border-color: var(--accent-border);
+}
+
+/* ─── Range Slider ─── */
+input[type="range"] {
+  height: 4px;
+  accent-color: var(--accent);
+  vertical-align: middle;
+  border-radius: 2px;
+  background: var(--bg-base);
+  outline: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+input[type="range"]::-webkit-slider-track {
+  height: 4px;
+  border-radius: 2px;
+  background: var(--bg-active);
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid var(--bg-surface);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+  cursor: pointer;
+  margin-top: -5px;
+  transition: transform var(--transition);
+}
+
+input[type="range"]::-webkit-slider-thumb:hover {
+  transform: scale(1.2);
+}
+
+.range-value {
+  display: inline-block;
+  width: 32px;
+  text-align: right;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+}
+
+/* ─── Color Picker ─── */
+.color-options {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.color-btn {
+  width: 26px;
+  height: 26px;
+  border: 2px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  padding: 3px;
+  background: none;
+  transition: all var(--transition);
+}
+
+.color-btn:hover {
+  border-color: var(--border-hover);
+  transform: scale(1.1);
+}
+
+.color-btn.active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-bg);
+}
+
+.color-btn span {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: 3px;
+}
+
+.transparent-pattern {
+  background: repeating-conic-gradient(#555 0% 25%, #333 0% 50%) 50% / 8px 8px !important;
+}
+
+#custom-color {
+  width: 26px;
+  height: 26px;
+  border: 2px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0;
+  cursor: pointer;
+  background: none;
+  transition: border-color var(--transition);
+}
+
+#custom-color:hover {
+  border-color: var(--border-hover);
+}
+
+/* ─── Image List ─── */
+.image-list {
+  flex: 1;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 6px;
+  min-height: 180px;
+  cursor: default;
+  background: var(--bg-base);
+}
+
+.image-list:has(.image-item.dragging) {
+  cursor: move;
+  border-color: var(--accent-border);
+}
+
+.empty-hint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  text-align: center;
+  line-height: 1.8;
+}
+
+.image-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  cursor: move;
+  transition: transform 0.2s ease, background var(--transition), opacity var(--transition);
+}
+
+.image-item:hover {
+  background: var(--bg-elevated);
+}
+
+.image-item.dragging {
+  opacity: 0.25;
+  cursor: move;
+}
+
+.image-item.drag-over {
+  background: var(--accent-bg);
+  cursor: move;
+}
+
+.image-item img {
+  width: 36px;
+  height: 36px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+  border: 1px solid var(--border);
+}
+
+.image-item .image-info {
+  flex: 1;
+  min-width: 0;
+  font-size: 11px;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.image-item .image-remove {
+  width: 20px;
+  height: 20px;
+  border: none;
+  background: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: all var(--transition);
+}
+
+.image-item:hover .image-remove {
+  opacity: 1;
+}
+
+.image-item .image-remove:hover {
+  background: var(--danger-bg);
+  color: var(--danger);
+}
+
+/* ─── Preview Area ─── */
+.preview-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.stash-shelf {
+  flex-shrink: 0;
+  padding: 8px 12px;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.stash-items {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  min-height: 56px;
+}
+
+.stash-item {
+  position: relative;
+  flex-shrink: 0;
+  width: 64px;
+  height: 52px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  border: 1px solid var(--border);
+  cursor: grab;
+  transition: all var(--transition);
+  background: var(--bg-base);
+}
+
+.stash-item:hover {
+  border-color: var(--accent-border);
+  box-shadow: 0 2px 8px rgba(77, 166, 255, 0.15);
+  transform: translateY(-2px);
+}
+
+.stash-item:active {
+  cursor: grabbing;
+}
+
+.stash-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.stash-item .stash-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.7);
+  border: none;
+  color: #fff;
+  font-size: 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.stash-item:hover .stash-remove {
+  opacity: 1;
+}
+
+.stash-item .stash-remove:hover {
+  background: var(--danger);
+}
+
+.preview-area {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+  padding: 24px;
+  background:
+    repeating-conic-gradient(var(--bg-elevated) 0% 25%, var(--bg-base) 0% 50%) 50% / 24px 24px;
+  position: relative;
+}
+
+.preview-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  color: var(--text-tertiary);
+}
+
+.preview-placeholder svg {
+  opacity: 0.4;
+}
+
+.preview-placeholder p {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+#canvas {
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-lg);
+}
+
+/* ─── Scrollbar ─── */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+/* ─── Confirm Dialog ─── */
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  backdrop-filter: blur(2px);
+}
+
+.confirm-overlay.visible {
+  opacity: 1;
+}
+
+.confirm-dialog {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-hover);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  width: 360px;
+  box-shadow: var(--shadow-lg);
+  transform: scale(0.95);
+  transition: transform 0.15s ease;
+}
+
+.confirm-overlay.visible .confirm-dialog {
+  transform: scale(1);
+}
+
+.confirm-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 10px;
+}
+
+.confirm-body {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.7;
+  margin-bottom: 14px;
+}
+
+.confirm-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  margin-bottom: 18px;
+}
+
+.confirm-checkbox input {
+  accent-color: var(--accent);
+}
+
+.confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}


### PR DESCRIPTION
## 插件信息

- **名称**: image-stitch (图片拼接)
- **作者**: Ethan0x0000
- **版本**: 1.0.0
- **技术栈**: 纯 HTML/CSS/JS，无构建依赖

## 功能

将多张图片拼接为一张长图：

- 纵向/横向拼接方向
- 尺寸统一（放大小图 / 缩小大图 / 不统一）
- 对齐方式（仅不统一模式下可选）
- 可调图片间距和外边距
- 背景颜色（透明/白/黑/自定义）
- 输出格式 PNG/JPEG/WebP，可调质量
- 拖拽添加图片 + 列表拖拽排序（带动画）
- 从剪贴板粘贴图片
- 文件拖入自动触发
- 暂存功能：保存中间结果，拖回列表再次拼接
- 复制到剪贴板 / 保存到文件
- 快捷键：Ctrl+A 添加、Ctrl+V 粘贴、Ctrl+S 保存、Ctrl+D 清空

## 入口

| 关键词 | 触发方式 |
|--------|----------|
| 图片拼接 / 拼图 / image stitch | 关键字搜索 |
| 拖入图片文件 | files 类型匹配 |
| 粘贴图片 | img 类型匹配 |