### PR TITLE
Update plugin 隐阅盒 v1.3.3

### DIFF
--- a/plugins/hushreader/CHANGELOG.md
+++ b/plugins/hushreader/CHANGELOG.md
@@ -10,11 +10,17 @@ All notable changes to this project will be documented in this file.
 - **备份和恢复所有阅读进度与配置**：备份和恢复所有阅读进度与配置。插件设置导出，所有书籍的元数据导出。实现设置导入，书籍数据导入
 - **多配置切换**：实现多配置切换、添加和删除(最少保留一个配置)，导入的配置自动添加为新配置
 
-### Fixed
-- **配置无法导入的问题**：修复配置无法导入的问题
-
 ### Changed
 - **分离配置和书籍的导入导出**：将配置和书籍的导入导出分离，配置导入导出时仅和配置相关，书籍导入导出时仅和书籍数据相关
+- **定时器相关通知**：在隐阅界面弹出相应通知
+
+### Fixed
+- **配置无法导入的问题**：修复配置无法导入的问题
+- **优化代码** ：减少不必要的性能开销
+- **系统主题自动切换**：修复系统主题发生变化时，systemDark 和 effectiveTheme 无法自动更新
+- **优化书籍导入流程**：在导入书籍的循环中，每次调用 bookStore.addBook(book) 都会触发一次同步的 save() 写入操作（保存到 dbStorage 或 localStorage）。如果用户导入的书籍数量较多，会产生大量连续的同步 I/O 写入
+- **JSON配置导入漏洞**：如果导入的备份 JSON 文件被恶意篡改，包含 __proto__ 或 constructor 等属性，可能会导致原型链污染（Prototype Pollution）漏洞
+
 
 ## [1.3.2](https://github.com/me1dlinger/hushreader/releases/tag/v1.3.2) - 2026-06-18
 

