### PR TITLE
Update plugin 隐阅盒 v1.3.2

### DIFF
--- a/plugins/hushreader/.gitignore
+++ b/plugins/hushreader/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 **/*.zip
+test

--- a/plugins/hushreader/CHANGELOG.md
+++ b/plugins/hushreader/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.2](https://github.com/me1dlinger/hushreader/releases/tag/v1.3.2) - 2026-06-18
+
+### Added
+- **拖拽导入书籍**：将书籍文件拖入书架界面时，显示拖拽悬停覆盖层提示"导入书籍"，松手后弹出确认弹窗列出待导入文件，确认后解析书籍并保存元数据，取消则放弃导入
+- **快捷文件导入**：支持通过 `hushreader-import` 命令从 ztools 快捷导入书籍文件，`onPluginEnter` 触发时自动解析并添加到书架
+- **TXT 章节正则提示气泡**：设置页"TXT 章节识别正则"标签旁新增 ⓘ 提示图标，悬停/聚焦时显示默认规则说明
+- **重载元数据**：右键菜单新增"重载元数据"选项，重新解析书籍的章节、封面、标题、作者等信息并更新，同时清除自定义封面
+- **恢复封面**：右键菜单新增"恢复封面"选项，EPUB/MOBI 删除自定义封面并重新从文件加载封面，TXT 删除自定义封面恢复为纯色封面
+- **多选模式**：书架头部新增多选按钮，点击进入多选模式，可逐个勾选书籍或通过分类栏"全选"按钮批量选中当前分类下所有书籍
+- **批量操作**：多选模式下底部显示操作栏，支持批量重载元数据和批量删除，批量删除前弹出确认弹窗
+
+- **书籍信息窗口**：右键菜单新增"书籍信息"选项，打开信息窗口展示封面与标题作者、简介、分类、阅读信息（导入/更新/首次阅读/最近阅读时间、阅读时长、阅读速度）；支持编辑模式可上传自定义封面、编辑标题/作者/简介、选择已有分类或新建分类
+- **EPUB/MOBI 简介解析**：导入和重载元数据时从 EPUB metadata.description 和 MOBI EXTH record 101 提取书籍简介
+- **阅读进度追踪**：保存阅读进度时记录首次阅读时间（firstReadAt）、累计阅读时长（readingTimeMs）、阅读速度（readingSpeed）
+- **updatedAt 时间戳**：书籍新增时设置 updatedAt = addedAt，编辑元数据或上传封面时更新 updatedAt，分类变更不更新 updatedAt
+
+
 ## [1.3.1](https://github.com/me1dlinger/hushreader/releases/tag/v1.3.1) - 2026-06-17
 
 ### Added

--- a/plugins/hushreader/CHANGELOG.md
+++ b/plugins/hushreader/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to this project will be documented in this file.
 - **阅读进度追踪**：保存阅读进度时记录首次阅读时间（firstReadAt）、累计阅读时长（readingTimeMs）、阅读速度（readingSpeed）
 - **updatedAt 时间戳**：书籍新增时设置 updatedAt = addedAt，编辑元数据或上传封面时更新 updatedAt，分类变更不更新 updatedAt
 
+### Fixed
+- **修复拖拽文件时的路径保存错误**：修复了在拖拽文件导入书籍时，路径保存错误导致相同书籍可以重复导入的问题
+- **阅读时长与速度统计逻辑修复**：修复了新会话第一页阅读时间丢失和闲置/关闭期间时间被错误计入的问题，确保阅读时长和速度统计准确。
+- **MOBI 封面缓存失效与重复解析性能问题**：修复了每次打开书架时，所有 MOBI 书籍都会被重新解析一次的问题。
+- **文件读取失败时导致元数据被静默清空**：修复了在文件读取失败时，元数据被静默清空的问题，确保元数据完整。
+- **修复书籍信息编辑时分类交互缺陷**：修复了在书籍信息编辑时，分类交互存在的缺陷。
 
 ## [1.3.1](https://github.com/me1dlinger/hushreader/releases/tag/v1.3.1) - 2026-06-17
 

--- a/plugins/hushreader/README.md
+++ b/plugins/hushreader/README.md
@@ -1,6 +1,8 @@
 <div align="center">
 
-# 隐阅盒 · HushReader
+![HushReader Logo](public/logo.png)
+
+# [隐阅盒 · HushReader](https://github.com/me1dlinger/hushreader)
 
 适配 [ZTools](https://github.com/ZToolsCenter/ZTools) 的阅读插件，支持 TXT / EPUB / MOBI 格式
 
@@ -19,12 +21,14 @@
 
 ## 截图
 
-<div align="center">
-  <img src="https://files.seeusercontent.com/2026/06/16/tr3Y/image_83.png" width="80%" />
-  <img src="https://files.seeusercontent.com/2026/06/16/zLc1/image_82.png" width="80%" />
-  <img src="https://files.seeusercontent.com/2026/06/16/4Uti/image_80.png" width="80%" />
-  <img src="https://files.seeusercontent.com/2026/06/16/fjG0/image_81.png" width="80%" />
-</div>
+![书架](https://files.seeusercontent.com/2026/06/17/qvX8/image_86.png)
+![暗色模式](https://files.seeusercontent.com/2026/06/17/lu4H/image_85.png)
+![书籍信息](https://files.seeusercontent.com/2026/06/18/D9di/image_90.png)
+![隐阅窗口设置](https://files.seeusercontent.com/2026/06/17/eCu4/image_89.png)
+![功能设置](https://files.seeusercontent.com/2026/06/17/0bqW/image_88.png)
+![其他设置](https://files.seeusercontent.com/2026/06/17/y3uD/image_87.png)
+![隐阅效果](https://files.seeusercontent.com/2026/06/18/h1Jb/show.gif)
+
 
 ## 快速开始
 

--- a/plugins/hushreader/public/plugin.json
+++ b/plugins/hushreader/public/plugin.json
@@ -4,7 +4,7 @@
   "title": "隐阅盒",
   "description": "隐阅盒，ZTools自己的摸鱼阅读，支持TXT/EPUB/MOBI格式，沉浸式阅读",
   "author": "meidlinger",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "index.html",
   "preload": "preload/services.js",
   "logo": "logo.png",
@@ -17,11 +17,11 @@
       "explain": "打开书架",
       "icon": "logo.png",
       "cmds": [
-        "yyh",
-        "摸鱼阅读",
         "隐阅盒",
         "书架",
-        "hushreader"
+        "摸鱼阅读",
+        "hushreader",
+        "yyh"
       ]
     },
     {
@@ -30,6 +30,25 @@
       "icon": "logo.png",
       "cmds": [
         "开始阅读"
+      ]
+    },
+    {
+      "code": "hushreader-import",
+      "explain": "导入本地书籍",
+      "icon": "logo.png",
+      "cmds": [
+        "导入书籍",
+        {
+          "type": "files",
+          "fileType": "file",
+          "extensions": [
+            "txt",
+            "epub",
+            "mobi"
+          ],
+          "maxLength": 1,
+          "label": "导入到 隐阅盒"
+        }
       ]
     }
   ],

--- a/plugins/hushreader/src/App.vue
+++ b/plugins/hushreader/src/App.vue
@@ -350,7 +350,7 @@ function toast(msg: string, type: 'info' | 'error' | 'success' = 'info') {
 function closePlugin() {
   isReaderHidden.value = true
   hushreaderActivated.value = false
-  try { (window as any).ztools?.outPlugin?.() } catch {}
+  try { (window as any).ztools?.outPlugin?.() } catch { }
 }
 
 function saveReadingProgress() {
@@ -367,31 +367,40 @@ function saveReadingProgress() {
   if (!book.firstReadAt) {
     updates.firstReadAt = now
   }
-  if (book.lastReadAt && book.lastReadAt > 0) {
-    const elapsed = now - book.lastReadAt
-    if (elapsed > 0 && elapsed < 30 * 60 * 1000) {
-      const totalMs = (book.readingTimeMs || 0) + elapsed
-      updates.readingTimeMs = totalMs
-      const totalChars = readerStore.chapters.reduce((sum, ch) => sum + ch.content.length, 0)
-      const currentReadChars = Math.round(totalChars * (readerStore.readingPercent / 100))
-      const prevReadChars = book.lastSaveReadChars || 0
-      const deltaChars = Math.max(0, currentReadChars - prevReadChars)
-      updates.lastSaveReadChars = currentReadChars
-      const elapsedMinutes = elapsed / 60000
-      if (elapsedMinutes > 0 && deltaChars > 0) {
-        const sessionSpeed = deltaChars / elapsedMinutes
-        const prevSpeed = book.readingSpeed || 0
-        if (prevSpeed > 0) {
-          updates.readingSpeed = Math.round(prevSpeed * 0.6 + sessionSpeed * 0.4)
-        } else {
-          updates.readingSpeed = Math.round(sessionSpeed)
-        }
+
+  // 初始化或重置会话计时器，避免将跨会话的闲置时间计入阅读时长
+  if ((window as any).__hushreaderSessionBookId !== book.id) {
+    (window as any).__hushreaderSessionBookId = book.id;
+    (window as any).__hushreaderSessionLastActive = now
+  }
+
+  const lastActive = (window as any).__hushreaderSessionLastActive || now
+  const elapsed = now - lastActive
+
+  if (elapsed > 0 && elapsed < 30 * 60 * 1000) {
+    const totalMs = (book.readingTimeMs || 0) + elapsed
+    updates.readingTimeMs = totalMs
+    const totalChars = readerStore.chapters.reduce((sum, ch) => sum + ch.content.length, 0)
+    const currentReadChars = Math.round(totalChars * (readerStore.readingPercent / 100))
+    const prevReadChars = book.lastSaveReadChars || 0
+    const deltaChars = Math.max(0, currentReadChars - prevReadChars)
+    updates.lastSaveReadChars = currentReadChars
+    const elapsedMinutes = elapsed / 60000
+    if (elapsedMinutes > 0 && deltaChars > 0) {
+      const sessionSpeed = deltaChars / elapsedMinutes
+      const prevSpeed = book.readingSpeed || 0
+      if (prevSpeed > 0) {
+        updates.readingSpeed = Math.round(prevSpeed * 0.6 + sessionSpeed * 0.4)
+      } else {
+        updates.readingSpeed = Math.round(sessionSpeed)
       }
     }
   } else {
     const totalChars = readerStore.chapters.reduce((sum, ch) => sum + ch.content.length, 0)
     updates.lastSaveReadChars = Math.round(totalChars * (readerStore.readingPercent / 100))
   }
+
+  (window as any).__hushreaderSessionLastActive = now
   bookStore.updateBook(book.id, updates)
 }
 
@@ -450,7 +459,7 @@ async function openBookAndHushreader(bookId: string) {
     if (!chapters || fileChanged) {
       chapters = await parseBookAndGetChapters(book)
       if (!chapters) return
-      saveChapters(bookId, chapters).catch(() => {})
+      saveChapters(bookId, chapters).catch(() => { })
     }
 
     readerStore.setChapters(chapters)
@@ -657,17 +666,17 @@ watch(
 onMounted(async () => {
   await configStore.load()
   await bookStore.load()
-  ;(window as any).ztools?.onPluginEnter?.((action: any) => {
-    route.value = action.code
-    enterAction.value = action
-  })
-  ;(window as any).ztools?.onPluginOut?.((processExit: boolean) => {
-    if (processExit) {
-      saveReadingProgress()
-      hushreaderActivated.value = false
-      hushreaderWindow?.close?.()
-    }
-  })
+    ; (window as any).ztools?.onPluginEnter?.((action: any) => {
+      route.value = action.code
+      enterAction.value = action
+    })
+    ; (window as any).ztools?.onPluginOut?.((processExit: boolean) => {
+      if (processExit) {
+        saveReadingProgress()
+        hushreaderActivated.value = false
+        hushreaderWindow?.close?.()
+      }
+    })
   offHushreaderCommand = (window as any).services?.onHushreaderCommand?.(handleHushreaderCommand)
 
   if (!route.value) route.value = 'bookshelf'
@@ -681,8 +690,6 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <Bookshelf
-    :enter-action="enterAction"
-  />
+  <Bookshelf :enter-action="enterAction" />
   <Toast :message="toastMsg" :type="toastType" />
 </template>

--- a/plugins/hushreader/src/App.vue
+++ b/plugins/hushreader/src/App.vue
@@ -356,13 +356,43 @@ function closePlugin() {
 function saveReadingProgress() {
   const book = bookStore.currentBook
   if (!book) return
-  bookStore.updateBook(book.id, {
+  const now = Date.now()
+  const updates: Partial<typeof book> = {
     lastChapter: readerStore.currentChapterIndex,
     progressIndex: readerStore.progressIndex,
-    lastReadAt: Date.now(),
+    lastReadAt: now,
     totalChapters: readerStore.chapters.length,
     readingPercent: readerStore.readingPercent
-  })
+  }
+  if (!book.firstReadAt) {
+    updates.firstReadAt = now
+  }
+  if (book.lastReadAt && book.lastReadAt > 0) {
+    const elapsed = now - book.lastReadAt
+    if (elapsed > 0 && elapsed < 30 * 60 * 1000) {
+      const totalMs = (book.readingTimeMs || 0) + elapsed
+      updates.readingTimeMs = totalMs
+      const totalChars = readerStore.chapters.reduce((sum, ch) => sum + ch.content.length, 0)
+      const currentReadChars = Math.round(totalChars * (readerStore.readingPercent / 100))
+      const prevReadChars = book.lastSaveReadChars || 0
+      const deltaChars = Math.max(0, currentReadChars - prevReadChars)
+      updates.lastSaveReadChars = currentReadChars
+      const elapsedMinutes = elapsed / 60000
+      if (elapsedMinutes > 0 && deltaChars > 0) {
+        const sessionSpeed = deltaChars / elapsedMinutes
+        const prevSpeed = book.readingSpeed || 0
+        if (prevSpeed > 0) {
+          updates.readingSpeed = Math.round(prevSpeed * 0.6 + sessionSpeed * 0.4)
+        } else {
+          updates.readingSpeed = Math.round(sessionSpeed)
+        }
+      }
+    }
+  } else {
+    const totalChars = readerStore.chapters.reduce((sum, ch) => sum + ch.content.length, 0)
+    updates.lastSaveReadChars = Math.round(totalChars * (readerStore.readingPercent / 100))
+  }
+  bookStore.updateBook(book.id, updates)
 }
 
 function getFileModifiedTime(filePath: string): number | null {
@@ -624,9 +654,9 @@ watch(
   }
 )
 
-onMounted(() => {
-  configStore.load()
-  bookStore.load()
+onMounted(async () => {
+  await configStore.load()
+  await bookStore.load()
   ;(window as any).ztools?.onPluginEnter?.((action: any) => {
     route.value = action.code
     enterAction.value = action

--- a/plugins/hushreader/src/components/Bookshelf/BookCard.vue
+++ b/plugins/hushreader/src/components/Bookshelf/BookCard.vue
@@ -5,12 +5,15 @@ import type { Book } from '../../stores/books'
 const props = defineProps<{
   book: Book
   listMode?: boolean
+  selectionMode?: boolean
+  selected?: boolean
 }>()
 
 const emit = defineEmits<{
   click: []
   contextmenu: [e: MouseEvent]
   'cover-error': []
+  'toggle-select': []
 }>()
 
 const imgError = ref(false)
@@ -46,10 +49,14 @@ function progressText(book: Book): string {
 <template>
   <div
     class="book-card"
-    :class="{ 'list-mode': listMode }"
-    @click="$emit('click')"
-    @contextmenu.prevent="$emit('contextmenu', $event)"
+    :class="{ 'list-mode': listMode, 'selection-mode': selectionMode, selected }"
+    @click="selectionMode ? emit('toggle-select') : emit('click')"
+    @contextmenu.prevent="!selectionMode && emit('contextmenu', $event)"
   >
+    <!-- Selection checkbox -->
+    <div v-if="selectionMode" class="select-check" :class="{ checked: selected }">
+      <svg v-if="selected" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+    </div>
     <!-- Cover -->
     <div
       class="book-cover"
@@ -103,6 +110,42 @@ function progressText(book: Book): string {
   gap: 14px;
   padding: 10px 12px;
   border-radius: var(--radius-sm);
+}
+
+.book-card.selection-mode {
+  cursor: pointer;
+  position: relative;
+}
+
+.book-card.selection-mode.selected {
+  background: var(--c-accent-soft);
+}
+
+.select-check {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid var(--c-border-strong);
+  background: var(--c-surface-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2;
+  transition: all 0.15s var(--ease-out);
+}
+
+.select-check.checked {
+  background: var(--c-accent);
+  border-color: var(--c-accent);
+  color: var(--c-ink-inverse);
+}
+
+.list-mode .select-check {
+  position: static;
+  flex-shrink: 0;
 }
 
 .book-cover {

--- a/plugins/hushreader/src/components/Bookshelf/BookInfoModal.vue
+++ b/plugins/hushreader/src/components/Bookshelf/BookInfoModal.vue
@@ -1,0 +1,628 @@
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import type { Book } from '../../stores/books'
+import { useBookStore } from '../../stores/books'
+import { saveCustomCover } from '../../utils/db'
+
+const props = defineProps<{ book: Book }>()
+const emit = defineEmits<{
+  close: []
+  saved: [updates: Partial<Book>]
+}>()
+
+const bookStore = useBookStore()
+
+const existingCategories = computed(() => bookStore.categories.filter(c => c !== '全部'))
+
+const isEditing = ref(false)
+
+const editTitle = ref('')
+const editAuthor = ref('')
+const editDescription = ref('')
+const editCategories = ref<string[]>([])
+const editNewCategory = ref('')
+
+const imgError = ref(false)
+
+const displayCover = computed(() => {
+  if (imgError.value) return undefined
+  return props.book.customCoverImage || props.book.coverImage
+})
+
+function formatDateTime(ts: number | undefined): string {
+  if (!ts) return '-'
+  const d = new Date(ts)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`
+}
+
+function formatReadingTime(ms: number | undefined): string {
+  if (!ms) return '00:00:00'
+  const totalSeconds = Math.floor(ms / 1000)
+  const h = Math.floor(totalSeconds / 3600)
+  const m = Math.floor((totalSeconds % 3600) / 60)
+  const s = totalSeconds % 60
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+}
+
+function formatReadingSpeed(speed: number | undefined): string {
+  if (!speed) return '-'
+  return String(Math.round(speed))
+}
+
+function enterEditMode() {
+  editTitle.value = props.book.title
+  editAuthor.value = props.book.author
+  editDescription.value = props.book.description || ''
+  editCategories.value = [...(props.book.categories || [])]
+  editNewCategory.value = ''
+  isEditing.value = true
+}
+
+function cancelEdit() {
+  isEditing.value = false
+}
+
+function toggleEditCategory(cat: string) {
+  const idx = editCategories.value.indexOf(cat)
+  if (idx > -1) {
+    editCategories.value.splice(idx, 1)
+  } else {
+    editCategories.value.push(cat)
+  }
+}
+
+function uploadCover() {
+  const input = document.createElement('input')
+  input.type = 'file'
+  input.accept = 'image/*'
+  input.onchange = () => {
+    const file = input.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = () => {
+      const data = reader.result as string
+      emit('saved', { customCoverImage: data, updatedAt: Date.now() })
+      saveCustomCover(props.book.id, data).catch(() => {})
+    }
+    reader.readAsDataURL(file)
+  }
+  input.click()
+}
+
+function saveEdit() {
+  const newCats = editNewCategory.value
+    .split(/[,，]/)
+    .map(s => s.trim())
+    .filter(Boolean)
+  const finalCats = [...new Set([...editCategories.value, ...newCats])]
+
+  const updates: Partial<Book> = {
+    title: editTitle.value.trim() || '未命名',
+    author: editAuthor.value.trim(),
+    description: editDescription.value.trim() || undefined,
+    categories: finalCats.length > 0 ? finalCats : undefined,
+    updatedAt: Date.now()
+  }
+  emit('saved', updates)
+  isEditing.value = false
+}
+
+watch(() => props.book, () => {
+  imgError.value = false
+  isEditing.value = false
+})
+</script>
+
+<template>
+  <div class="info-overlay" @click.self="emit('close')">
+    <div class="info-box">
+      <div class="info-header">
+        <h3 class="info-title">书籍信息</h3>
+        <button class="info-close" @click="emit('close')">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+        </button>
+      </div>
+      <div class="info-body">
+        <!-- Card 1: Cover + Title/Author -->
+        <div class="info-card">
+          <div class="cover-section">
+            <div
+              v-if="!isEditing"
+              class="cover-thumb"
+              :style="displayCover ? {} : { background: book.coverColor || '#4a7fa5' }"
+            >
+              <img v-if="displayCover" :src="displayCover" :alt="book.title" class="cover-img" @error="imgError = true" />
+              <template v-else>
+                <span class="cover-format">{{ book.format.toUpperCase() }}</span>
+                <span class="cover-title-text">{{ book.title }}</span>
+              </template>
+            </div>
+            <div v-else class="cover-thumb editable" @click="uploadCover">
+              <img v-if="displayCover" :src="displayCover" :alt="book.title" class="cover-img" @error="imgError = true" />
+              <template v-else>
+                <span class="cover-format">{{ book.format.toUpperCase() }}</span>
+                <span class="cover-title-text">{{ book.title }}</span>
+              </template>
+              <div class="cover-upload-hint">点击更换</div>
+            </div>
+          </div>
+          <div class="title-section">
+            <template v-if="!isEditing">
+              <h2 class="book-main-title">{{ book.title }}</h2>
+              <p class="book-main-author">{{ book.author || '未知作者' }}</p>
+              <span class="book-format-badge">{{ book.format.toUpperCase() }}</span>
+            </template>
+            <template v-else>
+              <label class="edit-label">标题</label>
+              <input v-model="editTitle" class="edit-input" placeholder="书籍标题" />
+              <label class="edit-label">作者</label>
+              <input v-model="editAuthor" class="edit-input" placeholder="作者名称" />
+            </template>
+          </div>
+        </div>
+
+        <!-- Card 2: Description -->
+        <div class="info-card">
+          <div class="card-label">简介</div>
+          <template v-if="!isEditing">
+            <p v-if="book.description" class="description-text">{{ book.description }}</p>
+            <p v-else class="description-empty">暂无简介</p>
+          </template>
+          <template v-else>
+            <textarea v-model="editDescription" class="edit-textarea" placeholder="输入书籍简介..." rows="4"></textarea>
+          </template>
+        </div>
+
+        <!-- Card 3: Categories -->
+        <div class="info-card">
+          <div class="card-label">分类</div>
+          <template v-if="!isEditing">
+            <div v-if="book.categories?.length" class="category-list">
+              <span v-for="cat in book.categories" :key="cat" class="category-chip">{{ cat }}</span>
+            </div>
+            <p v-else class="description-empty">未分类</p>
+          </template>
+          <template v-else>
+            <div v-if="existingCategories.length" class="edit-category-pick">
+              <button
+                v-for="cat in existingCategories"
+                :key="cat"
+                class="category-chip toggleable"
+                :class="{ active: editCategories.includes(cat) }"
+                @click="toggleEditCategory(cat)"
+              >{{ cat }}</button>
+            </div>
+            <div class="edit-category-tags" style="margin-top: 8px">
+              <button
+                v-for="cat in editCategories.filter(c => !existingCategories.includes(c))"
+                :key="cat"
+                class="category-chip removable"
+                @click="toggleEditCategory(cat)"
+              >
+                {{ cat }}
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+              </button>
+            </div>
+            <input v-model="editNewCategory" class="edit-input" placeholder="新分类，逗号分隔..." style="margin-top: 8px" />
+          </template>
+        </div>
+
+        <!-- Card 4: Reading Info -->
+        <div class="info-card">
+          <div class="card-label">阅读信息</div>
+          <div class="reading-grid">
+            <div class="reading-item">
+              <span class="reading-key">导入时间</span>
+              <span class="reading-val">{{ formatDateTime(book.addedAt) }}</span>
+            </div>
+            <div class="reading-item">
+              <span class="reading-key">更新时间</span>
+              <span class="reading-val">{{ formatDateTime(book.updatedAt || book.addedAt) }}</span>
+            </div>
+            <div class="reading-item">
+              <span class="reading-key">首次阅读</span>
+              <span class="reading-val">{{ formatDateTime(book.firstReadAt) }}</span>
+            </div>
+            <div class="reading-item">
+              <span class="reading-key">最近阅读</span>
+              <span class="reading-val">{{ formatDateTime(book.lastReadAt) }}</span>
+            </div>
+            <div class="reading-item">
+              <span class="reading-key">阅读时长</span>
+              <span class="reading-val">{{ formatReadingTime(book.readingTimeMs) }}</span>
+            </div>
+            <div class="reading-item">
+              <span class="reading-key">阅读速度</span>
+              <span class="reading-val">{{ formatReadingSpeed(book.readingSpeed) }} 字/分钟</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Footer buttons -->
+      <div class="info-footer">
+        <template v-if="!isEditing">
+          <button class="btn-secondary" @click="emit('close')">关闭</button>
+          <button class="btn-primary" @click="enterEditMode">编辑</button>
+        </template>
+        <template v-else>
+          <button class="btn-secondary" @click="cancelEdit">取消</button>
+          <button class="btn-primary" @click="saveEdit">保存</button>
+        </template>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.info-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--c-overlay-bg);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 8000;
+  animation: fade-in 0.15s var(--ease-out);
+}
+
+.info-box {
+  background: var(--c-surface-overlay);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-xl);
+  width: 90%;
+  max-width: 520px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: var(--shadow-xl);
+  animation: slide-up 0.2s var(--ease-out);
+}
+
+.info-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 14px;
+  border-bottom: 1px solid var(--c-border);
+  flex-shrink: 0;
+}
+
+.info-title {
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.info-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  color: var(--c-ink-tertiary);
+  transition: background 0.12s var(--ease-out), color 0.12s var(--ease-out);
+}
+.info-close:hover {
+  background: var(--c-surface-sunken);
+  color: var(--c-ink);
+}
+
+.info-body {
+  padding: 16px 20px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.info-card {
+  background: var(--c-surface-sunken);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-lg);
+  padding: 14px 16px;
+}
+
+.card-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--c-ink-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 10px;
+}
+
+/* Card 1: Cover + Title */
+.cover-section {
+  flex-shrink: 0;
+}
+
+.cover-thumb {
+  width: 80px;
+  height: 112px;
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 8px;
+  box-shadow: var(--shadow-sm);
+  position: relative;
+}
+
+.cover-thumb.editable {
+  cursor: pointer;
+}
+
+.cover-thumb.editable:hover .cover-upload-hint {
+  opacity: 1;
+}
+
+.cover-upload-hint {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 4px;
+  background: var(--c-progress-bg);
+  color: var(--c-progress-label);
+  font-size: 10px;
+  text-align: center;
+  opacity: 0;
+  transition: opacity 0.15s var(--ease-out);
+}
+
+.cover-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cover-format {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  color: var(--c-cover-text-muted);
+  text-transform: uppercase;
+}
+
+.cover-title-text {
+  font-size: 10px;
+  color: var(--c-cover-text);
+  text-align: center;
+  line-height: 1.3;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  word-break: break-all;
+}
+
+.info-card:first-child {
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.title-section {
+  flex: 1;
+  min-width: 0;
+}
+
+.book-main-title {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--c-ink);
+  line-height: 1.35;
+  margin-bottom: 4px;
+  word-break: break-word;
+}
+
+.book-main-author {
+  font-size: 13px;
+  color: var(--c-ink-secondary);
+  margin-bottom: 8px;
+}
+
+.book-format-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  color: var(--c-accent);
+  background: var(--c-accent-soft);
+  border-radius: var(--radius-full);
+}
+
+/* Card 2: Description */
+.description-text {
+  font-size: 13px;
+  color: var(--c-ink-secondary);
+  line-height: 1.65;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.description-empty {
+  font-size: 13px;
+  color: var(--c-ink-tertiary);
+  font-style: italic;
+}
+
+/* Card 3: Categories */
+.category-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.category-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 10px;
+  font-size: 12px;
+  color: var(--c-ink-secondary);
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-full);
+}
+
+.category-chip.removable {
+  cursor: pointer;
+  transition: all 0.12s var(--ease-out);
+}
+
+.category-chip.removable:hover {
+  border-color: var(--c-danger);
+  color: var(--c-danger);
+}
+
+.category-chip.removable svg {
+  opacity: 0.5;
+}
+
+.category-chip.removable:hover svg {
+  opacity: 1;
+}
+
+.category-chip.toggleable {
+  cursor: pointer;
+  transition: all 0.12s var(--ease-out);
+}
+
+.category-chip.toggleable:hover {
+  border-color: var(--c-accent);
+  color: var(--c-accent);
+}
+
+.category-chip.toggleable.active {
+  background: var(--c-accent);
+  color: var(--c-ink-inverse);
+  border-color: var(--c-accent);
+}
+
+.edit-category-pick {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.edit-category-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+/* Card 4: Reading info */
+.reading-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px 16px;
+}
+
+.reading-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.reading-key {
+  font-size: 11px;
+  color: var(--c-ink-tertiary);
+}
+
+.reading-val {
+  font-size: 13px;
+  color: var(--c-ink);
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono);
+  line-height: 1.4;
+}
+
+/* Edit mode inputs */
+.edit-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--c-ink-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+  display: block;
+}
+
+.edit-input {
+  width: 100%;
+  border: 1px solid var(--c-border);
+  background: var(--c-surface);
+  color: var(--c-ink);
+  border-radius: var(--radius-sm);
+  padding: 7px 10px;
+  font-size: 13px;
+  transition: border-color 0.15s var(--ease-out), box-shadow 0.15s var(--ease-out);
+}
+
+.edit-input:focus {
+  border-color: var(--c-accent);
+  box-shadow: 0 0 0 3px var(--c-accent-soft);
+}
+
+.edit-textarea {
+  width: 100%;
+  border: 1px solid var(--c-border);
+  background: var(--c-surface);
+  color: var(--c-ink);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  font-size: 13px;
+  line-height: 1.6;
+  resize: vertical;
+  min-height: 80px;
+  transition: border-color 0.15s var(--ease-out), box-shadow 0.15s var(--ease-out);
+}
+
+.edit-textarea:focus {
+  border-color: var(--c-accent);
+  box-shadow: 0 0 0 3px var(--c-accent-soft);
+}
+
+/* Footer */
+.info-footer {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  padding: 14px 20px;
+  border-top: 1px solid var(--c-border);
+  flex-shrink: 0;
+}
+
+.btn-primary, .btn-secondary {
+  padding: 7px 20px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  font-weight: 500;
+  transition: all 0.15s var(--ease-out);
+}
+
+.btn-primary {
+  background: var(--c-accent);
+  color: var(--c-ink-inverse);
+}
+.btn-primary:hover { background: var(--c-accent-hover); }
+
+.btn-secondary {
+  background: var(--c-surface-sunken);
+  color: var(--c-ink);
+}
+.btn-secondary:hover { background: var(--c-border); }
+</style>