--- a/plugins/hushreader/CHANGELOG.md
+++ b/plugins/hushreader/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [1.3.3](https://github.com/me1dlinger/hushreader/releases/tag/v1.3.3) - 2026-06-19
+
+### Added
+- **自动检测系统深浅色模式**：在插件加载时，根据系统深浅色模式自动切换主题，支持手动切换主题
+- **资源管理器打开文件位置**：在书籍右键菜单新增"打开文件位置"选项，使用ztools.shellShowItemInFolder()
+- **隐阅定时器**：新增设置项，打开定时器后可设置一个时长，隐阅时间到达之后自动关闭隐阅窗口并Toast提示用户
+- **备份和恢复所有阅读进度与配置**：备份和恢复所有阅读进度与配置。插件设置导出，所有书籍的元数据导出。实现设置导入，书籍数据导入
+- **多配置切换**：实现多配置切换、添加和删除(最少保留一个配置)，导入的配置自动添加为新配置
+
+### Fixed
+- **配置无法导入的问题**：修复配置无法导入的问题
+
+### Changed
+- **分离配置和书籍的导入导出**：将配置和书籍的导入导出分离，配置导入导出时仅和配置相关，书籍导入导出时仅和书籍数据相关
 
 ## [1.3.2](https://github.com/me1dlinger/hushreader/releases/tag/v1.3.2) - 2026-06-18
 

--- a/plugins/hushreader/README.md
+++ b/plugins/hushreader/README.md
@@ -10,14 +10,22 @@
 
 ***
 
+[更新日志](./CHANGELOG.md)
+
+***
+
 ## 功能一览
 
 | 阅读体验                | 个性化              | 书架管理              |
 | :------------------ | :--------------- | :---------------- |
-| 沉浸式悬浮窗口，可置于任意位置     | 背景透明度与整体透明度分离控制  | 支持按添加时间、书名、作者排序   |
-| 滚轮翻页 / 快捷键翻页 / 自动翻页 | 自定义字体，支持添加系统字体   | 右键编辑元数据（标题、作者） |
+| 沉浸式悬浮窗口，可置于任意位置     | 背景透明度与整体透明度分离控制  | 支持按添加时间、书名、作者、最近阅读排序 |
+| 滚轮翻页 / 快捷键翻页 / 自动翻页 | 自定义字体，支持添加系统字体   | 右键编辑元数据（标题、作者、分类） |
 | 只显示完整行，文字不残缺       | 十六进制颜色输入 + 颜色选择器 | 阅读进度持久化，关闭再开继续读   |
-| 文本预处理：压缩空行、清理空白     | 设置实时预览，取消可还原     | —                 |
+| 文本预处理：压缩空行、清理空白     | 设置实时预览，取消可还原     | 拖拽导入 / 快捷文件导入（`导入书籍`） |
+| 鼠标移出隐藏三模式（关闭/仅进度/全隐藏） | 亮色 / 暗色主题切换     | 书籍信息窗口（封面、简介、分类、阅读统计） |
+| 鼠标移入显示延迟可调         | 列表书架模式           | 多选模式 + 批量重载/删除    |
+| 百分比进度编辑跳转          | 窗口大小锁定           | 重载元数据 / 恢复封面      |
+| 章节列表高亮当前进度         | —                | 书籍分类筛选栏            |
 
 ## 截图
 
@@ -34,7 +42,8 @@
 
 ### 安装
 
-下载release文件，在ZTools中导入
+- 已上架市场，ZTools插件市场搜索**隐阅盒**，点击**安装**按钮
+- 下载github-release文件，在ZTools**搜索框**完成导入
 
 ### 开发
 
@@ -48,7 +57,7 @@ npm run build    # 构建生产版本
 
 在 ZTools 中输入以下关键词即可唤起：
 
-`yyh` · `摸鱼阅读` · `隐阅盒` · `书架` · `hushreader`
+`隐阅盒` · `hushreader` · `摸鱼阅读` · `书架` · `yyh` · `开始阅读` · `导入书籍`（支持拖入 txt/epub/mobi 文件）
 
 ## 技术细节
 
@@ -57,18 +66,27 @@ npm run build    # 构建生产版本
 
 阅读进度使用**字符偏移量**（`progressIndex`）而非页码保存，窗口大小或字体变化时进度不会丢失。
 
-**存储策略**：优先使用 `ztools.dbStorage`，回退到 `localStorage`。
+**存储策略**：轻量数据（书籍列表不含封面、阅读进度、配置）使用 `ztools.dbStorage`，回退到 `localStorage`；封面和章节内容使用 `ztools.db`（PouchDB 风格数据库），通过 `ztools.db.promises` API 管理 `cover_{bookId}`、`custom_cover_{bookId}`、`chapters_{bookId}` 等文档。
 
 **保存时机**：翻页时 · 章节切换时 · 自动翻页 tick · 插件退出时
 
 **每本书保存**：
 
-| 字段              | 说明       |
-| --------------- | -------- |
-| `lastChapter`   | 当前章节索引   |
-| `progressIndex` | 章节内字符偏移量 |
-| `lastReadAt`    | 最后阅读时间戳  |
-| `totalChapters` | 总章节数     |
+| 字段                 | 说明          |
+| ------------------ | ----------- |
+| `lastChapter`      | 当前章节索引      |
+| `progressIndex`    | 章节内字符偏移量    |
+| `lastReadAt`       | 最后阅读时间戳     |
+| `totalChapters`    | 总章节数        |
+| `firstReadAt`      | 首次阅读时间戳     |
+| `readingTimeMs`    | 累计阅读时长（毫秒）  |
+| `readingSpeed`     | 阅读速度（字/分钟）  |
+| `readingPercent`   | 阅读百分比       |
+| `updatedAt`        | 更新时间戳       |
+| `description`      | 书籍简介        |
+| `categories`       | 分类数组        |
+| `customCoverImage` | 自定义封面       |
+| `fileModifiedAt`   | 文件修改时间      |
 
 </details>
 
@@ -177,14 +195,14 @@ HTML/纯文本判断 → 分章解析或按 TXT 逻辑处理
 ├── src/
 │   ├── App.vue                   # 根组件
 │   ├── main.ts                   # 应用入口
-│   ├── main.css                   # 应用样式
-│   ├── env.d.ts                   #环境变量类型定义
+│   ├── main.css                  # 应用样式
+│   ├── env.d.ts                  # 环境变量类型定义
 │   ├── stores/
 │   │   ├── books.ts              # 书籍数据 + 持久化
 │   │   ├── config.ts             # 配置数据 + 持久化
 │   │   └── reader.ts             # 阅读器状态 + 分页
 │   ├── utils/
-│   │   ├── db.ts                 # 数据库操作工具
+│   │   ├── db.ts                 # 数据库操作工具（封面/章节缓存）
 │   │   ├── txtParser.ts          # TXT 解析 + 分页 + 预处理
 │   │   ├── epubParser.ts         # EPUB 解析
 │   │   └── mobiParser.ts         # MOBI 解析 + 加密检测 + 封面提取
@@ -192,17 +210,21 @@ HTML/纯文本判断 → 分章解析或按 TXT 逻辑处理
 │       ├── Bookshelf/            # 书架组件
 │       │   ├── index.vue
 │       │   ├── BookCard.vue
-│       │   ├── ContextMenu.vue
-│       │   ├── Modal.vue
-│       │   └── Toast.vue
+│       │   ├── BookInfoModal.vue # 书籍信息窗口
+│       │   ├── ContextMenu.vue   # 右键菜单
+│       │   ├── Modal.vue         # 通用弹窗
+│       │   ├── ThemeToggle.vue   # 主题切换
+│       │   └── Toast.vue         # Toast 提示
 │       └── Settings/             # 设置面板
 │           └── index.vue
 ├── .gitignore
+├── CHANGELOG.md                  # 更新日志
 ├── LICENSE
 ├── package.json
 ├── tsconfig.json
 ├── tsconfig.node.json
-└── vite.config.ts
+├── vite.config.ts
+└── ztools.api.md                 # ZTools API 文档
 ```
 
 ## 开源协议

--- a/plugins/hushreader/package.json
+++ b/plugins/hushreader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hushreader",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.3.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/plugins/hushreader/public/hushreader.html
+++ b/plugins/hushreader/public/hushreader.html
@@ -384,6 +384,26 @@
       background: transparent;
       color: var(--hushreader-text-color);
     }
+
+    .hushreader-timer {
+      position: absolute;
+      top: 4px;
+      left: 10px;
+      z-index: 4;
+      padding: 1px 6px;
+      border-radius: 3px;
+      font-size: 10px;
+      line-height: 1.3;
+      opacity: 0;
+      pointer-events: none;
+      color: var(--hushreader-text-color);
+      font-variant-numeric: tabular-nums;
+      transition: opacity 120ms ease;
+    }
+
+    .show-timer .hushreader-timer {
+      opacity: 0.66;
+    }
   </style>
 </head>
 
@@ -396,6 +416,7 @@
       </div>
       <button class="hushreader-hit next" type="button" aria-label="下一页" data-command="next"></button>
       <div id="hushreaderMeta" class="hushreader-meta"></div>
+      <div id="hushreaderTimer" class="hushreader-timer"></div>
       <div class="hushreader-resize-zone height" data-resize="height" aria-hidden="true"></div>
       <div class="hushreader-resize-zone width" data-resize="width" aria-hidden="true"></div>
       <div class="hushreader-resize-zone corner" data-resize="both" aria-hidden="true"></div>
@@ -408,6 +429,7 @@
     const root = document.getElementById("hushreader")
     const linesNode = document.getElementById("hushreaderLines")
     const metaNode = document.getElementById("hushreaderMeta")
+    const timerNode = document.getElementById("hushreaderTimer")
     const sizeHintNode = document.getElementById("hushreaderSizeHint")
     const contextMenuNode = document.getElementById("hushreaderContextMenu")
 
@@ -427,6 +449,37 @@
     let isKeyboardActive = false
     let isProgressEditing = false
     let isAutoPaging = false
+    let timerRemaining = null
+    let timerTickInterval = 0
+
+    function formatTimer(ms) {
+      if (ms == null || ms <= 0) return ''
+      const totalSec = Math.ceil(ms / 1000)
+      const min = Math.floor(totalSec / 60)
+      const sec = totalSec % 60
+      return `${min}:${String(sec).padStart(2, '0')}`
+    }
+
+    function startTimerTick() {
+      clearInterval(timerTickInterval)
+      if (timerRemaining == null || timerRemaining <= 0) {
+        timerNode.textContent = ''
+        root.classList.remove('show-timer')
+        return
+      }
+      root.classList.add('show-timer')
+      timerNode.textContent = formatTimer(timerRemaining)
+      timerTickInterval = setInterval(() => {
+        timerRemaining = Math.max(0, timerRemaining - 1000)
+        if (timerRemaining <= 0) {
+          clearInterval(timerTickInterval)
+          timerNode.textContent = ''
+          root.classList.remove('show-timer')
+        } else {
+          timerNode.textContent = formatTimer(timerRemaining)
+        }
+      }, 1000)
+    }
 
     function sendCommand(command) {
       if (window.ztools?.sendToParent) {
@@ -718,6 +771,12 @@
       if (!visible || !hideMode || hideMode === 'off') isAutoHidden = false
 
       isAutoPaging = Boolean(settings.autoFlipEnabled)
+
+      const newTimerRemaining = settings.timerEnabled ? settings.timerRemaining : null
+      if (newTimerRemaining !== timerRemaining) {
+        timerRemaining = newTimerRemaining
+        startTimerTick()
+      }
 
       root.className = [
         "hushreader-shell",

--- a/plugins/hushreader/public/hushreader.html
+++ b/plugins/hushreader/public/hushreader.html
@@ -404,6 +404,57 @@
     .show-timer .hushreader-timer {
       opacity: 0.66;
     }
+
+    .hushreader-notification {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      z-index: 50;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0, 0, 0, 0.55);
+      backdrop-filter: blur(4px);
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 200ms ease;
+    }
+
+    .hushreader-notification.visible {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .hushreader-notification-box {
+      max-width: 80%;
+      padding: 10px 18px;
+      border-radius: 8px;
+      background: rgba(30, 31, 34, 0.92);
+      color: var(--hushreader-text-color);
+      font-size: 12px;
+      line-height: 1.5;
+      text-align: center;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+    }
+
+    .hushreader-notification-box .notif-action {
+      display: inline-block;
+      margin-top: 8px;
+      padding: 3px 14px;
+      border: 1px solid rgba(255, 255, 255, 0.25);
+      border-radius: 4px;
+      background: transparent;
+      color: var(--hushreader-text-color);
+      font-size: 11px;
+      cursor: pointer;
+      transition: background 120ms ease;
+    }
+
+    .hushreader-notification-box .notif-action:hover {
+      background: rgba(255, 255, 255, 0.1);
+    }
   </style>
 </head>
 
@@ -423,6 +474,12 @@
       <div id="hushreaderSizeHint" class="hushreader-size-hint"></div>
     </section>
     <div id="hushreaderContextMenu" class="hushreader-context-menu" style="display:none"></div>
+    <div id="hushreaderNotification" class="hushreader-notification">
+      <div class="hushreader-notification-box">
+        <div id="notifMessage"></div>
+        <button id="notifAction" class="notif-action" style="display:none">确定</button>
+      </div>
+    </div>
   </main>
 
   <script>
@@ -451,6 +508,7 @@
     let isAutoPaging = false
     let timerRemaining = null
     let timerTickInterval = 0
+    let notifAutoCloseTimer = 0
 
     function formatTimer(ms) {
       if (ms == null || ms <= 0) return ''
@@ -486,6 +544,30 @@
         window.ztools.sendToParent("hushreader-command", command)
       }
     }
+
+    const notifNode = document.getElementById("hushreaderNotification")
+    const notifMessageNode = document.getElementById("notifMessage")
+    const notifActionNode = document.getElementById("notifAction")
+
+    window.hushreaderShowNotification = function hushreaderShowNotification(message) {
+      clearTimeout(notifAutoCloseTimer)
+      notifMessageNode.textContent = message
+      notifActionNode.style.display = "inline-block"
+      notifNode.classList.add("visible")
+    }
+
+    function closeNotification() {
+      clearTimeout(notifAutoCloseTimer)
+      notifNode.classList.remove("visible")
+      notifMessageNode.textContent = ""
+      notifActionNode.style.display = "none"
+      sendCommand("notification-close")
+    }
+
+    notifActionNode.addEventListener("click", (e) => {
+      e.stopPropagation()
+      closeNotification()
+    })
 
     function setAutoHidden(flag) {
       const mode = latestSettings.hideOnMouseLeave
@@ -774,8 +856,11 @@
 
       const newTimerRemaining = settings.timerEnabled ? settings.timerRemaining : null
       if (newTimerRemaining !== timerRemaining) {
+        const needsReset = timerRemaining == null || newTimerRemaining == null || Math.abs(newTimerRemaining - timerRemaining) > 2000
         timerRemaining = newTimerRemaining
-        startTimerTick()
+        if (needsReset) {
+          startTimerTick()
+        }
       }
 
       root.className = [

--- a/plugins/hushreader/public/plugin.json
+++ b/plugins/hushreader/public/plugin.json
@@ -4,7 +4,7 @@
   "title": "隐阅盒",
   "description": "隐阅盒，ZTools自己的摸鱼阅读，支持TXT/EPUB/MOBI格式，沉浸式阅读",
   "author": "meidlinger",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "index.html",
   "preload": "preload/services.js",
   "logo": "logo.png",

--- a/plugins/hushreader/public/plugin.json
+++ b/plugins/hushreader/public/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/@ztools-center/ztools-api-types/resource/ztools.schema.json",
   "name": "hushreader",
   "title": "隐阅盒",
-  "description": "隐阅盒，ZTools自己的摸鱼阅读，支持TXT/EPUB/MOBI格式，沉浸式阅读",
+  "description": "ZTools自己的摸鱼阅读，支持TXT/EPUB/MOBI格式，沉浸式阅读",
   "author": "meidlinger",
   "version": "1.3.3",
   "main": "index.html",

--- a/plugins/hushreader/public/preload/services.js
+++ b/plugins/hushreader/public/preload/services.js
@@ -170,5 +170,18 @@ window.services = {
     )
     fs.writeFileSync(filePath, text, { encoding: 'utf-8' })
     return filePath
+  },
+
+  writeFileToPath(filePath, content, encoding) {
+    const fullPath = path.resolve(filePath)
+    const dir = path.dirname(fullPath)
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(fullPath, content, { encoding: encoding || 'utf-8' })
+    return fullPath
+  },
+
+  readFileFromPath(filePath) {
+    const fullPath = path.resolve(filePath)
+    return fs.readFileSync(fullPath, 'utf-8')
   }
 }

--- a/plugins/hushreader/src/App.vue
+++ b/plugins/hushreader/src/App.vue
@@ -58,6 +58,7 @@ let toastTimer = 0
 let autoTimer = 0
 let readingTimer = 0
 let readingTimerStart = 0
+let readingTimerWarning = 0
 let isAutoPageTickRunning = false
 
 let hushreaderWindow: AppBrowserWindow | null = null
@@ -262,6 +263,23 @@ function pushHushreaderState(options?: { skipShow?: boolean }) {
   })
 }
 
+let pendingNotificationCallback: (() => void) | null = null
+
+function pushHushreaderNotification(message: string, onClose?: () => void) {
+  if (!hushreaderWindow || hushreaderWindow.isDestroyed?.()) {
+    onClose?.()
+    return
+  }
+  pendingNotificationCallback = onClose ?? null
+  const sync = hushreaderWindow.webContents?.executeJavaScript?.(
+    `window.hushreaderShowNotification?.(${JSON.stringify(message)})`
+  )
+  void sync?.catch((error) => {
+    console.warn('[HushReader] notification push failed', error)
+    onClose?.()
+  })
+}
+
 function ensureHushreaderWindow(options?: { skipShow?: boolean }) {
   if (!hushreaderActivated.value || !(window as any).ztools?.createBrowserWindow || !currentBook.value) return
   if (hushreaderWindow && !hushreaderWindow.isDestroyed?.()) {
@@ -354,18 +372,36 @@ function toast(msg: string, type: 'info' | 'error' | 'success' = 'info') {
 function startReadingTimer() {
   stopReadingTimer()
   if (!cfg.value.other.timerEnabled || !hushreaderActivated.value) return
+  const minutes = Number(cfg.value.other.timerMinutes)
+  if (isNaN(minutes) || minutes <= 0) return
   readingTimerStart = Date.now()
-  const ms = cfg.value.other.timerMinutes * 60 * 1000
+  const ms = minutes * 60 * 1000
+  const warningMs = Math.round(ms * 0.9)
+  readingTimerWarning = window.setTimeout(() => {
+    const elapsed = Math.round((Date.now() - readingTimerStart) / 1000)
+    const remaining = Math.round((ms - (Date.now() - readingTimerStart)) / 1000)
+    const elapsedMin = Math.floor(elapsed / 60)
+    const elapsedSec = elapsed % 60
+    const remainingMin = Math.floor(remaining / 60)
+    const remainingSec = remaining % 60
+    const elapsedStr = elapsedMin > 0 ? `${elapsedMin}分${elapsedSec}秒` : `${elapsedSec}秒`
+    const remainingStr = remainingMin > 0 ? `${remainingMin}分${remainingSec}秒` : `${remainingSec}秒`
+    pushHushreaderNotification(`已阅读${elapsedStr}，${remainingStr}后将自动关闭`)
+  }, warningMs)
   readingTimer = window.setTimeout(() => {
-    hideHushreaderWindow()
-    toast(`阅读定时器已到 ${cfg.value.other.timerMinutes} 分钟`, 'info')
+    const elapsedMin = minutes
+    pushHushreaderNotification(`阅读定时器已到 ${elapsedMin} 分钟，即将关闭`, () => {
+      hideHushreaderWindow()
+    })
     readingTimerStart = 0
   }, ms)
 }
 
 function stopReadingTimer() {
   clearTimeout(readingTimer)
+  clearTimeout(readingTimerWarning)
   readingTimer = 0
+  readingTimerWarning = 0
   readingTimerStart = 0
 }
 
@@ -596,6 +632,7 @@ function handleHushreaderCommand(command: HushreaderCommand) {
   else if (command === 'show-main') { (window as any).ztools?.showMainWindow?.() }
   else if (command === 'stop-auto') { isAutoPaging.value = false; hushreaderCfg.value.autoFlipEnabled = false }
   else if (command === 'start-auto') { if (currentBook.value) { isAutoPaging.value = true; hushreaderCfg.value.autoFlipEnabled = true } }
+  else if (command === 'notification-close') { pendingNotificationCallback?.(); pendingNotificationCallback = null }
 }
 
 watch(

--- a/plugins/hushreader/src/App.vue
+++ b/plugins/hushreader/src/App.vue
@@ -56,6 +56,8 @@ const toastMsg = ref('')
 const toastType = ref<'info' | 'error' | 'success'>('info')
 let toastTimer = 0
 let autoTimer = 0
+let readingTimer = 0
+let readingTimerStart = 0
 let isAutoPageTickRunning = false
 
 let hushreaderWindow: AppBrowserWindow | null = null
@@ -215,7 +217,9 @@ function getHushreaderPayload(bounds = getHushreaderWindowBounds()) {
       autoFlipEnabled: hushreaderCfg.value.autoFlipEnabled,
       fontFamily: hushreaderCfg.value.fontFamily,
       windowMovable: cfg.value.function.windowMovable,
-      windowSizeLocked: cfg.value.function.windowSizeLocked
+      windowSizeLocked: cfg.value.function.windowSizeLocked,
+      timerEnabled: cfg.value.other.timerEnabled,
+      timerRemaining: getReadingTimerRemaining()
     }
   }
 }
@@ -289,7 +293,6 @@ function ensureHushreaderWindow(options?: { skipShow?: boolean }) {
       hasShadow: false,
       focusable: true,
       acceptFirstMouse: true,
-      alwayOnTop: true,
       alwaysOnTop: true,
       webPreferences: {
         devTools: false,
@@ -313,6 +316,7 @@ function showHushreaderWindow() {
 function hideHushreaderWindow() {
   isReaderHidden.value = true
   blurHushreaderKeyboard()
+  stopReadingTimer()
 }
 
 function focusHushreaderKeyboard() {
@@ -347,9 +351,35 @@ function toast(msg: string, type: 'info' | 'error' | 'success' = 'info') {
   toastTimer = window.setTimeout(() => { toastMsg.value = '' }, 3000)
 }
 
+function startReadingTimer() {
+  stopReadingTimer()
+  if (!cfg.value.other.timerEnabled || !hushreaderActivated.value) return
+  readingTimerStart = Date.now()
+  const ms = cfg.value.other.timerMinutes * 60 * 1000
+  readingTimer = window.setTimeout(() => {
+    hideHushreaderWindow()
+    toast(`阅读定时器已到 ${cfg.value.other.timerMinutes} 分钟`, 'info')
+    readingTimerStart = 0
+  }, ms)
+}
+
+function stopReadingTimer() {
+  clearTimeout(readingTimer)
+  readingTimer = 0
+  readingTimerStart = 0
+}
+
+function getReadingTimerRemaining(): number | null {
+  if (!readingTimerStart || !cfg.value.other.timerEnabled) return null
+  const elapsed = Date.now() - readingTimerStart
+  const total = cfg.value.other.timerMinutes * 60 * 1000
+  return Math.max(0, total - elapsed)
+}
+
 function closePlugin() {
   isReaderHidden.value = true
   hushreaderActivated.value = false
+  stopReadingTimer()
   try { (window as any).ztools?.outPlugin?.() } catch { }
 }
 
@@ -475,6 +505,7 @@ async function openBookAndHushreader(bookId: string) {
     hushreaderActivated.value = true
     isReaderHidden.value = false
     ensureHushreaderWindow()
+    startReadingTimer()
     nextTick(() => {
       pushHushreaderState()
     })
@@ -685,6 +716,7 @@ onMounted(async () => {
 onBeforeUnmount(() => {
   saveReadingProgress()
   window.clearInterval(autoTimer)
+  stopReadingTimer()
   offHushreaderCommand?.()
 })
 </script>

--- a/plugins/hushreader/src/components/Bookshelf/ContextMenu.vue
+++ b/plugins/hushreader/src/components/Bookshelf/ContextMenu.vue
@@ -6,6 +6,7 @@ const emit = defineEmits<{
   'book-info': []
   'chapter-list': []
   'change-path': []
+  'open-file-location': []
   'edit-metadata': []
   'reload-metadata': []
   'set-category': []
@@ -53,6 +54,10 @@ watch(
       <li class="ctx-item" @click="emit('change-path')">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
         修改本地路径
+      </li>
+      <li class="ctx-item" @click="emit('open-file-location')">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+        打开文件位置
       </li>
       <li class="ctx-item" @click="emit('edit-metadata')">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/><path d="m15 5 4 4"/></svg>

--- a/plugins/hushreader/src/components/Bookshelf/ThemeToggle.vue
+++ b/plugins/hushreader/src/components/Bookshelf/ThemeToggle.vue
@@ -1,23 +1,64 @@
 <script setup lang="ts">
-import { computed, watch } from 'vue'
+import { computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useConfigStore } from '../../stores/config'
 
 const configStore = useConfigStore()
-const isDark = computed(() => configStore.config.other.theme === 'dark')
+const theme = computed(() => configStore.config.other.theme)
+
+function getSystemDark(): boolean {
+  try {
+    return (window as any).ztools?.isDarkColors?.() ?? false
+  } catch {
+    return window.matchMedia?.('(prefers-color-scheme: dark)')?.matches ?? false
+  }
+}
+
+const systemDark = computed(() => getSystemDark())
+
+const effectiveTheme = computed(() => {
+  if (theme.value === 'auto') return systemDark.value ? 'dark' : 'light'
+  return theme.value
+})
 
 function toggle() {
-  configStore.config.other.theme = isDark.value ? 'light' : 'dark'
+  const order: Array<'light' | 'dark' | 'auto'> = ['light', 'dark', 'auto']
+  const idx = order.indexOf(theme.value)
+  configStore.config.other.theme = order[(idx + 1) % 3]
   configStore.save()
 }
 
-watch(() => configStore.config.other.theme, (theme) => {
-  document.documentElement.setAttribute('data-theme', theme)
-}, { immediate: true })
+const titleMap = { light: '浅色模式', dark: '深色模式', auto: '跟随系统' }
+const nextMap = { light: '切换深色模式', dark: '切换自动模式', auto: '切换浅色模式' }
+
+let mediaQuery: MediaQueryList | null = null
+let mediaHandler: ((e: MediaQueryListEvent) => void) | null = null
+
+function applyTheme() {
+  document.documentElement.setAttribute('data-theme', effectiveTheme.value)
+}
+
+watch(effectiveTheme, () => applyTheme(), { immediate: true })
+
+onMounted(() => {
+  if (typeof window.matchMedia === 'function') {
+    mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    mediaHandler = () => {
+      if (theme.value === 'auto') applyTheme()
+    }
+    mediaQuery.addEventListener('change', mediaHandler)
+  }
+})
+
+onBeforeUnmount(() => {
+  if (mediaQuery && mediaHandler) {
+    mediaQuery.removeEventListener('change', mediaHandler)
+  }
+})
 </script>
 
 <template>
-  <button class="theme-toggle" :title="isDark ? '切换浅色模式' : '切换深色模式'" @click="toggle">
-    <svg v-if="isDark" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <button class="theme-toggle" :title="nextMap[theme]" @click="toggle">
+    <svg v-if="theme === 'light'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <circle cx="12" cy="12" r="5"/>
       <line x1="12" y1="1" x2="12" y2="3"/>
       <line x1="12" y1="21" x2="12" y2="23"/>
@@ -28,8 +69,15 @@ watch(() => configStore.config.other.theme, (theme) => {
       <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
       <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
     </svg>
-    <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <svg v-else-if="theme === 'dark'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+    </svg>
+    <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
+      <line x1="8" y1="21" x2="16" y2="21"/>
+      <line x1="12" y1="17" x2="12" y2="21"/>
+      <circle cx="12" cy="10" r="3"/>
+      <path d="M12 7a3 3 0 0 1 0 6"/>
     </svg>
   </button>
 </template>

--- a/plugins/hushreader/src/components/Bookshelf/ThemeToggle.vue
+++ b/plugins/hushreader/src/components/Bookshelf/ThemeToggle.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import { computed, watch, onMounted, onBeforeUnmount, ref } from 'vue'
 import { useConfigStore } from '../../stores/config'
 
 const configStore = useConfigStore()
@@ -13,7 +13,7 @@ function getSystemDark(): boolean {
   }
 }
 
-const systemDark = computed(() => getSystemDark())
+const systemDark = ref(getSystemDark())
 
 const effectiveTheme = computed(() => {
   if (theme.value === 'auto') return systemDark.value ? 'dark' : 'light'
@@ -42,8 +42,8 @@ watch(effectiveTheme, () => applyTheme(), { immediate: true })
 onMounted(() => {
   if (typeof window.matchMedia === 'function') {
     mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
-    mediaHandler = () => {
-      if (theme.value === 'auto') applyTheme()
+    mediaHandler = (e: MediaQueryListEvent) => {
+      systemDark.value = e.matches
     }
     mediaQuery.addEventListener('change', mediaHandler)
   }
@@ -58,26 +58,29 @@ onBeforeUnmount(() => {
 
 <template>
   <button class="theme-toggle" :title="nextMap[theme]" @click="toggle">
-    <svg v-if="theme === 'light'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="12" cy="12" r="5"/>
-      <line x1="12" y1="1" x2="12" y2="3"/>
-      <line x1="12" y1="21" x2="12" y2="23"/>
-      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
-      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-      <line x1="1" y1="12" x2="3" y2="12"/>
-      <line x1="21" y1="12" x2="23" y2="12"/>
-      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
-      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+    <svg v-if="theme === 'light'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
     </svg>
-    <svg v-else-if="theme === 'dark'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+    <svg v-else-if="theme === 'dark'" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
     </svg>
-    <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <rect x="2" y="3" width="20" height="14" rx="2" ry="2"/>
-      <line x1="8" y1="21" x2="16" y2="21"/>
-      <line x1="12" y1="17" x2="12" y2="21"/>
-      <circle cx="12" cy="10" r="3"/>
-      <path d="M12 7a3 3 0 0 1 0 6"/>
+    <svg v-else width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+      stroke-linecap="round" stroke-linejoin="round">
+      <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
+      <circle cx="12" cy="10" r="3" />
+      <path d="M12 7a3 3 0 0 1 0 6" />
     </svg>
   </button>
 </template>

--- a/plugins/hushreader/src/components/Bookshelf/index.vue
+++ b/plugins/hushreader/src/components/Bookshelf/index.vue
@@ -153,6 +153,18 @@ function confirmPath() {
   toast('路径已更新', 'success')
 }
 
+function openFileLocation(bookId: string) {
+  closeContextMenu()
+  const book = bookStore.books.find(b => b.id === bookId)
+  if (!book) return
+  try {
+    const result = (window as any).ztools?.shellShowItemInFolder?.(book.filePath)
+    if (!result) toast('无法打开文件位置', 'error')
+  } catch {
+    toast('无法打开文件位置', 'error')
+  }
+}
+
 // Category modal
 const showCategoryModal = ref(false)
 const categoryModalBookId = ref<string | null>(null)
@@ -946,10 +958,10 @@ const cfg = computed(() => configStore.config)
     <!-- Context Menu -->
     <ContextMenu v-if="contextMenuBook" :pos="contextMenuPos" @book-info="openBookInfo(contextMenuBook!)"
       @chapter-list="openChapterList(contextMenuBook!)" @change-path="openPathModal(contextMenuBook!)"
-      @edit-metadata="openMetadataModal(contextMenuBook!)" @reload-metadata="openReloadMetadata(contextMenuBook!)"
-      @set-category="openCategoryModal(contextMenuBook!)" @set-cover="openCoverPicker(contextMenuBook!)"
-      @restore-cover="openRestoreCover(contextMenuBook!)" @delete="openDeleteModal(contextMenuBook!)"
-      @close="closeContextMenu" />
+      @open-file-location="openFileLocation(contextMenuBook!)" @edit-metadata="openMetadataModal(contextMenuBook!)"
+      @reload-metadata="openReloadMetadata(contextMenuBook!)" @set-category="openCategoryModal(contextMenuBook!)"
+      @set-cover="openCoverPicker(contextMenuBook!)" @restore-cover="openRestoreCover(contextMenuBook!)"
+      @delete="openDeleteModal(contextMenuBook!)" @close="closeContextMenu" />
 
     <!-- Settings Modal -->
     <SettingsModal v-if="showSettings" @close="showSettings = false" />

--- a/plugins/hushreader/src/components/Settings/index.vue
+++ b/plugins/hushreader/src/components/Settings/index.vue
@@ -1,11 +1,24 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useConfigStore, type ReaderConfig } from '../../stores/config'
+import { useBookStore } from '../../stores/books'
+import Toast from '../Bookshelf/Toast.vue'
 
 const emit = defineEmits<{ close: [] }>()
 
 const configStore = useConfigStore()
 const cfg = computed(() => configStore.config)
+
+const toastMessage = ref('')
+const toastType = ref<'info' | 'success' | 'error'>('info')
+let toastTimer: ReturnType<typeof setTimeout> | null = null
+
+function showToast(msg: string, type: 'info' | 'success' | 'error' = 'info') {
+  if (toastTimer) clearTimeout(toastTimer)
+  toastMessage.value = msg
+  toastType.value = type
+  toastTimer = setTimeout(() => { toastMessage.value = '' }, 2500)
+}
 
 const activeTab = ref<'hushreader' | 'function' | 'other'>('hushreader')
 
@@ -64,6 +77,279 @@ function removeCustomFont(fontName: string) {
   if (cfg.value.hushreader.fontFamily === fontName) {
     cfg.value.hushreader.fontFamily = FONT_OPTIONS[0].value
   }
+}
+
+const bookStore = useBookStore()
+
+const isExportingConfig = ref(false)
+const isImportingConfig = ref(false)
+const isExportingBooks = ref(false)
+const isImportingBooks = ref(false)
+const isAddingConfig = ref(false)
+const newConfigName = ref('')
+const renamingConfigIndex = ref(-1)
+const renameInput = ref('')
+
+async function exportConfig() {
+  isExportingConfig.value = true
+  try {
+    const configData = JSON.parse(JSON.stringify(configStore.config))
+    const exportObj = {
+      _hushreaderConfigBackup: true,
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      config: configData
+    }
+    const json = JSON.stringify(exportObj, null, 2)
+    const ztools = (window as any).ztools
+    if (ztools?.showSaveDialog) {
+      const filePath = ztools.showSaveDialog({
+        title: '导出 HushReader 配置',
+        defaultPath: `hushreader-config-${new Date().toISOString().slice(0, 10)}.json`,
+        filters: [{ name: 'JSON', extensions: ['json'] }]
+      })
+      if (filePath) {
+        window.services.writeFileToPath(filePath, json)
+      }
+    } else {
+      const blob = new Blob([json], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `hushreader-config-${new Date().toISOString().slice(0, 10)}.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    }
+    showToast('配置导出成功', 'success')
+  } catch (e) {
+    console.warn('Export config failed', e)
+    showToast('配置导出失败', 'error')
+  } finally {
+    isExportingConfig.value = false
+  }
+}
+
+async function importConfig() {
+  isImportingConfig.value = true
+  try {
+    const ztools = (window as any).ztools
+    let json = ''
+    if (ztools?.showOpenDialog) {
+      const filePaths = ztools.showOpenDialog({
+        title: '导入 HushReader 配置',
+        filters: [{ name: 'JSON', extensions: ['json'] }],
+        properties: ['openFile']
+      })
+      if (!filePaths || !filePaths.length) {
+        isImportingConfig.value = false
+        return
+      }
+      json = window.services.readFileFromPath(filePaths[0])
+    } else {
+      const input = document.createElement('input')
+      input.type = 'file'
+      input.accept = '.json'
+      const file = await new Promise<File | null>(resolve => {
+        input.onchange = () => resolve(input.files?.[0] ?? null)
+        input.click()
+      })
+      if (!file) {
+        isImportingConfig.value = false
+        return
+      }
+      json = await file.text()
+    }
+    if (!json) {
+      isImportingConfig.value = false
+      return
+    }
+    const data = JSON.parse(json)
+    if (!data._hushreaderConfigBackup) {
+      showToast('无效的 HushReader 配置备份文件', 'error')
+      isImportingConfig.value = false
+      return
+    }
+    if (data.config) {
+      const configName = data.config.other?.configName || `导入配置 ${configStore.configList.length + 1}`
+      configStore.addConfig(configName)
+      configStore.config = deepMerge(JSON.parse(JSON.stringify(configStore.DEFAULT_CONFIG)), data.config)
+      configStore.config.other.configName = configName
+      configStore.save()
+      showToast(`配置「${configName}」导入成功`, 'success')
+    } else {
+      showToast('备份文件中未找到配置数据', 'error')
+    }
+  } catch (e) {
+    console.warn('Import config failed', e)
+    showToast('配置导入失败', 'error')
+  } finally {
+    isImportingConfig.value = false
+  }
+}
+
+async function exportBooks() {
+  isExportingBooks.value = true
+  try {
+    const booksData = bookStore.books.map(b => {
+      const { coverImage, customCoverImage, ...rest } = b
+      return rest
+    })
+    const exportObj = {
+      _hushreaderBooksBackup: true,
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      books: booksData
+    }
+    const json = JSON.stringify(exportObj, null, 2)
+    const ztools = (window as any).ztools
+    if (ztools?.showSaveDialog) {
+      const filePath = ztools.showSaveDialog({
+        title: '导出 HushReader 书籍',
+        defaultPath: `hushreader-books-${new Date().toISOString().slice(0, 10)}.json`,
+        filters: [{ name: 'JSON', extensions: ['json'] }]
+      })
+      if (filePath) {
+        window.services.writeFileToPath(filePath, json)
+      }
+    } else {
+      const blob = new Blob([json], { type: 'application/json' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `hushreader-books-${new Date().toISOString().slice(0, 10)}.json`
+      a.click()
+      URL.revokeObjectURL(url)
+    }
+    showToast(`成功导出 ${booksData.length} 本书`, 'success')
+  } catch (e) {
+    console.warn('Export books failed', e)
+    showToast('书籍导出失败', 'error')
+  } finally {
+    isExportingBooks.value = false
+  }
+}
+
+async function importBooks() {
+  isImportingBooks.value = true
+  try {
+    const ztools = (window as any).ztools
+    let json = ''
+    if (ztools?.showOpenDialog) {
+      const filePaths = ztools.showOpenDialog({
+        title: '导入 HushReader 书籍',
+        filters: [{ name: 'JSON', extensions: ['json'] }],
+        properties: ['openFile']
+      })
+      if (!filePaths || !filePaths.length) {
+        isImportingBooks.value = false
+        return
+      }
+      json = window.services.readFileFromPath(filePaths[0])
+    } else {
+      const input = document.createElement('input')
+      input.type = 'file'
+      input.accept = '.json'
+      const file = await new Promise<File | null>(resolve => {
+        input.onchange = () => resolve(input.files?.[0] ?? null)
+        input.click()
+      })
+      if (!file) {
+        isImportingBooks.value = false
+        return
+      }
+      json = await file.text()
+    }
+    if (!json) {
+      isImportingBooks.value = false
+      return
+    }
+    const data = JSON.parse(json)
+    if (!data._hushreaderBooksBackup) {
+      showToast('无效的 HushReader 书籍备份文件', 'error')
+      isImportingBooks.value = false
+      return
+    }
+    if (Array.isArray(data.books)) {
+      let added = 0
+      let skipped = 0
+      for (const book of data.books) {
+        if (bookStore.books.some(b => b.filePath === book.filePath)) {
+          skipped++
+          continue
+        }
+        bookStore.addBook(book)
+        added++
+      }
+      bookStore.save()
+      if (added > 0) {
+        const msg = skipped > 0
+          ? `成功导入 ${added} 本书，跳过 ${skipped} 本重复`
+          : `成功导入 ${added} 本书`
+        showToast(msg, 'success')
+      } else {
+        showToast(skipped > 0 ? `所有 ${skipped} 本书均已存在，无新增` : '备份文件中未找到书籍数据', 'info')
+      }
+    } else {
+      showToast('备份文件中未找到书籍数据', 'error')
+    }
+  } catch (e) {
+    console.warn('Import books failed', e)
+    showToast('书籍导入失败', 'error')
+  } finally {
+    isImportingBooks.value = false
+  }
+}
+
+function deepMerge(target: any, source: any): any {
+  for (const key of Object.keys(source)) {
+    if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+      if (!target[key]) target[key] = {}
+      deepMerge(target[key], source[key])
+    } else {
+      target[key] = source[key]
+    }
+  }
+  return target
+}
+
+function startAddConfig() {
+  isAddingConfig.value = true
+  newConfigName.value = ''
+}
+
+function confirmAddConfig() {
+  const name = newConfigName.value.trim()
+  if (!name) {
+    isAddingConfig.value = false
+    return
+  }
+  configStore.addConfig(name)
+  isAddingConfig.value = false
+  newConfigName.value = ''
+}
+
+function cancelAddConfig() {
+  isAddingConfig.value = false
+  newConfigName.value = ''
+}
+
+function startRenameConfig(index: number) {
+  renamingConfigIndex.value = index
+  renameInput.value = configStore.configList[index]?.name || ''
+}
+
+function confirmRenameConfig() {
+  const name = renameInput.value.trim()
+  if (name && renamingConfigIndex.value >= 0) {
+    configStore.renameConfig(renamingConfigIndex.value, name)
+  }
+  renamingConfigIndex.value = -1
+  renameInput.value = ''
+}
+
+function cancelRenameConfig() {
+  renamingConfigIndex.value = -1
+  renameInput.value = ''
 }
 
 let originalConfig: ReaderConfig | null = null
@@ -154,17 +440,63 @@ function commitCapture(targetArr: string[]) {
       <!-- Header -->
       <div class="settings-header">
         <h2 class="settings-title">插件设置</h2>
+        <div class="config-switcher">
+          <select :value="configStore.activeConfigIndex"
+            @change="(e: Event) => configStore.switchConfig(Number((e.target as HTMLSelectElement).value))"
+            class="config-select" title="切换配置">
+            <option v-for="(c, i) in configStore.configList" :key="i" :value="i">{{ c.name }}</option>
+          </select>
+          <button class="config-action-btn" @click="startAddConfig" title="添加配置">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+          </button>
+          <button class="config-action-btn" @click="startRenameConfig(configStore.activeConfigIndex)" title="重命名配置">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+              <path d="M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z" />
+            </svg>
+          </button>
+          <button class="config-action-btn" :disabled="configStore.configList.length <= 1"
+            @click="configStore.removeConfig(configStore.activeConfigIndex)" title="删除配置">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
         <button class="close-btn" @click="emit('close')">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-            <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
           </svg>
         </button>
       </div>
 
+      <!-- Config rename/add inline bar -->
+      <div v-if="isAddingConfig || renamingConfigIndex >= 0" class="config-inline-bar">
+        <template v-if="isAddingConfig">
+          <input v-model="newConfigName" class="config-inline-input" placeholder="新配置名称..."
+            @keyup.enter="confirmAddConfig" @keyup.esc="cancelAddConfig" />
+          <button class="btn-primary" @click="confirmAddConfig" style="padding: 3px 10px; font-size: 12px">确定</button>
+          <button class="btn-secondary" @click="cancelAddConfig" style="padding: 3px 10px; font-size: 12px">取消</button>
+        </template>
+        <template v-else-if="renamingConfigIndex >= 0">
+          <input v-model="renameInput" class="config-inline-input" placeholder="输入新名称..."
+            @keyup.enter="confirmRenameConfig" @keyup.esc="cancelRenameConfig" />
+          <button class="btn-primary" @click="confirmRenameConfig"
+            style="padding: 3px 10px; font-size: 12px">确定</button>
+          <button class="btn-secondary" @click="cancelRenameConfig"
+            style="padding: 3px 10px; font-size: 12px">取消</button>
+        </template>
+      </div>
+
       <!-- Tabs -->
       <div class="tab-bar">
-        <button class="tab-btn" :class="{ active: activeTab === 'hushreader' }" @click="activeTab = 'hushreader'">隐阅窗口</button>
-        <button class="tab-btn" :class="{ active: activeTab === 'function' }" @click="activeTab = 'function'">功能设置</button>
+        <button class="tab-btn" :class="{ active: activeTab === 'hushreader' }"
+          @click="activeTab = 'hushreader'">隐阅窗口</button>
+        <button class="tab-btn" :class="{ active: activeTab === 'function' }"
+          @click="activeTab = 'function'">功能设置</button>
         <button class="tab-btn" :class="{ active: activeTab === 'other' }" @click="activeTab = 'other'">其他设置</button>
       </div>
 
@@ -183,17 +515,12 @@ function commitCapture(targetArr: string[]) {
                 <option v-for="f in allFontOptions" :key="f.value" :value="f.value">{{ f.label }}</option>
                 <option value="__add__">+ 添加自定义字体</option>
               </select>
-              <input
-                v-else
-                v-model="newFontInput"
-                class="text-input"
-                placeholder="输入字体名称..."
-                @keyup.enter="confirmAddFont"
-                @keyup.esc="cancelAddFont"
-                style="flex: 1"
-              />
-              <button v-if="isAddingFont" class="btn-primary" @click="confirmAddFont" style="padding: 4px 10px">确定</button>
-              <button v-if="isAddingFont" class="btn-secondary" @click="cancelAddFont" style="padding: 4px 10px">取消</button>
+              <input v-else v-model="newFontInput" class="text-input" placeholder="输入字体名称..."
+                @keyup.enter="confirmAddFont" @keyup.esc="cancelAddFont" style="flex: 1" />
+              <button v-if="isAddingFont" class="btn-primary" @click="confirmAddFont"
+                style="padding: 4px 10px">确定</button>
+              <button v-if="isAddingFont" class="btn-secondary" @click="cancelAddFont"
+                style="padding: 4px 10px">取消</button>
             </div>
           </div>
 
@@ -208,7 +535,8 @@ function commitCapture(targetArr: string[]) {
           <div class="setting-row">
             <label>行间距</label>
             <div class="input-group">
-              <input type="range" min="1.2" max="3" step="0.1" v-model.number="cfg.hushreader.lineHeight" class="slider" />
+              <input type="range" min="1.2" max="3" step="0.1" v-model.number="cfg.hushreader.lineHeight"
+                class="slider" />
               <span class="badge">{{ cfg.hushreader.lineHeight.toFixed(1) }}</span>
             </div>
           </div>
@@ -216,7 +544,8 @@ function commitCapture(targetArr: string[]) {
           <div class="setting-row">
             <label>字间距</label>
             <div class="input-group">
-              <input type="range" min="0" max="8" step="0.5" v-model.number="cfg.hushreader.letterSpacing" class="slider" />
+              <input type="range" min="0" max="8" step="0.5" v-model.number="cfg.hushreader.letterSpacing"
+                class="slider" />
               <span class="badge">{{ cfg.hushreader.letterSpacing }}px</span>
             </div>
           </div>
@@ -263,13 +592,8 @@ function commitCapture(targetArr: string[]) {
             <label>背景颜色</label>
             <div class="input-group">
               <input type="color" v-model="cfg.hushreader.bgColor" class="color-picker" />
-              <input
-                type="text"
-                v-model="cfg.hushreader.bgColor"
-                class="color-input"
-                placeholder="#16191c"
-                pattern="^#[0-9A-Fa-f]{6}$"
-              />
+              <input type="text" v-model="cfg.hushreader.bgColor" class="color-input" placeholder="#16191c"
+                pattern="^#[0-9A-Fa-f]{6}$" />
             </div>
           </div>
 
@@ -277,13 +601,8 @@ function commitCapture(targetArr: string[]) {
             <label>文字颜色</label>
             <div class="input-group">
               <input type="color" v-model="cfg.hushreader.textColor" class="color-picker" />
-              <input
-                type="text"
-                v-model="cfg.hushreader.textColor"
-                class="color-input"
-                placeholder="#cccccc"
-                pattern="^#[0-9A-Fa-f]{6}$"
-              />
+              <input type="text" v-model="cfg.hushreader.textColor" class="color-input" placeholder="#cccccc"
+                pattern="^#[0-9A-Fa-f]{6}$" />
             </div>
           </div>
 
@@ -324,7 +643,8 @@ function commitCapture(targetArr: string[]) {
           <div class="setting-row" v-if="cfg.hushreader.hideOnMouseLeave !== 'off'">
             <label>移入显示延迟</label>
             <div class="input-group">
-              <input type="number" min="0" max="10" step="0.1" v-model.number="cfg.hushreader.mouseEnterDelay" class="number-input" />
+              <input type="number" min="0" max="10" step="0.1" v-model.number="cfg.hushreader.mouseEnterDelay"
+                class="number-input" />
               <span class="unit">秒</span>
             </div>
           </div>
@@ -340,26 +660,18 @@ function commitCapture(targetArr: string[]) {
           <div class="setting-row">
             <label>上一页快捷键</label>
             <div class="input-group">
-              <input
-                class="key-input"
-                :value="cfg.hushreader.prevPageKey"
+              <input class="key-input" :value="cfg.hushreader.prevPageKey"
                 @keydown.prevent="(e: KeyboardEvent) => { const b = getKeyBinding(e); if (b) cfg.hushreader.prevPageKey = b }"
-                placeholder="按下按键..."
-                readonly
-              />
+                placeholder="按下按键..." readonly />
             </div>
           </div>
 
           <div class="setting-row">
             <label>下一页快捷键</label>
             <div class="input-group">
-              <input
-                class="key-input"
-                :value="cfg.hushreader.nextPageKey"
+              <input class="key-input" :value="cfg.hushreader.nextPageKey"
                 @keydown.prevent="(e: KeyboardEvent) => { const b = getKeyBinding(e); if (b) cfg.hushreader.nextPageKey = b }"
-                placeholder="按下按键..."
-                readonly
-              />
+                placeholder="按下按键..." readonly />
             </div>
           </div>
 
@@ -377,7 +689,8 @@ function commitCapture(targetArr: string[]) {
           <div class="setting-row" v-if="cfg.hushreader.autoFlipEnabled">
             <label>翻页间隔</label>
             <div class="input-group">
-              <input type="number" min="1000" max="60000" step="500" v-model.number="cfg.hushreader.autoFlipInterval" class="number-input" />
+              <input type="number" min="1000" max="60000" step="500" v-model.number="cfg.hushreader.autoFlipInterval"
+                class="number-input" />
               <span class="unit">ms</span>
             </div>
           </div>
@@ -408,6 +721,26 @@ function commitCapture(targetArr: string[]) {
               <span class="toggle-track"></span>
             </label>
           </div>
+
+          <div class="divider"></div>
+          <div class="section-label">阅读定时器</div>
+
+          <div class="setting-row">
+            <label>启用定时器</label>
+            <label class="toggle">
+              <input type="checkbox" v-model="cfg.other.timerEnabled" />
+              <span class="toggle-track"></span>
+            </label>
+          </div>
+
+          <div class="setting-row" v-if="cfg.other.timerEnabled">
+            <label>定时时长</label>
+            <div class="input-group">
+              <input type="number" min="1" max="180" step="1" v-model.number="cfg.other.timerMinutes"
+                class="number-input" />
+              <span class="unit">分钟</span>
+            </div>
+          </div>
         </div>
 
         <!-- ===== 其他设置 ===== -->
@@ -430,31 +763,33 @@ function commitCapture(targetArr: string[]) {
               <span class="toggle-track"></span>
             </label>
           </div>
-          <p v-if="!cfg.other.plainTextCover" class="hint" style="margin: -2px 0 6px; padding-left: 0">关闭时书籍将解析封面图片，可能消耗较多资源</p>
+          <p v-if="!cfg.other.plainTextCover" class="hint" style="margin: -2px 0 6px; padding-left: 0">
+            关闭时书籍将解析封面图片，可能消耗较多资源
+          </p>
           <p v-else class="hint" style="margin: -2px 0 6px; padding-left: 0">所有书籍使用纯色背景封面，不解析封面图片</p>
 
           <div class="divider"></div>
           <div class="section-label">解析</div>
 
           <div class="setting-row" style="align-items: flex-start; flex-direction: column; gap: 6px;">
-            <label>TXT 章节识别正则 <span class="tip-icon" tabindex="0">ⓘ<span class="tip-bubble">默认规则：匹配以"第"开头，后跟中文数字（零一二三…）或阿拉伯数字，再跟"章/节/卷/集/部"的行，如"第三章 大战"、第12卷 等</span></span></label>
-            <input
-              v-model="cfg.other.chapterRegex"
-              class="text-input full-width"
-              placeholder="留空使用默认规则（第X章...）"
-            />
+            <label>TXT 章节识别正则 <span class="tip-icon" tabindex="0">ⓘ<span
+                  class="tip-bubble">默认规则：匹配以"第"开头，后跟中文数字（零一二三…）或阿拉伯数字，再跟"章/节/卷/集/部"的行，如"第三章 大战"、第12卷
+                  等</span></span></label>
+            <input v-model="cfg.other.chapterRegex" class="text-input full-width" placeholder="留空使用默认规则（第X章...）" />
             <p class="hint" style="margin:0">支持标准 JavaScript 正则语法，EPUB/MOBI 使用内置章节标识</p>
           </div>
 
           <div class="divider"></div>
           <div class="section-label">自定义字体</div>
 
-          <div v-if="cfg.other.customFonts && cfg.other.customFonts.length > 0" class="setting-row" style="align-items: flex-start; flex-direction: column; gap: 6px;">
+          <div v-if="cfg.other.customFonts && cfg.other.customFonts.length > 0" class="setting-row"
+            style="align-items: flex-start; flex-direction: column; gap: 6px;">
             <label>已添加的字体</label>
             <div class="custom-fonts-list">
               <div v-for="font in cfg.other.customFonts" :key="font" class="custom-font-item">
                 <span class="custom-font-name">{{ font }}</span>
-                <button class="btn-ghost" @click="removeCustomFont(font)" style="padding: 2px 8px; font-size: 12px">删除</button>
+                <button class="btn-ghost" @click="removeCustomFont(font)"
+                  style="padding: 2px 8px; font-size: 12px">删除</button>
               </div>
             </div>
           </div>
@@ -462,6 +797,47 @@ function commitCapture(targetArr: string[]) {
             <label>已添加的字体</label>
             <span class="badge" style="font-size: 12px">暂无自定义字体</span>
           </div>
+
+          <div class="divider"></div>
+          <div class="section-label">备份与恢复</div>
+
+          <div class="setting-row">
+            <label>导出配置</label>
+            <button class="btn-secondary" :disabled="isExportingConfig" @click="exportConfig"
+              style="padding: 5px 14px; font-size: 12px">
+              {{ isExportingConfig ? '导出中...' : '导出配置' }}
+            </button>
+          </div>
+          <p class="hint" style="margin: -2px 0 6px; padding-left: 0">将当前插件设置导出为 JSON 文件</p>
+
+          <div class="setting-row">
+            <label>导入配置</label>
+            <button class="btn-secondary" :disabled="isImportingConfig" @click="importConfig"
+              style="padding: 5px 14px; font-size: 12px">
+              {{ isImportingConfig ? '导入中...' : '导入配置' }}
+            </button>
+          </div>
+          <p class="hint" style="margin: -2px 0 6px; padding-left: 0">从备份文件导入配置，将新增为独立配置项</p>
+
+          <div class="divider"></div>
+
+          <div class="setting-row">
+            <label>导出书籍</label>
+            <button class="btn-secondary" :disabled="isExportingBooks" @click="exportBooks"
+              style="padding: 5px 14px; font-size: 12px">
+              {{ isExportingBooks ? '导出中...' : '导出书籍' }}
+            </button>
+          </div>
+          <p class="hint" style="margin: -2px 0 6px; padding-left: 0">将书架书籍信息导出为 JSON 文件（不含封面图片）</p>
+
+          <div class="setting-row">
+            <label>导入书籍</label>
+            <button class="btn-secondary" :disabled="isImportingBooks" @click="importBooks"
+              style="padding: 5px 14px; font-size: 12px">
+              {{ isImportingBooks ? '导入中...' : '导入书籍' }}
+            </button>
+          </div>
+          <p class="hint" style="margin: -2px 0 6px; padding-left: 0">从备份文件导入书籍到书架，自动跳过路径重复的书籍</p>
 
         </div>
       </div>
@@ -485,6 +861,8 @@ function commitCapture(targetArr: string[]) {
         </div>
       </div>
     </div>
+
+    <Toast :message="toastMessage" :type="toastType" />
   </div>
 </template>
 
@@ -517,7 +895,7 @@ function commitCapture(targetArr: string[]) {
 .settings-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 10px;
   padding: 18px 22px 16px;
   border-bottom: 1px solid var(--c-border);
   flex-shrink: 0;
@@ -527,6 +905,78 @@ function commitCapture(targetArr: string[]) {
   font-size: 17px;
   font-weight: 700;
   letter-spacing: -0.02em;
+  flex-shrink: 0;
+}
+
+.config-switcher {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.config-select {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  color: var(--c-ink);
+  border-radius: var(--radius-sm);
+  padding: 4px 8px;
+  font-size: 12px;
+  cursor: pointer;
+  max-width: 120px;
+  transition: border-color 0.15s var(--ease-out);
+}
+
+.config-select:focus {
+  border-color: var(--c-accent);
+  outline: none;
+}
+
+.config-action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-xs);
+  color: var(--c-ink-tertiary);
+  transition: background 0.12s var(--ease-out), color 0.12s var(--ease-out);
+}
+
+.config-action-btn:hover:not(:disabled) {
+  background: var(--c-surface-sunken);
+  color: var(--c-ink);
+}
+
+.config-action-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.config-inline-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 22px;
+  background: var(--c-surface-sunken);
+  border-bottom: 1px solid var(--c-border);
+  animation: slide-up 0.15s var(--ease-out);
+}
+
+.config-inline-input {
+  background: var(--c-surface);
+  border: 1px solid var(--c-border);
+  color: var(--c-ink);
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  font-size: 12px;
+  flex: 1;
+  max-width: 200px;
+  transition: border-color 0.15s var(--ease-out);
+}
+
+.config-inline-input:focus {
+  border-color: var(--c-accent);
+  outline: none;
 }
 
 .close-btn {
@@ -537,8 +987,10 @@ function commitCapture(targetArr: string[]) {
   height: 30px;
   border-radius: var(--radius-sm);
   color: var(--c-ink-tertiary);
+  margin-left: auto;
   transition: background 0.12s var(--ease-out), color 0.12s var(--ease-out);
 }
+
 .close-btn:hover {
   background: var(--c-surface-sunken);
   color: var(--c-ink);
@@ -561,7 +1013,11 @@ function commitCapture(targetArr: string[]) {
   margin-bottom: -1px;
   transition: color 0.15s var(--ease-out), border-color 0.15s var(--ease-out);
 }
-.tab-btn:hover { color: var(--c-ink-secondary); }
+
+.tab-btn:hover {
+  color: var(--c-ink-secondary);
+}
+
 .tab-btn.active {
   color: var(--c-accent);
   border-bottom-color: var(--c-accent);
@@ -597,7 +1053,7 @@ function commitCapture(targetArr: string[]) {
   min-height: 36px;
 }
 
-.setting-row > label:first-child {
+.setting-row>label:first-child {
   font-size: 13px;
   color: var(--c-ink);
   flex-shrink: 0;
@@ -626,7 +1082,10 @@ function commitCapture(targetArr: string[]) {
   font-variant-numeric: tabular-nums;
 }
 
-.badge.mono { font-family: var(--font-mono); min-width: 60px; }
+.badge.mono {
+  font-family: var(--font-mono);
+  min-width: 60px;
+}
 
 .select {
   background: var(--c-surface);
@@ -638,6 +1097,7 @@ function commitCapture(targetArr: string[]) {
   cursor: pointer;
   transition: border-color 0.15s var(--ease-out), box-shadow 0.15s var(--ease-out);
 }
+
 .select:focus {
   border-color: var(--c-accent);
   box-shadow: 0 0 0 3px var(--c-accent-soft);
@@ -664,6 +1124,7 @@ function commitCapture(targetArr: string[]) {
   width: 72px;
   transition: border-color 0.15s var(--ease-out), box-shadow 0.15s var(--ease-out);
 }
+
 .color-input:focus {
   border-color: var(--c-accent);
   box-shadow: 0 0 0 3px var(--c-accent-soft);
@@ -681,6 +1142,7 @@ function commitCapture(targetArr: string[]) {
   cursor: pointer;
   transition: border-color 0.15s var(--ease-out), box-shadow 0.15s var(--ease-out);
 }
+
 .key-input:focus {
   border-color: var(--c-accent);
   box-shadow: 0 0 0 3px var(--c-accent-soft);
@@ -696,12 +1158,16 @@ function commitCapture(targetArr: string[]) {
   width: 80px;
   transition: border-color 0.15s var(--ease-out), box-shadow 0.15s var(--ease-out);
 }
+
 .number-input:focus {
   border-color: var(--c-accent);
   box-shadow: 0 0 0 3px var(--c-accent-soft);
 }
 
-.unit { font-size: 12px; color: var(--c-ink-tertiary); }
+.unit {
+  font-size: 12px;
+  color: var(--c-ink-tertiary);
+}
 
 .text-input {
   background: var(--c-surface);
@@ -712,13 +1178,21 @@ function commitCapture(targetArr: string[]) {
   font-size: 13px;
   transition: border-color 0.15s var(--ease-out), box-shadow 0.15s var(--ease-out);
 }
+
 .text-input:focus {
   border-color: var(--c-accent);
   box-shadow: 0 0 0 3px var(--c-accent-soft);
 }
-.full-width { width: 100%; }
 
-.hint { font-size: 11px; color: var(--c-ink-tertiary); margin: 0 0 6px; }
+.full-width {
+  width: 100%;
+}
+
+.hint {
+  font-size: 11px;
+  color: var(--c-ink-tertiary);
+  margin: 0 0 6px;
+}
 
 .tip-icon {
   position: relative;
@@ -735,8 +1209,12 @@ function commitCapture(targetArr: string[]) {
   border-radius: 50%;
   transition: color 0.15s var(--ease-out);
 }
+
 .tip-icon:hover,
-.tip-icon:focus { color: var(--c-accent); }
+.tip-icon:focus {
+  color: var(--c-accent);
+}
+
 .tip-bubble {
   display: none;
   position: absolute;
@@ -757,6 +1235,7 @@ function commitCapture(targetArr: string[]) {
   z-index: 100;
   pointer-events: none;
 }
+
 .tip-bubble::after {
   content: '';
   position: absolute;
@@ -766,8 +1245,11 @@ function commitCapture(targetArr: string[]) {
   border: 6px solid transparent;
   border-top-color: var(--c-surface-overlay);
 }
+
 .tip-icon:hover .tip-bubble,
-.tip-icon:focus .tip-bubble { display: block; }
+.tip-icon:focus .tip-bubble {
+  display: block;
+}
 
 .toggle {
   position: relative;
@@ -775,7 +1257,14 @@ function commitCapture(targetArr: string[]) {
   align-items: center;
   cursor: pointer;
 }
-.toggle input { position: absolute; opacity: 0; width: 0; height: 0; }
+
+.toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
 .toggle-track {
   width: 36px;
   height: 20px;
@@ -784,6 +1273,7 @@ function commitCapture(targetArr: string[]) {
   transition: background 0.2s var(--ease-out);
   position: relative;
 }
+
 .toggle-track::after {
   content: '';
   position: absolute;
@@ -796,10 +1286,20 @@ function commitCapture(targetArr: string[]) {
   transition: transform 0.2s var(--ease-out);
   box-shadow: 0 1px 3px rgba(28, 25, 23, 0.15);
 }
-.toggle input:checked + .toggle-track { background: var(--c-accent); }
-.toggle input:checked + .toggle-track::after { transform: translateX(16px); }
 
-.divider { height: 1px; background: var(--c-border); margin: 10px 0 6px; }
+.toggle input:checked+.toggle-track {
+  background: var(--c-accent);
+}
+
+.toggle input:checked+.toggle-track::after {
+  transform: translateX(16px);
+}
+
+.divider {
+  height: 1px;
+  background: var(--c-border);
+  margin: 10px 0 6px;
+}
 
 .settings-footer {
   display: flex;
@@ -810,34 +1310,53 @@ function commitCapture(targetArr: string[]) {
   flex-shrink: 0;
 }
 
-.btn-primary, .btn-secondary, .btn-ghost, .btn-danger {
+.btn-primary,
+.btn-secondary,
+.btn-ghost,
+.btn-danger {
   padding: 8px 18px;
   border-radius: var(--radius-sm);
   font-size: 13px;
   font-weight: 500;
   transition: all 0.15s var(--ease-out);
 }
+
 .btn-primary {
   background: var(--c-accent);
   color: var(--c-ink-inverse);
 }
-.btn-primary:hover { background: var(--c-accent-hover); }
+
+.btn-primary:hover {
+  background: var(--c-accent-hover);
+}
+
 .btn-secondary {
   background: var(--c-surface-sunken);
   color: var(--c-ink);
   border: 1px solid var(--c-border);
 }
-.btn-secondary:hover { background: var(--c-border); }
+
+.btn-secondary:hover {
+  background: var(--c-border);
+}
+
 .btn-ghost {
   color: var(--c-ink-tertiary);
   padding-left: 0;
 }
-.btn-ghost:hover { color: var(--c-ink); }
+
+.btn-ghost:hover {
+  color: var(--c-ink);
+}
+
 .btn-danger {
   background: var(--c-danger);
   color: var(--c-ink-inverse);
 }
-.btn-danger:hover { opacity: 0.85; }
+
+.btn-danger:hover {
+  opacity: 0.85;
+}
 
 .custom-fonts-list {
   display: flex;
@@ -873,6 +1392,7 @@ function commitCapture(targetArr: string[]) {
   z-index: 9000;
   animation: fade-in 0.12s var(--ease-out);
 }
+
 .confirm-box {
   background: var(--c-surface-overlay);
   border: 1px solid var(--c-border);
@@ -882,6 +1402,16 @@ function commitCapture(targetArr: string[]) {
   box-shadow: var(--shadow-xl);
   animation: slide-up 0.15s var(--ease-out);
 }
-.confirm-box p { margin: 0 0 20px; font-size: 14px; line-height: 1.6; }
-.confirm-actions { display: flex; gap: 8px; justify-content: flex-end; }
+
+.confirm-box p {
+  margin: 0 0 20px;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.confirm-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
 </style>

--- a/plugins/hushreader/src/components/Settings/index.vue
+++ b/plugins/hushreader/src/components/Settings/index.vue
@@ -272,15 +272,37 @@ async function importBooks() {
     if (Array.isArray(data.books)) {
       let added = 0
       let skipped = 0
+      const newBooks = []
       for (const book of data.books) {
-        if (bookStore.books.some(b => b.filePath === book.filePath)) {
+        const filePathName = book.filePath.split(/[\\/]/).pop() ?? book.filePath
+        const isDuplicate = bookStore.books.some(b => {
+          if (b.filePath === book.filePath) return true
+          const existingName = b.filePath.split(/[\\/]/).pop() ?? b.filePath
+          return existingName === filePathName
+        }) || newBooks.some(b => {
+          if (b.filePath === book.filePath) return true
+          const existingName = b.filePath.split(/[\\/]/).pop() ?? b.filePath
+          return existingName === filePathName
+        })
+
+        if (isDuplicate) {
           skipped++
           continue
         }
-        bookStore.addBook(book)
+
+        const now = Date.now()
+        newBooks.push({
+          ...book,
+          id: `book_${now}_${Math.random().toString(36).slice(2)}`,
+          addedAt: now,
+          updatedAt: now
+        })
         added++
       }
-      bookStore.save()
+      if (newBooks.length > 0) {
+        bookStore.books.unshift(...newBooks)
+        bookStore.save()
+      }
       if (added > 0) {
         const msg = skipped > 0
           ? `成功导入 ${added} 本书，跳过 ${skipped} 本重复`
@@ -302,6 +324,7 @@ async function importBooks() {
 
 function deepMerge(target: any, source: any): any {
   for (const key of Object.keys(source)) {
+    if (key === '__proto__' || key === 'constructor') continue
     if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
       if (!target[key]) target[key] = {}
       deepMerge(target[key], source[key])

--- a/plugins/hushreader/src/components/Settings/index.vue
+++ b/plugins/hushreader/src/components/Settings/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useConfigStore, type ReaderConfig } from '../../stores/config'
-import { useBookStore } from '../../stores/books'
+import { useBookStore, type Book } from '../../stores/books'
 import Toast from '../Bookshelf/Toast.vue'
 
 const emit = defineEmits<{ close: [] }>()
@@ -272,7 +272,7 @@ async function importBooks() {
     if (Array.isArray(data.books)) {
       let added = 0
       let skipped = 0
-      const newBooks = []
+      const newBooks: Book[] = []
       for (const book of data.books) {
         const filePathName = book.filePath.split(/[\\/]/).pop() ?? book.filePath
         const isDuplicate = bookStore.books.some(b => {

--- a/plugins/hushreader/src/env.d.ts
+++ b/plugins/hushreader/src/env.d.ts
@@ -28,6 +28,8 @@ interface Services {
   readFileBinary: (filePath: string) => Buffer
   getFileInfo: (filePath: string) => FileInfoResult
   writeTextFile: (text: string) => string
+  writeFileToPath: (filePath: string, content: string, encoding?: string) => string
+  readFileFromPath: (filePath: string) => string
   writeImageFile: (imageData: any) => string
   onHushreaderCommand: (handler: (command: any) => void) => () => void
   getFileModifiedTime: (filePath: string) => number

--- a/plugins/hushreader/src/main.ts
+++ b/plugins/hushreader/src/main.ts
@@ -12,6 +12,13 @@ if (saved) {
   try {
     const cfg = JSON.parse(saved)
     const theme = cfg?.other?.theme
-    if (theme) document.documentElement.setAttribute('data-theme', theme)
-  } catch {}
+    if (theme) {
+      if (theme === 'auto') {
+        const isDark = (window as any).ztools?.isDarkColors?.() ?? window.matchMedia?.('(prefers-color-scheme: dark)')?.matches ?? false
+        document.documentElement.setAttribute('data-theme', isDark ? 'dark' : 'light')
+      } else {
+        document.documentElement.setAttribute('data-theme', theme)
+      }
+    }
+  } catch { }
 }

--- a/plugins/hushreader/src/stores/books.ts
+++ b/plugins/hushreader/src/stores/books.ts
@@ -132,7 +132,7 @@ export const useBookStore = defineStore('books', () => {
     books.value = books.value.filter(b => b.id !== id)
     if (currentBookId.value === id) currentBookId.value = null
     save()
-    removeBookData(id).catch(() => {})
+    removeBookData(id).catch(() => { })
   }
 
   function updateBook(id: string, updates: Partial<Book>) {
@@ -192,6 +192,6 @@ export const useBookStore = defineStore('books', () => {
   return {
     books, currentBookId, currentBook,
     sortBy, searchQuery, activeCategory, filteredBooks, categories,
-    load, addBook, removeBook, updateBook, setCurrentBook
+    load, addBook, removeBook, updateBook, setCurrentBook, save
   }
 })

--- a/plugins/hushreader/src/stores/config.ts
+++ b/plugins/hushreader/src/stores/config.ts
@@ -58,7 +58,10 @@ export interface OtherConfig {
   listMode: boolean
   chapterRegex: string
   customFonts: string[]
-  theme: 'light' | 'dark'
+  theme: 'light' | 'dark' | 'auto'
+  timerEnabled: boolean
+  timerMinutes: number
+  showImages: boolean
 }
 
 export interface ReaderConfig {
@@ -112,7 +115,10 @@ const DEFAULT_CONFIG: ReaderConfig = {
     listMode: false,
     chapterRegex: '',
     customFonts: [],
-    theme: 'light'
+    theme: 'auto',
+    timerEnabled: false,
+    timerMinutes: 30,
+    showImages: false
   },
   appearance: {
     fontSize: 16,
@@ -157,6 +163,10 @@ function storageSet(key: string, value: string) {
 
 export const useConfigStore = defineStore('config', () => {
   const config = ref<ReaderConfig>(structuredClone(DEFAULT_CONFIG))
+  const configList = ref<{ name: string; config: ReaderConfig }[]>([
+    { name: '默认配置', config: structuredClone(DEFAULT_CONFIG) }
+  ])
+  const activeConfigIndex = ref(0)
 
   function load() {
     const data = storageGet('hushreader_config')
@@ -171,10 +181,38 @@ export const useConfigStore = defineStore('config', () => {
         config.value = deepMerge(structuredClone(DEFAULT_CONFIG), saved)
       } catch { }
     }
+    const listData = storageGet('hushreader_config_list')
+    if (listData) {
+      try {
+        const parsed = JSON.parse(listData)
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          configList.value = parsed
+        }
+      } catch { }
+    }
+    const idxData = storageGet('hushreader_active_config')
+    if (idxData) {
+      const idx = parseInt(idxData, 10)
+      if (Number.isFinite(idx) && idx >= 0 && idx < configList.value.length) {
+        activeConfigIndex.value = idx
+      }
+    }
+    if (configList.value.length > 0) {
+      const active = configList.value[activeConfigIndex.value]
+      if (active?.config) {
+        config.value = deepMerge(structuredClone(DEFAULT_CONFIG), active.config)
+      }
+    }
   }
 
   function save() {
     storageSet('hushreader_config', JSON.stringify(config.value))
+    if (configList.value[activeConfigIndex.value]) {
+      configList.value[activeConfigIndex.value].config = JSON.parse(JSON.stringify(config.value))
+      configList.value[activeConfigIndex.value].name = config.value.other.configName || configList.value[activeConfigIndex.value].name
+    }
+    storageSet('hushreader_config_list', JSON.stringify(configList.value))
+    storageSet('hushreader_active_config', String(activeConfigIndex.value))
   }
 
   function resetToDefault() {
@@ -182,7 +220,55 @@ export const useConfigStore = defineStore('config', () => {
     save()
   }
 
-  return { config, load, save, resetToDefault, DEFAULT_CONFIG }
+  function switchConfig(index: number) {
+    if (index < 0 || index >= configList.value.length) return
+    if (configList.value[activeConfigIndex.value]) {
+      configList.value[activeConfigIndex.value].config = JSON.parse(JSON.stringify(config.value))
+    }
+    activeConfigIndex.value = index
+    const target = configList.value[index]
+    config.value = deepMerge(structuredClone(DEFAULT_CONFIG), target.config)
+    save()
+  }
+
+  function addConfig(name: string) {
+    const newConfig = structuredClone(DEFAULT_CONFIG)
+    newConfig.other.configName = name
+    configList.value.push({ name, config: newConfig })
+    const newIndex = configList.value.length - 1
+    switchConfig(newIndex)
+  }
+
+  function removeConfig(index: number) {
+    if (configList.value.length <= 1) return
+    configList.value.splice(index, 1)
+    if (activeConfigIndex.value >= configList.value.length) {
+      activeConfigIndex.value = configList.value.length - 1
+    } else if (activeConfigIndex.value === index) {
+      activeConfigIndex.value = Math.min(index, configList.value.length - 1)
+    } else if (activeConfigIndex.value > index) {
+      activeConfigIndex.value--
+    }
+    const target = configList.value[activeConfigIndex.value]
+    config.value = deepMerge(structuredClone(DEFAULT_CONFIG), target.config)
+    save()
+  }
+
+  function renameConfig(index: number, name: string) {
+    if (configList.value[index]) {
+      configList.value[index].name = name
+      if (index === activeConfigIndex.value) {
+        config.value.other.configName = name
+      }
+      save()
+    }
+  }
+
+  return {
+    config, configList, activeConfigIndex,
+    load, save, resetToDefault,
+    switchConfig, addConfig, removeConfig, renameConfig, DEFAULT_CONFIG
+  }
 })
 
 function deepMerge(target: any, source: any): any {

--- a/plugins/hushreader/src/stores/config.ts
+++ b/plugins/hushreader/src/stores/config.ts
@@ -273,6 +273,7 @@ export const useConfigStore = defineStore('config', () => {
 
 function deepMerge(target: any, source: any): any {
   for (const key of Object.keys(source)) {
+    if (key === '__proto__' || key === 'constructor') continue
     if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
       if (!target[key]) target[key] = {}
       deepMerge(target[key], source[key])


### PR DESCRIPTION
## 插件信息

- **名称**: 隐阅盒
- **插件ID**: hushreader
- **版本**: 1.3.3
- **描述**: 隐阅盒，ZTools自己的摸鱼阅读，支持TXT/EPUB/MOBI格式，沉浸式阅读
- **作者**: meidlinger
- **类型**: 更新

## 本次变更

## [1.3.3](https://github.com/me1dlinger/hushreader/releases/tag/v1.3.3) - 2026-06-19

### Added
- **自动检测系统深浅色模式**：在插件加载时，根据系统深浅色模式自动切换主题，支持手动切换主题
- **资源管理器打开文件位置**：在书籍右键菜单新增"打开文件位置"选项，使用ztools.shellShowItemInFolder()
- **隐阅定时器**：新增设置项，打开定时器后可设置一个时长，隐阅时间到达之后自动关闭隐阅窗口并Toast提示用户
- **备份和恢复所有阅读进度与配置**：备份和恢复所有阅读进度与配置。插件设置导出，所有书籍的元数据导出。实现设置导入，书籍数据导入
- **多配置切换**：实现多配置切换、添加和删除(最少保留一个配置)，导入的配置自动添加为新配置

### Changed
- **分离配置和书籍的导入导出**：将配置和书籍的导入导出分离，配置导入导出时仅和配置相关，书籍导入导出时仅和书籍数据相关
- **定时器相关通知**：在隐阅界面弹出相应通知

### Fixed
- **配置无法导入的问题**：修复配置无法导入的问题
- **优化代码** ：减少不必要的性能开销
- **系统主题自动切换**：修复系统主题发生变化时，systemDark 和 effectiveTheme 无法自动更新
- **优化书籍导入流程**：在导入书籍的循环中，每次调用 bookStore.addBook(book) 都会触发一次同步的 save() 写入操作（保存到 dbStorage 或 localStorage）。如果用户导入的书籍数量较多，会产生大量连续的同步 I/O 写入
- **JSON配置导入漏洞**：如果导入的备份 JSON 文件被恶意篡改，包含 __proto__ 或 constructor 等属性，可能会导致原型链污染（Prototype Pollution）漏洞

## 截图 / 演示
<img width="808" height="609" alt="image_95" src="https://github.com/user-attachments/assets/55ef1940-18f3-4e66-9723-31a5289a978b" />
<img width="775" height="158" alt="image_93" src="https://github.com/user-attachments/assets/ea2aefe2-30de-4e43-b7e3-779ed3fa4e2a" />
<img width="782" height="150" alt="image_94" src="https://github.com/user-attachments/assets/ae4fc914-c277-49fd-b7f1-9c364608e46f" />

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/hushreader/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