--- a/plugins/hushreader/src/components/Bookshelf/BookInfoModal.vue
+++ b/plugins/hushreader/src/components/Bookshelf/BookInfoModal.vue
@@ -83,19 +83,28 @@ function uploadCover() {
     reader.onload = () => {
       const data = reader.result as string
       emit('saved', { customCoverImage: data, updatedAt: Date.now() })
-      saveCustomCover(props.book.id, data).catch(() => {})
+      saveCustomCover(props.book.id, data).catch(() => { })
     }
     reader.readAsDataURL(file)
   }
   input.click()
 }
 
+function addCustomCategory() {
+  const val = editNewCategory.value.trim()
+  if (!val) return
+  const cats = val.split(/[,，]/).map(s => s.trim()).filter(Boolean)
+  cats.forEach(c => {
+    if (!editCategories.value.includes(c)) {
+      editCategories.value.push(c)
+    }
+  })
+  editNewCategory.value = ''
+}
+
 function saveEdit() {
-  const newCats = editNewCategory.value
-    .split(/[,，]/)
-    .map(s => s.trim())
-    .filter(Boolean)
-  const finalCats = [...new Set([...editCategories.value, ...newCats])]
+  addCustomCategory()
+  const finalCats = [...new Set(editCategories.value)]
 
   const updates: Partial<Book> = {
     title: editTitle.value.trim() || '未命名',
@@ -121,7 +130,8 @@ watch(() => props.book, () => {
         <h3 class="info-title">书籍信息</h3>
         <button class="info-close" @click="emit('close')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
           </svg>
         </button>
       </div>
@@ -129,19 +139,18 @@ watch(() => props.book, () => {
         <!-- Card 1: Cover + Title/Author -->
         <div class="info-card">
           <div class="cover-section">
-            <div
-              v-if="!isEditing"
-              class="cover-thumb"
-              :style="displayCover ? {} : { background: book.coverColor || '#4a7fa5' }"
-            >
-              <img v-if="displayCover" :src="displayCover" :alt="book.title" class="cover-img" @error="imgError = true" />
+            <div v-if="!isEditing" class="cover-thumb"
+              :style="displayCover ? {} : { background: book.coverColor || '#4a7fa5' }">
+              <img v-if="displayCover" :src="displayCover" :alt="book.title" class="cover-img"
+                @error="imgError = true" />
               <template v-else>
                 <span class="cover-format">{{ book.format.toUpperCase() }}</span>
                 <span class="cover-title-text">{{ book.title }}</span>
               </template>
             </div>
             <div v-else class="cover-thumb editable" @click="uploadCover">
-              <img v-if="displayCover" :src="displayCover" :alt="book.title" class="cover-img" @error="imgError = true" />
+              <img v-if="displayCover" :src="displayCover" :alt="book.title" class="cover-img"
+                @error="imgError = true" />
               <template v-else>
                 <span class="cover-format">{{ book.format.toUpperCase() }}</span>
                 <span class="cover-title-text">{{ book.title }}</span>
@@ -187,26 +196,22 @@ watch(() => props.book, () => {
           </template>
           <template v-else>
             <div v-if="existingCategories.length" class="edit-category-pick">
-              <button
-                v-for="cat in existingCategories"
-                :key="cat"
-                class="category-chip toggleable"
-                :class="{ active: editCategories.includes(cat) }"
-                @click="toggleEditCategory(cat)"
-              >{{ cat }}</button>
+              <button v-for="cat in existingCategories" :key="cat" class="category-chip toggleable"
+                :class="{ active: editCategories.includes(cat) }" @click="toggleEditCategory(cat)">{{ cat }}</button>
             </div>
             <div class="edit-category-tags" style="margin-top: 8px">
-              <button
-                v-for="cat in editCategories.filter(c => !existingCategories.includes(c))"
-                :key="cat"
-                class="category-chip removable"
-                @click="toggleEditCategory(cat)"
-              >
+              <button v-for="cat in editCategories.filter(c => !existingCategories.includes(c))" :key="cat"
+                class="category-chip removable" @click="toggleEditCategory(cat)">
                 {{ cat }}
-                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3">
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
               </button>
             </div>
-            <input v-model="editNewCategory" class="edit-input" placeholder="新分类，逗号分隔..." style="margin-top: 8px" />
+            <input v-model="editNewCategory" class="edit-input" placeholder="新分类，回车或逗号添加..." style="margin-top: 8px"
+              @keydown.enter.prevent="addCustomCategory" @keydown.comma.prevent="addCustomCategory"
+              @blur="addCustomCategory" />
           </template>
         </div>
 
@@ -308,6 +313,7 @@ watch(() => props.book, () => {
   color: var(--c-ink-tertiary);
   transition: background 0.12s var(--ease-out), color 0.12s var(--ease-out);
 }
+
 .info-close:hover {
   background: var(--c-surface-sunken);
   color: var(--c-ink);
@@ -606,7 +612,8 @@ watch(() => props.book, () => {
   flex-shrink: 0;
 }
 
-.btn-primary, .btn-secondary {
+.btn-primary,
+.btn-secondary {
   padding: 7px 20px;
   border-radius: var(--radius-sm);
   font-size: 13px;
@@ -618,11 +625,17 @@ watch(() => props.book, () => {
   background: var(--c-accent);
   color: var(--c-ink-inverse);
 }
-.btn-primary:hover { background: var(--c-accent-hover); }
+
+.btn-primary:hover {
+  background: var(--c-accent-hover);
+}
 
 .btn-secondary {
   background: var(--c-surface-sunken);
   color: var(--c-ink);
 }
-.btn-secondary:hover { background: var(--c-border); }
+
+.btn-secondary:hover {
+  background: var(--c-border);
+}
 </style>

--- a/plugins/hushreader/src/components/Bookshelf/ContextMenu.vue
+++ b/plugins/hushreader/src/components/Bookshelf/ContextMenu.vue
@@ -3,11 +3,14 @@ import { ref, nextTick, watch } from 'vue'
 
 const props = defineProps<{ pos: { x: number; y: number } }>()
 const emit = defineEmits<{
+  'book-info': []
   'chapter-list': []
   'change-path': []
   'edit-metadata': []
+  'reload-metadata': []
   'set-category': []
   'set-cover': []
+  'restore-cover': []
   'delete': []
   'close': []
 }>()
@@ -39,6 +42,10 @@ watch(
 <template>
   <div class="ctx-backdrop" @click.self="emit('close')" @contextmenu.prevent>
     <ul ref="menuRef" class="ctx-menu" :style="style" @click.stop>
+      <li class="ctx-item" @click="emit('book-info')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>
+        书籍信息
+      </li>
       <li class="ctx-item" @click="emit('chapter-list')">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
         章节列表
@@ -51,6 +58,10 @@ watch(
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>
         编辑元数据
       </li>
+      <li class="ctx-item" @click="emit('reload-metadata')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+        重载元数据
+      </li>
       <li class="ctx-divider"></li>
       <li class="ctx-item" @click="emit('set-category')">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg>
@@ -59,6 +70,10 @@ watch(
       <li class="ctx-item" @click="emit('set-cover')">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
         设置封面
+      </li>
+      <li class="ctx-item" @click="emit('restore-cover')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>
+        恢复封面
       </li>
       <li class="ctx-divider"></li>
       <li class="ctx-item ctx-danger" @click="emit('delete')">

--- a/plugins/hushreader/src/components/Bookshelf/index.vue
+++ b/plugins/hushreader/src/components/Bookshelf/index.vue
@@ -6,12 +6,13 @@ import { useReaderStore } from '../../stores/reader'
 import { parseTxt } from '../../utils/txtParser'
 import { parseEpub } from '../../utils/epubParser'
 import { parseMobi } from '../../utils/mobiParser'
-import { saveCover, loadCover, removeCover, saveCustomCover, loadCustomCover, removeCustomCover, removeBookData } from '../../utils/db'
+import { saveCover, loadCover, removeCover, saveCustomCover, loadCustomCover, removeCustomCover, removeBookData, saveChapters, removeChapters } from '../../utils/db'
 import SettingsModal from '../Settings/index.vue'
 import ContextMenu from './ContextMenu.vue'
 import BookCard from './BookCard.vue'
 import Toast from './Toast.vue'
 import Modal from './Modal.vue'
+import BookInfoModal from './BookInfoModal.vue'
 import ThemeToggle from './ThemeToggle.vue'
 
 const props = defineProps<{ enterAction?: any }>()
@@ -209,7 +210,8 @@ function confirmMetadata() {
   if (!metadataModalBookId.value) return
   bookStore.updateBook(metadataModalBookId.value, {
     title: metadataModalTitle.value.trim() || '未命名',
-    author: metadataModalAuthor.value.trim()
+    author: metadataModalAuthor.value.trim(),
+    updatedAt: Date.now()
   })
   showMetadataModal.value = false
   toast('元数据已更新', 'success')
@@ -227,7 +229,7 @@ function openCoverPicker(bookId: string) {
     const reader = new FileReader()
     reader.onload = () => {
       const data = reader.result as string
-      bookStore.updateBook(bookId, { customCoverImage: data })
+      bookStore.updateBook(bookId, { customCoverImage: data, updatedAt: Date.now() })
       saveCustomCover(bookId, data).catch(() => {})
       toast('封面已更新', 'success')
     }
@@ -266,9 +268,88 @@ async function repairCover(bookId: string) {
   }
 }
 
+async function restoreCover(bookId: string) {
+  const book = bookStore.books.find(b => b.id === bookId)
+  if (!book) return
+
+  bookStore.updateBook(bookId, { customCoverImage: undefined })
+  removeCustomCover(bookId).catch(() => {})
+
+  if (book.format === 'txt') {
+    bookStore.updateBook(bookId, { coverImage: undefined })
+    removeCover(bookId).catch(() => {})
+    toast('封面已恢复为纯色', 'success')
+    return
+  }
+
+  if (configStore.config.other.plainTextCover) {
+    bookStore.updateBook(bookId, { coverImage: undefined })
+    removeCover(bookId).catch(() => {})
+    toast('封面已恢复', 'success')
+    return
+  }
+
+  try {
+    const content = window.services?.readFileBinary?.(book.filePath)
+    if (!content) {
+      bookStore.updateBook(bookId, { coverImage: undefined })
+      removeCover(bookId).catch(() => {})
+      toast('封面已恢复', 'success')
+      return
+    }
+
+    let coverImage: string | undefined
+    if (book.format === 'epub') {
+      const blob = new Blob([content], { type: 'application/epub+zip' })
+      const file = new File([blob], book.filePath.split(/[\\/]/).pop() ?? 'book.epub')
+      const result = await parseEpub(file)
+      coverImage = result.coverUrl || undefined
+    } else if (book.format === 'mobi') {
+      const blob = new Blob([content], { type: 'application/x-mobipocket-ebook' })
+      const file = new File([blob], book.filePath.split(/[\\/]/).pop() ?? 'book.mobi')
+      const result = await parseMobi(file)
+      if (!result.error) coverImage = result.coverUrl || undefined
+    }
+
+    if (coverImage) {
+      bookStore.updateBook(bookId, { coverImage })
+      saveCover(bookId, coverImage).catch(() => {})
+    } else {
+      bookStore.updateBook(bookId, { coverImage: undefined })
+      removeCover(bookId).catch(() => {})
+    }
+    toast('封面已恢复', 'success')
+  } catch {
+    bookStore.updateBook(bookId, { coverImage: undefined })
+    removeCover(bookId).catch(() => {})
+    toast('封面已恢复', 'success')
+  }
+}
+
+function openRestoreCover(bookId: string) {
+  closeContextMenu()
+  restoreCover(bookId)
+}
+
 // Delete modal
 const showDeleteModal = ref(false)
 const deleteBookId = ref<string | null>(null)
+
+// Book info modal
+const showBookInfo = ref(false)
+const bookInfoId = ref<string | null>(null)
+
+function openBookInfo(bookId: string) {
+  closeContextMenu()
+  bookInfoId.value = bookId
+  showBookInfo.value = true
+}
+
+function onBookInfoSaved(updates: Partial<typeof bookStore.books[0]>) {
+  if (!bookInfoId.value) return
+  bookStore.updateBook(bookInfoId.value, updates)
+  toast('信息已更新', 'success')
+}
 
 function openDeleteModal(bookId: string) {
   closeContextMenu()
@@ -281,6 +362,150 @@ function confirmDelete() {
   bookStore.removeBook(deleteBookId.value)
   showDeleteModal.value = false
   toast('已删除', 'info')
+}
+
+// Reload metadata
+async function reloadMetadata(bookId: string, silent = false) {
+  const book = bookStore.books.find(b => b.id === bookId)
+  if (!book) return
+
+  try {
+    let title = book.title
+    let author = book.author
+    let description = book.description || ''
+    let coverImage: string | undefined
+    let totalChapters: number | undefined
+
+    if (book.format === 'epub') {
+      const content = window.services?.readFileBinary?.(book.filePath)
+      if (content) {
+        const blob = new Blob([content], { type: 'application/epub+zip' })
+        const file = new File([blob], book.filePath.split(/[\\/]/).pop() ?? 'book.epub')
+        const result = await parseEpub(file)
+        title = result.title || title
+        author = result.author || author
+        description = result.description || description
+        totalChapters = result.chapters?.length
+        if (result.coverUrl && !configStore.config.other.plainTextCover) coverImage = result.coverUrl
+        if (result.chapters?.length) saveChapters(bookId, result.chapters).catch(() => {})
+      }
+    } else if (book.format === 'mobi') {
+      const content = window.services?.readFileBinary?.(book.filePath)
+      if (content) {
+        const blob = new Blob([content], { type: 'application/x-mobipocket-ebook' })
+        const file = new File([blob], book.filePath.split(/[\\/]/).pop() ?? 'book.mobi')
+        const result = await parseMobi(file)
+        if (!result.error) {
+          title = result.title || title
+          author = result.author || author
+          description = result.description || description
+          totalChapters = result.chapters?.length
+          if (result.coverUrl && !configStore.config.other.plainTextCover) coverImage = result.coverUrl
+          if (result.chapters?.length) saveChapters(bookId, result.chapters).catch(() => {})
+        }
+      }
+    } else {
+      const text = window.services?.readFile(book.filePath) ?? ''
+      const chapters = parseTxt(text, configStore.config.other.chapterRegex || undefined)
+      totalChapters = chapters.length
+      if (chapters.length) saveChapters(bookId, chapters).catch(() => {})
+    }
+
+    const fileModifiedAt = window.services?.getFileModifiedTime?.(book.filePath)
+    const updates: Partial<typeof book> = { title, author, description: description || undefined, totalChapters, fileModifiedAt, customCoverImage: undefined }
+
+    removeCustomCover(bookId).catch(() => {})
+
+    if (coverImage) {
+      updates.coverImage = coverImage
+      saveCover(bookId, coverImage).catch(() => {})
+    } else {
+      updates.coverImage = undefined
+      removeCover(bookId).catch(() => {})
+    }
+
+    bookStore.updateBook(bookId, updates)
+    if (!silent) toast(`《${title}》元数据已重载`, 'success')
+  } catch (e: any) {
+    if (!silent) toast(`重载失败：${e.message}`, 'error')
+    throw e
+  }
+}
+
+function openReloadMetadata(bookId: string) {
+  closeContextMenu()
+  reloadMetadata(bookId)
+}
+
+// Multi-select mode
+const selectionMode = ref(false)
+const selectedIds = ref<Set<string>>(new Set())
+
+function toggleSelectionMode() {
+  selectionMode.value = !selectionMode.value
+  if (!selectionMode.value) selectedIds.value.clear()
+  if (selectionMode.value) closeContextMenu()
+}
+
+function exitSelectionMode() {
+  selectionMode.value = false
+  selectedIds.value.clear()
+}
+
+function toggleBookSelect(bookId: string) {
+  if (selectedIds.value.has(bookId)) {
+    selectedIds.value.delete(bookId)
+  } else {
+    selectedIds.value.add(bookId)
+  }
+}
+
+function selectAllInCategory() {
+  const books = bookStore.filteredBooks
+  const allSelected = books.every(b => selectedIds.value.has(b.id))
+  if (allSelected) {
+    books.forEach(b => selectedIds.value.delete(b.id))
+  } else {
+    books.forEach(b => selectedIds.value.add(b.id))
+  }
+}
+
+const selectedCount = computed(() => selectedIds.value.size)
+
+// Batch operations
+const showBatchDeleteModal = ref(false)
+const batchReloading = ref(false)
+
+function openBatchDelete() {
+  if (selectedIds.value.size === 0) return
+  showBatchDeleteModal.value = true
+}
+
+function confirmBatchDelete() {
+  for (const id of selectedIds.value) {
+    bookStore.removeBook(id)
+  }
+  showBatchDeleteModal.value = false
+  toast(`已删除 ${selectedIds.value.size} 本书`, 'info')
+  exitSelectionMode()
+}
+
+async function batchReload() {
+  if (selectedIds.value.size === 0) return
+  batchReloading.value = true
+  let success = 0
+  let fail = 0
+  for (const id of selectedIds.value) {
+    try {
+      await reloadMetadata(id, true)
+      success++
+    } catch {
+      fail++
+    }
+  }
+  batchReloading.value = false
+  toast(`重载完成：${success} 成功${fail ? `，${fail} 失败` : ''}`, fail ? 'error' : 'success')
+  exitSelectionMode()
 }
 
 // Import book
@@ -299,6 +524,7 @@ async function importBook(filePath: string) {
   try {
     let title = name.replace(/\.(epub|txt|mobi)$/i, '')
     let author = ''
+    let description = ''
     let coverColor = randomCoverColor()
     let coverImage: string | undefined
 
@@ -311,6 +537,7 @@ async function importBook(filePath: string) {
           const result = await parseEpub(file)
           title = result.title || title
           author = result.author || ''
+          description = result.description || ''
           if (result.coverUrl && !configStore.config.other.plainTextCover) coverImage = result.coverUrl
         }
       } catch {}
@@ -326,6 +553,7 @@ async function importBook(filePath: string) {
           if (result.error) { toast(`MOBI解析失败：${result.error}`, 'error'); return }
           title = result.title || title
           author = result.author || ''
+          description = result.description || ''
           if (result.coverUrl && !configStore.config.other.plainTextCover) coverImage = result.coverUrl
         }
       } catch (e: any) {
@@ -336,12 +564,74 @@ async function importBook(filePath: string) {
     const fileModifiedAt = window.services?.getFileModifiedTime?.(filePath)
 
     const book = bookStore.addBook({
-      title, author,
+      title, author, description: description || undefined,
       format: isEpub ? 'epub' : isMobi ? 'mobi' : 'txt',
       filePath,
       coverColor,
       coverImage,
       fileModifiedAt
+    })
+
+    if (book) {
+      if (coverImage) saveCover(book.id, coverImage).catch(() => {})
+      toast(`《${title}》已加入书架`, 'success')
+    } else {
+      toast('该书籍已在书架中', 'info')
+    }
+  } catch (error: any) {
+    toast(`导入失败: ${error.message || error}`, 'error')
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function importDroppedFile(file: File) {
+  const name = file.name
+  const isEpub = /\.epub$/i.test(name)
+  const isTxt = /\.txt$/i.test(name)
+  const isMobi = /\.mobi$/i.test(name)
+  if (!isEpub && !isTxt && !isMobi) {
+    toast('仅支持 EPUB、TXT 和 MOBI 格式', 'error')
+    return
+  }
+
+  isLoading.value = true
+  try {
+    let title = name.replace(/\.(epub|txt|mobi)$/i, '')
+    let author = ''
+    let description = ''
+    let coverColor = randomCoverColor()
+    let coverImage: string | undefined
+
+    if (isEpub) {
+      try {
+        const result = await parseEpub(file)
+        title = result.title || title
+        author = result.author || ''
+        description = result.description || ''
+        if (result.coverUrl && !configStore.config.other.plainTextCover) coverImage = result.coverUrl
+      } catch {}
+    }
+
+    if (isMobi) {
+      try {
+        const result = await parseMobi(file)
+        if (result.error) { toast(`MOBI解析失败：${result.error}`, 'error'); return }
+        title = result.title || title
+        author = result.author || ''
+        description = result.description || ''
+        if (result.coverUrl && !configStore.config.other.plainTextCover) coverImage = result.coverUrl
+      } catch (e: any) {
+        toast(`MOBI导入失败：${e.message}`, 'error'); return
+      }
+    }
+
+    const book = bookStore.addBook({
+      title, author, description: description || undefined,
+      format: isEpub ? 'epub' : isMobi ? 'mobi' : 'txt',
+      filePath: (file as any).path || name,
+      coverColor,
+      coverImage
     })
 
     if (book) {
@@ -369,26 +659,89 @@ function handleAddBook() {
 }
 
 // Handle plugin enter with file import
-onMounted(() => {
-  if (props.enterAction?.code === 'import' && props.enterAction?.type === 'files') {
-    const filePath = props.enterAction?.payload?.[0]?.path
-    if (filePath) importBook(filePath)
+watch(() => props.enterAction, async (action) => {
+  if (action?.code === 'hushreader-import' && action?.type === 'files') {
+    const filePath = (action.payload as { path?: string }[] | undefined)?.[0]?.path
+    if (filePath) {
+      await bookStore.load()
+      importBook(filePath)
+    }
   }
-})
+}, { immediate: true })
 
 // Drag and drop import
-function onDrop(e: DragEvent) {
-  e.preventDefault()
-  const files = e.dataTransfer?.files
-  if (!files?.length) return
-  const file = files[0]
-  // In Electron context the path is available
-  const filePath = (file as any).path
-  if (filePath) importBook(filePath)
+const fileHovering = ref(false)
+let hoverNestLevel = 0
+const showDropConfirmModal = ref(false)
+const pendingDropFiles = ref<File[]>([])
+
+function hasFilePayload(ev: DragEvent) {
+  return Array.from(ev.dataTransfer?.types ?? []).includes('Files')
 }
 
-function onDragover(e: DragEvent) {
-  e.preventDefault()
+function markDropCopy(ev: DragEvent) {
+  if (ev.dataTransfer) ev.dataTransfer.dropEffect = 'copy'
+}
+
+function cursorInsideBounds(ev: DragEvent) {
+  const el = ev.currentTarget
+  if (!(el instanceof HTMLElement)) return false
+  const r = el.getBoundingClientRect()
+  return ev.clientX >= r.left && ev.clientX <= r.right && ev.clientY >= r.top && ev.clientY <= r.bottom
+}
+
+function onDragEnter(ev: DragEvent) {
+  if (!hasFilePayload(ev)) return
+  hoverNestLevel += 1
+  markDropCopy(ev)
+  fileHovering.value = true
+}
+
+function onDragover(ev: DragEvent) {
+  if (!hasFilePayload(ev)) return
+  ev.preventDefault()
+  markDropCopy(ev)
+  fileHovering.value = true
+}
+
+function onDragLeave(ev: DragEvent) {
+  if (!fileHovering.value) return
+  hoverNestLevel = Math.max(0, hoverNestLevel - 1)
+  if (hoverNestLevel > 0 && cursorInsideBounds(ev)) return
+  hoverNestLevel = 0
+  fileHovering.value = false
+}
+
+function onDrop(ev: DragEvent) {
+  ev.preventDefault()
+  hoverNestLevel = 0
+  fileHovering.value = false
+  const files = ev.dataTransfer?.files
+  if (!files?.length) return
+  const validExts = /\.(epub|txt|mobi)$/i
+  const valid: File[] = []
+  for (let i = 0; i < files.length; i++) {
+    if (validExts.test(files[i].name)) valid.push(files[i])
+  }
+  if (!valid.length) {
+    toast('仅支持 EPUB、TXT 和 MOBI 格式', 'error')
+    return
+  }
+  pendingDropFiles.value = valid
+  showDropConfirmModal.value = true
+}
+
+async function confirmDropImport() {
+  showDropConfirmModal.value = false
+  for (const f of pendingDropFiles.value) {
+    await importDroppedFile(f)
+  }
+  pendingDropFiles.value = []
+}
+
+function cancelDropImport() {
+  showDropConfirmModal.value = false
+  pendingDropFiles.value = []
 }
 
 // Close context menu on outside click
@@ -477,11 +830,21 @@ watch(() => configStore.config.other.plainTextCover, async (plain) => {
   }
 })
 
+
+
+
 const cfg = computed(() => configStore.config)
 </script>
 
 <template>
-  <div class="bookshelf" @drop="onDrop" @dragover="onDragover">
+  <div class="bookshelf" @dragenter="onDragEnter" @dragover="onDragover" @dragleave="onDragLeave" @drop="onDrop">
+    <!-- Drop overlay -->
+    <div v-if="fileHovering" class="drop-overlay">
+      <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/>
+      </svg>
+      <span>导入书籍</span>
+    </div>
     <!-- Header -->
     <header class="shelf-header">
       <h1 class="shelf-title">书架</h1>
@@ -496,6 +859,17 @@ const cfg = computed(() => configStore.config)
         />
       </div>
       <div class="shelf-actions">
+        <button
+          class="icon-btn"
+          :class="{ active: selectionMode }"
+          :title="selectionMode ? '退出多选' : '多选'"
+          @click="toggleSelectionMode"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <polyline v-if="selectionMode" points="18 6 6 18"/><polyline v-if="selectionMode" points="6 6 18 18"/>
+            <template v-else><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></template>
+          </svg>
+        </button>
         <button class="icon-btn" title="关闭隐阅窗口" @click="handleHideHushreaderWindow">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/>
@@ -513,6 +887,12 @@ const cfg = computed(() => configStore.config)
 
     <!-- Category tabs -->
     <div class="category-bar">
+      <button
+        v-if="selectionMode"
+        class="category-tab select-all-btn"
+        :class="{ active: bookStore.filteredBooks.length > 0 && bookStore.filteredBooks.every(b => selectedIds.has(b.id)) }"
+        @click="selectAllInCategory"
+      >全选</button>
       <button
         v-for="cat in bookStore.categories"
         :key="cat"
@@ -564,7 +944,10 @@ const cfg = computed(() => configStore.config)
         :key="book.id"
         :book="book"
         :list-mode="cfg.other.listMode"
-        @click="openBookAndHushreader?.(book.id)"
+        :selection-mode="selectionMode"
+        :selected="selectedIds.has(book.id)"
+        @click="!selectionMode && openBookAndHushreader?.(book.id)"
+        @toggle-select="toggleBookSelect(book.id)"
         @contextmenu.prevent="onContextMenu(book.id, $event)"
         @cover-error="repairCover(book.id)"
       />
@@ -582,11 +965,14 @@ const cfg = computed(() => configStore.config)
     <ContextMenu
       v-if="contextMenuBook"
       :pos="contextMenuPos"
+      @book-info="openBookInfo(contextMenuBook!)"
       @chapter-list="openChapterList(contextMenuBook!)"
       @change-path="openPathModal(contextMenuBook!)"
       @edit-metadata="openMetadataModal(contextMenuBook!)"
+      @reload-metadata="openReloadMetadata(contextMenuBook!)"
       @set-category="openCategoryModal(contextMenuBook!)"
       @set-cover="openCoverPicker(contextMenuBook!)"
+      @restore-cover="openRestoreCover(contextMenuBook!)"
       @delete="openDeleteModal(contextMenuBook!)"
       @close="closeContextMenu"
     />
@@ -679,6 +1065,57 @@ const cfg = computed(() => configStore.config)
       </div>
     </Modal>
 
+    <!-- Drop Confirm Modal -->
+    <Modal v-if="showDropConfirmModal" title="导入书籍" @close="cancelDropImport">
+      <div class="form-modal">
+        <p style="margin: 0 0 8px; color: var(--c-ink)">检测到拖入的书籍文件，是否导入到书架？</p>
+        <div class="drop-file-list">
+          <div v-for="(f, i) in pendingDropFiles" :key="i" class="drop-file-item">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+            </svg>
+            <span>{{ f.name }}</span>
+          </div>
+        </div>
+        <div class="form-actions">
+          <button class="btn-secondary" @click="cancelDropImport">取消</button>
+          <button class="btn-primary" @click="confirmDropImport">导入</button>
+        </div>
+      </div>
+    </Modal>
+
+    <!-- Batch action bar -->
+    <div v-if="selectionMode" class="batch-bar">
+      <span class="batch-info">已选 {{ selectedCount }} 本</span>
+      <div class="batch-actions">
+        <button class="btn-secondary" :disabled="selectedCount === 0 || batchReloading" @click="batchReload">
+          <span v-if="batchReloading" class="spinner" style="width:14px;height:14px;border-width:1.5px;margin-right:4px"></span>
+          批量重载
+        </button>
+        <button class="btn-danger" :disabled="selectedCount === 0" @click="openBatchDelete">批量删除</button>
+        <button class="btn-ghost" @click="exitSelectionMode">取消</button>
+      </div>
+    </div>
+
+    <!-- Batch Delete Confirm Modal -->
+    <Modal v-if="showBatchDeleteModal" title="批量删除" @close="showBatchDeleteModal = false">
+      <div class="form-modal">
+        <p style="margin: 0 0 16px; color: var(--c-ink)">确定从书架中删除选中的 {{ selectedCount }} 本书吗？本地文件不会被删除。</p>
+        <div class="form-actions">
+          <button class="btn-secondary" @click="showBatchDeleteModal = false">取消</button>
+          <button class="btn-danger" @click="confirmBatchDelete">删除</button>
+        </div>
+      </div>
+    </Modal>
+
+    <!-- Book Info Modal -->
+    <BookInfoModal
+      v-if="showBookInfo && bookInfoId"
+      :book="bookStore.books.find(b => b.id === bookInfoId)!"
+      @close="showBookInfo = false"
+      @saved="onBookInfoSaved"
+    />
+
     <!-- Toast -->
     <Toast :message="toastMsg" :type="toastType" />
 
@@ -697,6 +1134,25 @@ const cfg = computed(() => configStore.config)
   background: var(--c-surface);
   color: var(--c-ink);
   overflow: hidden;
+  position: relative;
+}
+
+.drop-overlay {
+  position: absolute;
+  inset: 10px;
+  z-index: 20;
+  pointer-events: none;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 10px;
+  border: 1px dashed var(--c-accent);
+  border-radius: var(--radius-lg);
+  background: color-mix(in srgb, var(--c-surface) 86%, transparent);
+  color: var(--c-accent);
+  font-weight: 800;
+  font-size: 14px;
+  backdrop-filter: blur(18px);
 }
 
 .shelf-header {
@@ -1042,6 +1498,108 @@ const cfg = computed(() => configStore.config)
   color: var(--c-ink-inverse);
 }
 .btn-danger:hover { opacity: 0.85; }
+
+.drop-file-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 8px 0 12px;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.drop-file-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--c-surface-sunken);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  color: var(--c-ink-secondary);
+}
+
+.drop-file-item svg {
+  flex-shrink: 0;
+  color: var(--c-accent);
+}
+
+.drop-file-item span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.batch-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  background: var(--c-surface-overlay);
+  border-top: 1px solid var(--c-border);
+  box-shadow: var(--shadow-xl);
+  animation: slide-up 0.15s var(--ease-out);
+}
+
+.batch-info {
+  font-size: 13px;
+  color: var(--c-ink-secondary);
+  font-weight: 500;
+}
+
+.batch-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.batch-actions .btn-secondary,
+.batch-actions .btn-danger {
+  display: flex;
+  align-items: center;
+  padding: 7px 16px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  font-weight: 500;
+  transition: all 0.15s var(--ease-out);
+}
+
+.batch-actions .btn-secondary {
+  background: var(--c-surface-sunken);
+  color: var(--c-ink);
+}
+.batch-actions .btn-secondary:hover:not(:disabled) { background: var(--c-border); }
+.batch-actions .btn-danger {
+  background: var(--c-danger);
+  color: var(--c-ink-inverse);
+}
+.batch-actions .btn-danger:hover:not(:disabled) { opacity: 0.85; }
+.batch-actions .btn-secondary:disabled,
+.batch-actions .btn-danger:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.batch-actions .btn-ghost {
+  color: var(--c-ink-tertiary);
+  font-size: 13px;
+  padding: 7px 12px;
+}
+.batch-actions .btn-ghost:hover { color: var(--c-ink); }
+
+.select-all-btn {
+  font-weight: 600;
+}
+
+.icon-btn.active {
+  background: var(--c-accent-soft);
+  color: var(--c-accent);
+}
 
 .theme-toggle-fab {
   position: fixed;

--- a/plugins/hushreader/src/components/Bookshelf/index.vue
+++ b/plugins/hushreader/src/components/Bookshelf/index.vue
@@ -230,7 +230,7 @@ function openCoverPicker(bookId: string) {
     reader.onload = () => {
       const data = reader.result as string
       bookStore.updateBook(bookId, { customCoverImage: data, updatedAt: Date.now() })
-      saveCustomCover(bookId, data).catch(() => {})
+      saveCustomCover(bookId, data).catch(() => { })
       toast('封面已更新', 'success')
     }
     reader.readAsDataURL(file)
@@ -242,14 +242,14 @@ async function repairCover(bookId: string) {
   const book = bookStore.books.find(b => b.id === bookId)
   if (!book || book.format !== 'epub' || configStore.config.other.plainTextCover) {
     bookStore.updateBook(bookId, { coverImage: undefined })
-    removeCover(bookId).catch(() => {})
+    removeCover(bookId).catch(() => { })
     return
   }
   try {
     const content = window.services?.readFileBinary?.(book.filePath)
     if (!content) {
       bookStore.updateBook(bookId, { coverImage: undefined })
-      removeCover(bookId).catch(() => {})
+      removeCover(bookId).catch(() => { })
       return
     }
     const blob = new Blob([content], { type: 'application/epub+zip' })
@@ -257,14 +257,14 @@ async function repairCover(bookId: string) {
     const result = await parseEpub(file)
     if (result.coverUrl) {
       bookStore.updateBook(bookId, { coverImage: result.coverUrl })
-      saveCover(bookId, result.coverUrl).catch(() => {})
+      saveCover(bookId, result.coverUrl).catch(() => { })
     } else {
       bookStore.updateBook(bookId, { coverImage: undefined })
-      removeCover(bookId).catch(() => {})
+      removeCover(bookId).catch(() => { })
     }
   } catch {
     bookStore.updateBook(bookId, { coverImage: undefined })
-    removeCover(bookId).catch(() => {})
+    removeCover(bookId).catch(() => { })
   }
 }
 
@@ -273,18 +273,18 @@ async function restoreCover(bookId: string) {
   if (!book) return
 
   bookStore.updateBook(bookId, { customCoverImage: undefined })
-  removeCustomCover(bookId).catch(() => {})
+  removeCustomCover(bookId).catch(() => { })
 
   if (book.format === 'txt') {
     bookStore.updateBook(bookId, { coverImage: undefined })
-    removeCover(bookId).catch(() => {})
+    removeCover(bookId).catch(() => { })
     toast('封面已恢复为纯色', 'success')
     return
   }
 
   if (configStore.config.other.plainTextCover) {
     bookStore.updateBook(bookId, { coverImage: undefined })
-    removeCover(bookId).catch(() => {})
+    removeCover(bookId).catch(() => { })
     toast('封面已恢复', 'success')
     return
   }
@@ -293,7 +293,7 @@ async function restoreCover(bookId: string) {
     const content = window.services?.readFileBinary?.(book.filePath)
     if (!content) {
       bookStore.updateBook(bookId, { coverImage: undefined })
-      removeCover(bookId).catch(() => {})
+      removeCover(bookId).catch(() => { })
       toast('封面已恢复', 'success')
       return
     }
@@ -313,15 +313,15 @@ async function restoreCover(bookId: string) {
 
     if (coverImage) {
       bookStore.updateBook(bookId, { coverImage })
-      saveCover(bookId, coverImage).catch(() => {})
+      saveCover(bookId, coverImage).catch(() => { })
     } else {
       bookStore.updateBook(bookId, { coverImage: undefined })
-      removeCover(bookId).catch(() => {})
+      removeCover(bookId).catch(() => { })
     }
     toast('封面已恢复', 'success')
   } catch {
     bookStore.updateBook(bookId, { coverImage: undefined })
-    removeCover(bookId).catch(() => {})
+    removeCover(bookId).catch(() => { })
     toast('封面已恢复', 'success')
   }
 }
@@ -339,12 +339,13 @@ const deleteBookId = ref<string | null>(null)
 const showBookInfo = ref(false)
 const bookInfoId = ref<string | null>(null)
 
+const bookInfoBook = computed(() => bookStore.books.find(b => b.id === bookInfoId.value))
+
 function openBookInfo(bookId: string) {
   closeContextMenu()
   bookInfoId.value = bookId
   showBookInfo.value = true
 }
-
 function onBookInfoSaved(updates: Partial<typeof bookStore.books[0]>) {
   if (!bookInfoId.value) return
   bookStore.updateBook(bookInfoId.value, updates)
@@ -378,50 +379,54 @@ async function reloadMetadata(bookId: string, silent = false) {
 
     if (book.format === 'epub') {
       const content = window.services?.readFileBinary?.(book.filePath)
-      if (content) {
-        const blob = new Blob([content], { type: 'application/epub+zip' })
-        const file = new File([blob], book.filePath.split(/[\\/]/).pop() ?? 'book.epub')
-        const result = await parseEpub(file)
-        title = result.title || title
-        author = result.author || author
-        description = result.description || description
-        totalChapters = result.chapters?.length
-        if (result.coverUrl && !configStore.config.other.plainTextCover) coverImage = result.coverUrl
-        if (result.chapters?.length) saveChapters(bookId, result.chapters).catch(() => {})
+      if (!content) {
+        throw new Error('无法读取文件，请检查文件是否存在或路径是否正确')
       }
+      const blob = new Blob([content], { type: 'application/epub+zip' })
+      const file = new File([blob], book.filePath.split(/[\\/]/).pop() ?? 'book.epub')
+      const result = await parseEpub(file)
+      title = result.title || title
+      author = result.author || author
+      description = result.description || description
+      totalChapters = result.chapters?.length
+      if (result.coverUrl && !configStore.config.other.plainTextCover) coverImage = result.coverUrl
+      if (result.chapters?.length) saveChapters(bookId, result.chapters).catch(() => { })
     } else if (book.format === 'mobi') {
       const content = window.services?.readFileBinary?.(book.filePath)
-      if (content) {
-        const blob = new Blob([content], { type: 'application/x-mobipocket-ebook' })
-        const file = new File([blob], book.filePath.split(/[\\/]/).pop() ?? 'book.mobi')
-        const result = await parseMobi(file)
-        if (!result.error) {
-          title = result.title || title
-          author = result.author || author
-          description = result.description || description
-          totalChapters = result.chapters?.length
-          if (result.coverUrl && !configStore.config.other.plainTextCover) coverImage = result.coverUrl
-          if (result.chapters?.length) saveChapters(bookId, result.chapters).catch(() => {})
-        }
+      if (!content) {
+        throw new Error('无法读取文件，请检查文件是否存在或路径是否正确')
       }
+      const blob = new Blob([content], { type: 'application/x-mobipocket-ebook' })
+      const file = new File([blob], book.filePath.split(/[\\/]/).pop() ?? 'book.mobi')
+      const result = await parseMobi(file)
+      if (result.error) { throw new Error(result.error) }
+      title = result.title || title
+      author = result.author || author
+      description = result.description || description
+      totalChapters = result.chapters?.length
+      if (result.coverUrl && !configStore.config.other.plainTextCover) coverImage = result.coverUrl
+      if (result.chapters?.length) saveChapters(bookId, result.chapters).catch(() => { })
     } else {
-      const text = window.services?.readFile(book.filePath) ?? ''
+      const text = window.services?.readFile(book.filePath)
+      if (text === undefined || text === null) {
+        throw new Error('无法读取文件，请检查文件是否存在或路径是否正确')
+      }
       const chapters = parseTxt(text, configStore.config.other.chapterRegex || undefined)
       totalChapters = chapters.length
-      if (chapters.length) saveChapters(bookId, chapters).catch(() => {})
+      if (chapters.length) saveChapters(bookId, chapters).catch(() => { })
     }
 
     const fileModifiedAt = window.services?.getFileModifiedTime?.(book.filePath)
     const updates: Partial<typeof book> = { title, author, description: description || undefined, totalChapters, fileModifiedAt, customCoverImage: undefined }
 
-    removeCustomCover(bookId).catch(() => {})
+    removeCustomCover(bookId).catch(() => { })
 
     if (coverImage) {
       updates.coverImage = coverImage
-      saveCover(bookId, coverImage).catch(() => {})
+      saveCover(bookId, coverImage).catch(() => { })
     } else {
       updates.coverImage = undefined
-      removeCover(bookId).catch(() => {})
+      removeCover(bookId).catch(() => { })
     }
 
     bookStore.updateBook(bookId, updates)
@@ -540,7 +545,7 @@ async function importBook(filePath: string) {
           description = result.description || ''
           if (result.coverUrl && !configStore.config.other.plainTextCover) coverImage = result.coverUrl
         }
-      } catch {}
+      } catch { }
     }
 
     if (isMobi) {
@@ -573,7 +578,7 @@ async function importBook(filePath: string) {
     })
 
     if (book) {
-      if (coverImage) saveCover(book.id, coverImage).catch(() => {})
+      if (coverImage) saveCover(book.id, coverImage).catch(() => { })
       toast(`《${title}》已加入书架`, 'success')
     } else {
       toast('该书籍已在书架中', 'info')
@@ -610,7 +615,7 @@ async function importDroppedFile(file: File) {
         author = result.author || ''
         description = result.description || ''
         if (result.coverUrl && !configStore.config.other.plainTextCover) coverImage = result.coverUrl
-      } catch {}
+      } catch { }
     }
 
     if (isMobi) {
@@ -635,7 +640,7 @@ async function importDroppedFile(file: File) {
     })
 
     if (book) {
-      if (coverImage) saveCover(book.id, coverImage).catch(() => {})
+      if (coverImage) saveCover(book.id, coverImage).catch(() => { })
       toast(`《${title}》已加入书架`, 'success')
     } else {
       toast('该书籍已在书架中', 'info')
@@ -783,9 +788,9 @@ async function resolveEpubCovers() {
       const result = await parseEpub(file)
       if (result.coverUrl) {
         book.coverImage = result.coverUrl
-        saveCover(book.id, result.coverUrl).catch(() => {})
+        saveCover(book.id, result.coverUrl).catch(() => { })
       }
-    } catch {}
+    } catch { }
   }
 }
 
@@ -806,9 +811,9 @@ async function resolveMobiCovers() {
       const result = await parseMobi(file)
       if (result.coverUrl) {
         book.coverImage = result.coverUrl
-        saveCover(book.id, result.coverUrl).catch(() => {})
+        saveCover(book.id, result.coverUrl).catch(() => { })
       }
-    } catch {}
+    } catch { }
   }
 }
 
@@ -841,7 +846,9 @@ const cfg = computed(() => configStore.config)
     <!-- Drop overlay -->
     <div v-if="fileHovering" class="drop-overlay">
       <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/>
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+        <polyline points="17 8 12 3 7 8" />
+        <line x1="12" y1="3" x2="12" y2="15" />
       </svg>
       <span>导入书籍</span>
     </div>
@@ -850,36 +857,37 @@ const cfg = computed(() => configStore.config)
       <h1 class="shelf-title">书架</h1>
       <div class="shelf-search">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/>
+          <circle cx="11" cy="11" r="8" />
+          <path d="m21 21-4.35-4.35" />
         </svg>
-        <input
-          v-model="bookStore.searchQuery"
-          class="search-input"
-          placeholder="搜索书名或作者..."
-        />
+        <input v-model="bookStore.searchQuery" class="search-input" placeholder="搜索书名或作者..." />
       </div>
       <div class="shelf-actions">
-        <button
-          class="icon-btn"
-          :class="{ active: selectionMode }"
-          :title="selectionMode ? '退出多选' : '多选'"
-          @click="toggleSelectionMode"
-        >
+        <button class="icon-btn" :class="{ active: selectionMode }" :title="selectionMode ? '退出多选' : '多选'"
+          @click="toggleSelectionMode">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <polyline v-if="selectionMode" points="18 6 6 18"/><polyline v-if="selectionMode" points="6 6 18 18"/>
-            <template v-else><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></template>
+            <polyline v-if="selectionMode" points="18 6 6 18" />
+            <polyline v-if="selectionMode" points="6 6 18 18" />
+            <template v-else>
+              <rect x="3" y="3" width="7" height="7" rx="1" />
+              <rect x="14" y="3" width="7" height="7" rx="1" />
+              <rect x="3" y="14" width="7" height="7" rx="1" />
+              <rect x="14" y="14" width="7" height="7" rx="1" />
+            </template>
           </svg>
         </button>
         <button class="icon-btn" title="关闭隐阅窗口" @click="handleHideHushreaderWindow">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/>
-            <line x1="1" y1="1" x2="23" y2="23"/>
+            <path
+              d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24" />
+            <line x1="1" y1="1" x2="23" y2="23" />
           </svg>
         </button>
         <button class="icon-btn" title="设置" @click="showSettings = true">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <circle cx="12" cy="12" r="3"/>
-            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+            <circle cx="12" cy="12" r="3" />
+            <path
+              d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
           </svg>
         </button>
       </div>
@@ -887,40 +895,20 @@ const cfg = computed(() => configStore.config)
 
     <!-- Category tabs -->
     <div class="category-bar">
-      <button
-        v-if="selectionMode"
-        class="category-tab select-all-btn"
+      <button v-if="selectionMode" class="category-tab select-all-btn"
         :class="{ active: bookStore.filteredBooks.length > 0 && bookStore.filteredBooks.every(b => selectedIds.has(b.id)) }"
-        @click="selectAllInCategory"
-      >全选</button>
-      <button
-        v-for="cat in bookStore.categories"
-        :key="cat"
-        class="category-tab"
-        :class="{ active: bookStore.activeCategory === cat }"
-        @click="bookStore.activeCategory = cat"
-      >{{ cat }}</button>
+        @click="selectAllInCategory">全选</button>
+      <button v-for="cat in bookStore.categories" :key="cat" class="category-tab"
+        :class="{ active: bookStore.activeCategory === cat }" @click="bookStore.activeCategory = cat">{{ cat }}</button>
       <div class="sort-group">
-        <button
-          class="sort-btn"
-          :class="{ active: bookStore.sortBy === 'lastReadAt' }"
-          @click="bookStore.sortBy = 'lastReadAt'"
-        >最近阅读</button>
-        <button
-          class="sort-btn"
-          :class="{ active: bookStore.sortBy === 'addedAt' }"
-          @click="bookStore.sortBy = 'addedAt'"
-        >最近添加</button>
-        <button
-          class="sort-btn"
-          :class="{ active: bookStore.sortBy === 'name' }"
-          @click="bookStore.sortBy = 'name'"
-        >名称</button>
-        <button
-          class="sort-btn"
-          :class="{ active: bookStore.sortBy === 'author' }"
-          @click="bookStore.sortBy = 'author'"
-        >作者</button>
+        <button class="sort-btn" :class="{ active: bookStore.sortBy === 'lastReadAt' }"
+          @click="bookStore.sortBy = 'lastReadAt'">最近阅读</button>
+        <button class="sort-btn" :class="{ active: bookStore.sortBy === 'addedAt' }"
+          @click="bookStore.sortBy = 'addedAt'">最近添加</button>
+        <button class="sort-btn" :class="{ active: bookStore.sortBy === 'name' }"
+          @click="bookStore.sortBy = 'name'">名称</button>
+        <button class="sort-btn" :class="{ active: bookStore.sortBy === 'author' }"
+          @click="bookStore.sortBy = 'author'">作者</button>
       </div>
     </div>
 
@@ -929,8 +917,9 @@ const cfg = computed(() => configStore.config)
       <!-- Add book card -->
       <div class="add-book-card" @click="handleAddBook" :class="{ loading: isLoading }">
         <div class="add-icon">
-          <svg v-if="!isLoading" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
-            <path d="M12 5v14M5 12h14"/>
+          <svg v-if="!isLoading" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+            stroke-width="1.5">
+            <path d="M12 5v14M5 12h14" />
           </svg>
           <div v-else class="spinner"></div>
         </div>
@@ -939,43 +928,28 @@ const cfg = computed(() => configStore.config)
       </div>
 
       <!-- Book cards -->
-      <BookCard
-        v-for="book in bookStore.filteredBooks"
-        :key="book.id"
-        :book="book"
-        :list-mode="cfg.other.listMode"
-        :selection-mode="selectionMode"
-        :selected="selectedIds.has(book.id)"
-        @click="!selectionMode && openBookAndHushreader?.(book.id)"
-        @toggle-select="toggleBookSelect(book.id)"
-        @contextmenu.prevent="onContextMenu(book.id, $event)"
-        @cover-error="repairCover(book.id)"
-      />
+      <BookCard v-for="book in bookStore.filteredBooks" :key="book.id" :book="book" :list-mode="cfg.other.listMode"
+        :selection-mode="selectionMode" :selected="selectedIds.has(book.id)"
+        @click="!selectionMode && openBookAndHushreader?.(book.id)" @toggle-select="toggleBookSelect(book.id)"
+        @contextmenu.prevent="onContextMenu(book.id, $event)" @cover-error="repairCover(book.id)" />
     </main>
 
     <!-- Empty state -->
     <div v-if="bookStore.filteredBooks.length === 0 && !isLoading" class="empty-state">
       <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1">
-        <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+        <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+        <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
       </svg>
       <p>{{ bookStore.searchQuery ? '未找到匹配的书籍' : '书架空空如也，添加一本书开始阅读吧' }}</p>
     </div>
 
     <!-- Context Menu -->
-    <ContextMenu
-      v-if="contextMenuBook"
-      :pos="contextMenuPos"
-      @book-info="openBookInfo(contextMenuBook!)"
-      @chapter-list="openChapterList(contextMenuBook!)"
-      @change-path="openPathModal(contextMenuBook!)"
-      @edit-metadata="openMetadataModal(contextMenuBook!)"
-      @reload-metadata="openReloadMetadata(contextMenuBook!)"
-      @set-category="openCategoryModal(contextMenuBook!)"
-      @set-cover="openCoverPicker(contextMenuBook!)"
-      @restore-cover="openRestoreCover(contextMenuBook!)"
-      @delete="openDeleteModal(contextMenuBook!)"
-      @close="closeContextMenu"
-    />
+    <ContextMenu v-if="contextMenuBook" :pos="contextMenuPos" @book-info="openBookInfo(contextMenuBook!)"
+      @chapter-list="openChapterList(contextMenuBook!)" @change-path="openPathModal(contextMenuBook!)"
+      @edit-metadata="openMetadataModal(contextMenuBook!)" @reload-metadata="openReloadMetadata(contextMenuBook!)"
+      @set-category="openCategoryModal(contextMenuBook!)" @set-cover="openCoverPicker(contextMenuBook!)"
+      @restore-cover="openRestoreCover(contextMenuBook!)" @delete="openDeleteModal(contextMenuBook!)"
+      @close="closeContextMenu" />
 
     <!-- Settings Modal -->
     <SettingsModal v-if="showSettings" @close="showSettings = false" />
@@ -988,13 +962,8 @@ const cfg = computed(() => configStore.config)
           <span>正在解析章节...</span>
         </div>
         <div v-else class="chapter-items">
-          <button
-            v-for="ch in chapterListItems"
-            :key="ch.index"
-            class="chapter-item"
-            :class="{ current: ch.index === chapterListCurrentIndex }"
-            @click="jumpToChapter(ch.index)"
-          >
+          <button v-for="ch in chapterListItems" :key="ch.index" class="chapter-item"
+            :class="{ current: ch.index === chapterListCurrentIndex }" @click="jumpToChapter(ch.index)">
             <span class="ch-index">{{ ch.index + 1 }}</span>
             <span class="ch-title">{{ ch.title }}</span>
           </button>
@@ -1019,13 +988,8 @@ const cfg = computed(() => configStore.config)
       <div class="form-modal">
         <label class="form-label">已有分类（多选）</label>
         <div v-if="bookStore.categories.length > 1" class="category-tags">
-          <button
-            v-for="cat in bookStore.categories.filter(c => c !== '全部')"
-            :key="cat"
-            class="category-tag"
-            :class="{ active: categoryModalSelected.includes(cat) }"
-            @click="toggleCategorySelection(cat)"
-          >
+          <button v-for="cat in bookStore.categories.filter(c => c !== '全部')" :key="cat" class="category-tag"
+            :class="{ active: categoryModalSelected.includes(cat) }" @click="toggleCategorySelection(cat)">
             {{ cat }}
           </button>
         </div>
@@ -1072,7 +1036,8 @@ const cfg = computed(() => configStore.config)
         <div class="drop-file-list">
           <div v-for="(f, i) in pendingDropFiles" :key="i" class="drop-file-item">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+              <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+              <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
             </svg>
             <span>{{ f.name }}</span>
           </div>
@@ -1089,7 +1054,8 @@ const cfg = computed(() => configStore.config)
       <span class="batch-info">已选 {{ selectedCount }} 本</span>
       <div class="batch-actions">
         <button class="btn-secondary" :disabled="selectedCount === 0 || batchReloading" @click="batchReload">
-          <span v-if="batchReloading" class="spinner" style="width:14px;height:14px;border-width:1.5px;margin-right:4px"></span>
+          <span v-if="batchReloading" class="spinner"
+            style="width:14px;height:14px;border-width:1.5px;margin-right:4px"></span>
           批量重载
         </button>
         <button class="btn-danger" :disabled="selectedCount === 0" @click="openBatchDelete">批量删除</button>
@@ -1109,12 +1075,8 @@ const cfg = computed(() => configStore.config)
     </Modal>
 
     <!-- Book Info Modal -->
-    <BookInfoModal
-      v-if="showBookInfo && bookInfoId"
-      :book="bookStore.books.find(b => b.id === bookInfoId)!"
-      @close="showBookInfo = false"
-      @saved="onBookInfoSaved"
-    />
+    <BookInfoModal v-if="showBookInfo && bookInfoBook" :book="bookInfoBook" @close="showBookInfo = false"
+      @saved="onBookInfoSaved" />
 
     <!-- Toast -->
     <Toast :message="toastMsg" :type="toastType" />
@@ -1236,7 +1198,9 @@ const cfg = computed(() => configStore.config)
   border-bottom: 1px solid var(--c-border);
 }
 
-.category-bar::-webkit-scrollbar { display: none; }
+.category-bar::-webkit-scrollbar {
+  display: none;
+}
 
 .category-tab {
   padding: 5px 12px;
@@ -1346,7 +1310,9 @@ const cfg = computed(() => configStore.config)
   opacity: 0.7;
 }
 
-.shelf-grid.list-mode .add-sub { display: none; }
+.shelf-grid.list-mode .add-sub {
+  display: none;
+}
 
 .spinner {
   width: 20px;
@@ -1408,7 +1374,9 @@ const cfg = computed(() => configStore.config)
   transition: background 0.12s var(--ease-out);
 }
 
-.chapter-item:hover { background: var(--c-surface-sunken); }
+.chapter-item:hover {
+  background: var(--c-surface-sunken);
+}
 
 .chapter-item.current {
   background: var(--c-accent-soft);
@@ -1427,10 +1395,27 @@ const cfg = computed(() => configStore.config)
   font-family: var(--font-mono);
 }
 
-.ch-title { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ch-title {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 
-.form-modal { display: flex; flex-direction: column; gap: 10px; }
-.form-label { font-size: 12px; font-weight: 600; color: var(--c-ink-secondary); text-transform: uppercase; letter-spacing: 0.04em; }
+.form-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.form-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--c-ink-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
 .form-input {
   border: 1px solid var(--c-border);
   background: var(--c-surface);
@@ -1440,12 +1425,23 @@ const cfg = computed(() => configStore.config)
   font-size: 13px;
   transition: border-color 0.15s var(--ease-out), box-shadow 0.15s var(--ease-out);
 }
+
 .form-input:focus {
   border-color: var(--c-accent);
   box-shadow: 0 0 0 3px var(--c-accent-soft);
 }
-.form-hint { font-size: 11px; color: var(--c-ink-tertiary); }
-.form-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 8px; }
+
+.form-hint {
+  font-size: 11px;
+  color: var(--c-ink-tertiary);
+}
+
+.form-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
 
 .category-tags {
   display: flex;
@@ -1476,28 +1472,42 @@ const cfg = computed(() => configStore.config)
   border-color: var(--c-accent);
 }
 
-.btn-primary, .btn-secondary, .btn-danger {
+.btn-primary,
+.btn-secondary,
+.btn-danger {
   padding: 7px 18px;
   border-radius: var(--radius-sm);
   font-size: 13px;
   font-weight: 500;
   transition: all 0.15s var(--ease-out);
 }
+
 .btn-primary {
   background: var(--c-accent);
   color: var(--c-ink-inverse);
 }
-.btn-primary:hover { background: var(--c-accent-hover); }
+
+.btn-primary:hover {
+  background: var(--c-accent-hover);
+}
+
 .btn-secondary {
   background: var(--c-surface-sunken);
   color: var(--c-ink);
 }
-.btn-secondary:hover { background: var(--c-border); }
+
+.btn-secondary:hover {
+  background: var(--c-border);
+}
+
 .btn-danger {
   background: var(--c-danger);
   color: var(--c-ink-inverse);
 }
-.btn-danger:hover { opacity: 0.85; }
+
+.btn-danger:hover {
+  opacity: 0.85;
+}
 
 .drop-file-list {
   display: flex;
@@ -1573,12 +1583,20 @@ const cfg = computed(() => configStore.config)
   background: var(--c-surface-sunken);
   color: var(--c-ink);
 }
-.batch-actions .btn-secondary:hover:not(:disabled) { background: var(--c-border); }
+
+.batch-actions .btn-secondary:hover:not(:disabled) {
+  background: var(--c-border);
+}
+
 .batch-actions .btn-danger {
   background: var(--c-danger);
   color: var(--c-ink-inverse);
 }
-.batch-actions .btn-danger:hover:not(:disabled) { opacity: 0.85; }
+
+.batch-actions .btn-danger:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
 .batch-actions .btn-secondary:disabled,
 .batch-actions .btn-danger:disabled {
   opacity: 0.4;
@@ -1590,7 +1608,10 @@ const cfg = computed(() => configStore.config)
   font-size: 13px;
   padding: 7px 12px;
 }
-.batch-actions .btn-ghost:hover { color: var(--c-ink); }
+
+.batch-actions .btn-ghost:hover {
+  color: var(--c-ink);
+}
 
 .select-all-btn {
   font-weight: 600;

--- a/plugins/hushreader/src/components/Settings/index.vue
+++ b/plugins/hushreader/src/components/Settings/index.vue
@@ -437,13 +437,13 @@ function commitCapture(targetArr: string[]) {
           <div class="section-label">解析</div>
 
           <div class="setting-row" style="align-items: flex-start; flex-direction: column; gap: 6px;">
-            <label>TXT 章节识别正则</label>
+            <label>TXT 章节识别正则 <span class="tip-icon" tabindex="0">ⓘ<span class="tip-bubble">默认规则：匹配以"第"开头，后跟中文数字（零一二三…）或阿拉伯数字，再跟"章/节/卷/集/部"的行，如"第三章 大战"、第12卷 等</span></span></label>
             <input
               v-model="cfg.other.chapterRegex"
               class="text-input full-width"
               placeholder="留空使用默认规则（第X章...）"
             />
-            <p class="hint" style="margin:0">支持标准 JavaScript 正则语法，EPUB 使用内置章节标识</p>
+            <p class="hint" style="margin:0">支持标准 JavaScript 正则语法，EPUB/MOBI 使用内置章节标识</p>
           </div>
 
           <div class="divider"></div>
@@ -719,6 +719,55 @@ function commitCapture(targetArr: string[]) {
 .full-width { width: 100%; }
 
 .hint { font-size: 11px; color: var(--c-ink-tertiary); margin: 0 0 6px; }
+
+.tip-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  font-size: 12px;
+  color: var(--c-ink-tertiary);
+  cursor: help;
+  vertical-align: middle;
+  margin-left: 4px;
+  border-radius: 50%;
+  transition: color 0.15s var(--ease-out);
+}
+.tip-icon:hover,
+.tip-icon:focus { color: var(--c-accent); }
+.tip-bubble {
+  display: none;
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  transform: translateX(-50%);
+  width: 260px;
+  padding: 10px 12px;
+  background: var(--c-surface-overlay);
+  border: 1px solid var(--c-border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-xl);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.6;
+  color: var(--c-ink);
+  white-space: normal;
+  z-index: 100;
+  pointer-events: none;
+}
+.tip-bubble::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 6px solid transparent;
+  border-top-color: var(--c-surface-overlay);
+}
+.tip-icon:hover .tip-bubble,
+.tip-icon:focus .tip-bubble { display: block; }
 
 .toggle {
   position: relative;

--- a/plugins/hushreader/src/stores/books.ts
+++ b/plugins/hushreader/src/stores/books.ts
@@ -6,6 +6,7 @@ export interface Book {
   id: string
   title: string
   author: string
+  description?: string
   format: 'epub' | 'txt' | 'mobi'
   filePath: string
   coverColor?: string
@@ -13,12 +14,17 @@ export interface Book {
   customCoverImage?: string
   categories?: string[]
   addedAt: number
+  updatedAt?: number
+  firstReadAt?: number
   lastReadAt?: number
   lastChapter?: number
   lastPage?: number
   progressIndex?: number
   totalChapters?: number
   readingPercent?: number
+  readingTimeMs?: number
+  readingSpeed?: number
+  lastSaveReadChars?: number
   fileModifiedAt?: number | null
 }
 
@@ -103,12 +109,14 @@ export const useBookStore = defineStore('books', () => {
     }
   }
 
-  function addBook(book: Omit<Book, 'id' | 'addedAt'>) {
+  function addBook(book: Omit<Book, 'id' | 'addedAt' | 'updatedAt'>) {
     if (books.value.some(b => b.filePath === book.filePath)) return undefined
+    const now = Date.now()
     const newBook: Book = {
       ...book,
-      id: `book_${Date.now()}_${Math.random().toString(36).slice(2)}`,
-      addedAt: Date.now()
+      id: `book_${now}_${Math.random().toString(36).slice(2)}`,
+      addedAt: now,
+      updatedAt: now
     }
     books.value.unshift(newBook)
     save()

--- a/plugins/hushreader/src/stores/books.ts
+++ b/plugins/hushreader/src/stores/books.ts
@@ -110,7 +110,12 @@ export const useBookStore = defineStore('books', () => {
   }
 
   function addBook(book: Omit<Book, 'id' | 'addedAt' | 'updatedAt'>) {
-    if (books.value.some(b => b.filePath === book.filePath)) return undefined
+    const filePathName = book.filePath.split(/[\\/]/).pop() ?? book.filePath
+    if (books.value.some(b => {
+      if (b.filePath === book.filePath) return true
+      const existingName = b.filePath.split(/[\\/]/).pop() ?? b.filePath
+      return existingName === filePathName
+    })) return undefined
     const now = Date.now()
     const newBook: Book = {
       ...book,

--- a/plugins/hushreader/src/utils/epubParser.ts
+++ b/plugins/hushreader/src/utils/epubParser.ts
@@ -8,6 +8,7 @@ import { preprocessText } from './txtParser'
 export async function parseEpub(file: File): Promise<{
   title: string
   author: string
+  description: string
   chapters: Chapter[]
   coverUrl?: string
 }> {
@@ -20,6 +21,7 @@ export async function parseEpub(file: File): Promise<{
   const metadata = await book.loaded.metadata
   const title = (metadata as any).title || file.name.replace(/\.epub$/i, '')
   const author = (metadata as any).creator || ''
+  const description = (metadata as any).description || ''
 
   // 尝试获取封面
   let coverUrl: string | undefined
@@ -113,7 +115,7 @@ export async function parseEpub(file: File): Promise<{
 
   try { book.destroy() } catch { }
 
-  return { title, author, chapters, coverUrl }
+  return { title, author, description, chapters, coverUrl }
 }
 
 interface ExtractResult {

--- a/plugins/hushreader/src/utils/mobiParser.ts
+++ b/plugins/hushreader/src/utils/mobiParser.ts
@@ -237,8 +237,13 @@ function extractCoverUrl(
     const mime = detectImageMime(imageBytes)
     if (!mime) return undefined
 
-    const blob = new Blob([imageBytes], { type: mime })
-    return URL.createObjectURL(blob)
+    // 同步转换为 Base64，确保可以被 IndexedDB 永久缓存
+    let binary = ''
+    const len = imageBytes.byteLength
+    for (let i = 0; i < len; i++) {
+      binary += String.fromCharCode(imageBytes[i])
+    }
+    return `data:${mime};base64,${btoa(binary)}`
   } catch {
     return undefined
   }

--- a/plugins/hushreader/src/utils/mobiParser.ts
+++ b/plugins/hushreader/src/utils/mobiParser.ts
@@ -375,6 +375,7 @@ function encryptionAdvisory(type: number): string {
 export async function parseMobi(file: File): Promise<{
   title: string
   author: string
+  description: string
   chapters: Chapter[]
   coverUrl?: string
   encrypted?: boolean
@@ -384,7 +385,7 @@ export async function parseMobi(file: File): Promise<{
   const data = new Uint8Array(buffer)
 
   if (data.length < PALMDB_HEADER_SIZE + RECORD_INFO_SIZE) {
-    return { title: '', author: '', chapters: [], error: '文件太小，不是有效的MOBI文件' }
+    return { title: '', author: '', description: '', chapters: [], error: '文件太小，不是有效的MOBI文件' }
   }
 
   // The PDB header's own record count (not the PalmDOC "text record count")
@@ -393,12 +394,12 @@ export async function parseMobi(file: File): Promise<{
   const recordOffsets = getPalmDBRecordOffsets(data, totalPdbRecordCount)
 
   if (recordOffsets.length === 0) {
-    return { title: '', author: '', chapters: [], error: '无法读取MOBI文件的记录索引' }
+    return { title: '', author: '', description: '', chapters: [], error: '无法读取MOBI文件的记录索引' }
   }
 
   const firstRecordOffset = recordOffsets[0]
   if (firstRecordOffset + 16 > data.length) {
-    return { title: '', author: '', chapters: [], error: 'MOBI文件格式损坏或记录偏移越界' }
+    return { title: '', author: '', description: '', chapters: [], error: 'MOBI文件格式损坏或记录偏移越界' }
   }
   const palmDocHeader = parsePalmDocHeader(data, firstRecordOffset)
   const mobiHeader = parseMobiHeader(data, firstRecordOffset)
@@ -407,6 +408,7 @@ export async function parseMobi(file: File): Promise<{
   // ---- when the book's text content is DRM-protected, so it always works. ----
   let title = file.name.replace(/\.mobi$/i, '')
   let author = ''
+  let description = ''
   let exthRecords: EXTHRecord[] = []
 
   if (mobiHeader) {
@@ -428,6 +430,11 @@ export async function parseMobi(file: File): Promise<{
       if (authorRecord && authorRecord.text.trim()) {
         author = authorRecord.text.trim()
       }
+
+      const descRecord = findExthRecord(exthRecords, 101) // EXTH 101 = description
+      if (descRecord && descRecord.text.trim()) {
+        description = descRecord.text.trim()
+      }
     }
   }
 
@@ -441,6 +448,7 @@ export async function parseMobi(file: File): Promise<{
     return {
       title,
       author,
+      description,
       chapters: [],
       coverUrl,
       encrypted: true,
@@ -452,6 +460,7 @@ export async function parseMobi(file: File): Promise<{
     return {
       title,
       author,
+      description,
       chapters: [],
       coverUrl,
       error: '该书使用 HUFF/CDIC 高压缩格式，当前暂不支持解析正文（这与加密无关，是另一种压缩方案）。'
@@ -517,5 +526,5 @@ export async function parseMobi(file: File): Promise<{
     }
   }
 
-  return { title, author, chapters, coverUrl }
+  return { title, author, description, chapters, coverUrl }
 }


### PR DESCRIPTION
## 插件信息

- **名称**: 隐阅盒
- **插件ID**: hushreader
- **版本**: 1.3.2
- **描述**: 隐阅盒，ZTools自己的摸鱼阅读，支持TXT/EPUB/MOBI格式，沉浸式阅读
- **作者**: meidlinger
- **类型**: 更新

## 本次变更

### Added
- **拖拽导入书籍**：将书籍文件拖入书架界面时，显示拖拽悬停覆盖层提示"导入书籍"，松手后弹出确认弹窗列出待导入文件，确认后解析书籍并保存元数据，取消则放弃导入
- **快捷文件导入**：支持通过 `hushreader-import` 命令从 ztools 快捷导入书籍文件，`onPluginEnter` 触发时自动解析并添加到书架
- **TXT 章节正则提示气泡**：设置页"TXT 章节识别正则"标签旁新增 ⓘ 提示图标，悬停/聚焦时显示默认规则说明
- **重载元数据**：右键菜单新增"重载元数据"选项，重新解析书籍的章节、封面、标题、作者等信息并更新，同时清除自定义封面
- **恢复封面**：右键菜单新增"恢复封面"选项，EPUB/MOBI 删除自定义封面并重新从文件加载封面，TXT 删除自定义封面恢复为纯色封面
- **多选模式**：书架头部新增多选按钮，点击进入多选模式，可逐个勾选书籍或通过分类栏"全选"按钮批量选中当前分类下所有书籍
- **批量操作**：多选模式下底部显示操作栏，支持批量重载元数据和批量删除，批量删除前弹出确认弹窗

- **书籍信息窗口**：右键菜单新增"书籍信息"选项，打开信息窗口展示封面与标题作者、简介、分类、阅读信息（导入/更新/首次阅读/最近阅读时间、阅读时长、阅读速度）；支持编辑模式可上传自定义封面、编辑标题/作者/简介、选择已有分类或新建分类
- **EPUB/MOBI 简介解析**：导入和重载元数据时从 EPUB metadata.description 和 MOBI EXTH record 101 提取书籍简介
- **阅读进度追踪**：保存阅读进度时记录首次阅读时间（firstReadAt）、累计阅读时长（readingTimeMs）、阅读速度（readingSpeed）
- **updatedAt 时间戳**：书籍新增时设置 updatedAt = addedAt，编辑元数据或上传封面时更新 updatedAt，分类变更不更新 updatedAt

### Fixed
- **修复拖拽文件时的路径保存错误**：修复了在拖拽文件导入书籍时，路径保存错误导致相同书籍可以重复导入的问题
- **阅读时长与速度统计逻辑修复**：修复了新会话第一页阅读时间丢失和闲置/关闭期间时间被错误计入的问题，确保阅读时长和速度统计准确。
- **MOBI 封面缓存失效与重复解析性能问题**：修复了每次打开书架时，所有 MOBI 书籍都会被重新解析一次的问题。
- **文件读取失败时导致元数据被静默清空**：修复了在文件读取失败时，元数据被静默清空的问题，确保元数据完整。
- **修复书籍信息编辑时分类交互缺陷**：修复了在书籍信息编辑时，分类交互存在的缺陷。


## 截图 / 演示
<img width="1920" height="980" alt="image_91" src="https://github.com/user-attachments/assets/7a12115d-d68c-4f3b-bdd4-92d024a18e1f" />

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/hushreader/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
