### PR TITLE
Update plugin 本地搜索Neo v1.0.0

### DIFF
--- a/plugins/local-search-neo/package.json
+++ b/plugins/local-search-neo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-search-neo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "借助 Everything 来进行文件搜索",
   "type": "module",
   "scripts": {

--- a/plugins/local-search-neo/public/plugin.json
+++ b/plugins/local-search-neo/public/plugin.json
@@ -4,7 +4,7 @@
   "author": "the_tree",
   "title": "本地搜索Neo",
   "description": "借助 Everything 来进行文件搜索",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.html",
   "preload": "preload/services.js",
   "logo": "logo.png",

--- a/plugins/local-search-neo/src/App.vue
+++ b/plugins/local-search-neo/src/App.vue
@@ -3,7 +3,11 @@ import { onMounted } from "vue";
 import Finder from "./Finder/index.vue";
 import { useFinderEnterAction } from "./Finder/composables/useFinderEnterAction";
 import { getFileIconDataUrl, warmUpFileIconCache } from "./Finder/core/fileIconCache";
-import { DEFAULT_CATEGORIES, buildEverythingQuery } from "./Finder/core/finderLogic";
+import {
+  DEFAULT_CATEGORIES,
+  buildEverythingQuery,
+  mergeResultsByMatchPathPriority,
+} from "./Finder/core/finderLogic";
 import { useFinderCategories } from "./Finder/composables/useFinderCategories";
 import { usePersistStorage } from "./Finder/composables/usePersistStorage";
 import { useSubInput } from "./Finder/composables/useSubInput";
@@ -47,23 +51,39 @@ onMounted(() => {
       try {
         if (!window.services.everything.isAvailable()) return [];
         if (window.services.everything.getStartupStatus().state !== "ready") return [];
-        const result = window.services.everything.query(
+        const nameResult = window.services.everything.query(
           everythingQuery,
           MAIN_PUSH_RESULT_LIMIT,
           "modified-desc",
-          matchPathEnabled.value,
+          false,
         );
-        const items: MainPushSearchResult[] = result.items.map((item) => ({
-          title: item.path ?? getParentPath(item.fullPath),
-          text: item.name,
-          icon: window.ztools.getFileIcon(item.fullPath),
-          fullPath: item.fullPath,
-        }));
+        const matchPathResult = matchPathEnabled.value
+          ? window.services.everything.query(
+              everythingQuery,
+              MAIN_PUSH_RESULT_LIMIT,
+              "modified-desc",
+              true,
+            )
+          : undefined;
 
-        if (result.total > MAIN_PUSH_RESULT_LIMIT) {
+        const resultItems = matchPathResult
+          ? mergeResultsByMatchPathPriority(nameResult.items, matchPathResult.items)
+          : nameResult.items;
+        const total = matchPathResult?.total ?? nameResult.total;
+
+        const items: MainPushSearchResult[] = resultItems
+          .slice(0, MAIN_PUSH_RESULT_LIMIT)
+          .map((item) => ({
+            title: item.path ?? getParentPath(item.fullPath),
+            text: item.name,
+            icon: window.ztools.getFileIcon(item.fullPath),
+            fullPath: item.fullPath,
+          }));
+
+        if (total > MAIN_PUSH_RESULT_LIMIT) {
           items.pop();
           items.push({
-            text: `共有${result.total}个结果，查看更多...`,
+            text: `共有${total}个结果，查看更多...`,
           });
         }
 

--- a/plugins/local-search-neo/src/App.vue
+++ b/plugins/local-search-neo/src/App.vue
@@ -74,9 +74,9 @@ onMounted(() => {
         const items: MainPushSearchResult[] = resultItems
           .slice(0, MAIN_PUSH_RESULT_LIMIT)
           .map((item) => ({
-            title: item.path ?? getParentPath(item.fullPath),
+            title: item.path ?? (item.fullPath ? getParentPath(item.fullPath) : ""),
             text: item.name,
-            icon: window.ztools.getFileIcon(item.fullPath),
+            icon: item.fullPath ? window.ztools.getFileIcon(item.fullPath) : undefined,
             fullPath: item.fullPath,
           }));
 

--- a/plugins/local-search-neo/src/Finder/composables/useFinderSearch.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useFinderSearch.ts
@@ -91,7 +91,10 @@ export function useFinderSearch({
           currentSortMode,
           true,
         );
-        results.value = mergeResultsByMatchPathPriority(nameResult.items, matchPathResult.items);
+        results.value = mergeResultsByMatchPathPriority(
+          nameResult.items,
+          matchPathResult.items,
+        ).slice(0, maxResults);
         everythingTotal.value = matchPathResult.total;
       } else {
         results.value = nameResult.items;

--- a/plugins/local-search-neo/src/Finder/composables/useFinderSearch.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useFinderSearch.ts
@@ -3,6 +3,7 @@ import {
   getNextSelectedPath,
   getNextVisibleCount,
   getRestoredSelectedPath,
+  mergeResultsByMatchPathPriority,
   type FinderResult,
   type FinderSortMode,
 } from "../core/finderLogic";
@@ -76,14 +77,26 @@ export function useFinderSearch({
     visibleCount.value = pageSize;
 
     try {
-      const result = window.services.everything.query(
+      const nameResult = window.services.everything.query(
         everythingQuery,
         maxResults,
         currentSortMode,
-        currentMatchPathEnabled,
+        false,
       );
-      results.value = result.items;
-      everythingTotal.value = result.total;
+
+      if (currentMatchPathEnabled) {
+        const matchPathResult = window.services.everything.query(
+          everythingQuery,
+          maxResults,
+          currentSortMode,
+          true,
+        );
+        results.value = mergeResultsByMatchPathPriority(nameResult.items, matchPathResult.items);
+        everythingTotal.value = matchPathResult.total;
+      } else {
+        results.value = nameResult.items;
+        everythingTotal.value = nameResult.total;
+      }
       updateResultStatus();
       restoreSelection(options);
     } catch (error: unknown) {

--- a/plugins/local-search-neo/src/Finder/composables/useSubInput.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useSubInput.ts
@@ -22,7 +22,6 @@ export function useSubInput({ onInput, placeholder = "全盘搜索" }: UseSubInp
     if (onInput) {
       inputListeners.delete(onInput);
     }
-    disposeSubInput();
   });
 
   function bindSubInput() {
@@ -46,6 +45,7 @@ export function useSubInput({ onInput, placeholder = "全盘搜索" }: UseSubInp
     subInputReady = true;
   }
 
+  /** 当非用户操作需要修改子输入框的值, 不触发重新搜索 */
   function syncSubInputValue() {
     if (!subInputReady) return;
     programmaticInputValue = queryText.value;
@@ -56,19 +56,10 @@ export function useSubInput({ onInput, placeholder = "全盘搜索" }: UseSubInp
     window.ztools.subInputFocus();
   }
 
-  function disposeSubInput() {
-    if (!subInputReady) return;
-
-    window.ztools.removeSubInput();
-    subInputReady = false;
-    programmaticInputValue = undefined;
-  }
-
   return {
     bindSubInput,
     syncSubInputValue,
     focusSubInput,
-    disposeSubInput,
   };
 }
 

--- a/plugins/local-search-neo/src/Finder/core/finderLogic.test.ts
+++ b/plugins/local-search-neo/src/Finder/core/finderLogic.test.ts
@@ -17,6 +17,7 @@ import {
   isPdfPreviewCandidate,
   isTextPreviewCandidate,
   isVideoPreviewCandidate,
+  mergeResultsByMatchPathPriority,
   type FinderCategory,
   type FinderResult,
 } from "./finderLogic";
@@ -103,6 +104,30 @@ test("getRestoredSelectedPath keeps existing visible selection or picks sorted f
   assert.equal(getRestoredSelectedPath(sampleResults, ""), "C:\\beta\\b.txt");
   assert.equal(getRestoredSelectedPath(sampleResults, "D:\\missing.txt"), "C:\\beta\\b.txt");
   assert.equal(getRestoredSelectedPath([], "D:\\missing.txt"), "");
+});
+
+test("mergeResultsByMatchPathPriority keeps name matches first and removes duplicates", () => {
+  const nameResults: FinderResult[] = [
+    { name: "name-a.txt", path: "C:\\demo", fullPath: "C:\\demo\\name-a.txt" },
+    { name: "shared.txt", path: "C:\\demo", fullPath: "C:\\demo\\shared.txt" },
+    { name: "name-b.txt", path: "D:\\demo", fullPath: "D:\\demo\\name-b.txt" },
+  ];
+  const matchPathResults: FinderResult[] = [
+    { name: "shared.txt", path: "C:\\demo", fullPath: "c:\\demo\\shared.txt" },
+    { name: "path-a.txt", path: "C:\\demo", fullPath: "C:\\demo\\path-a.txt" },
+    { name: "path-b.txt", path: "D:\\demo", fullPath: "D:\\demo\\path-b.txt" },
+  ];
+
+  assert.deepEqual(
+    mergeResultsByMatchPathPriority(nameResults, matchPathResults).map((item) => item.fullPath),
+    [
+      "C:\\demo\\name-a.txt",
+      "C:\\demo\\shared.txt",
+      "D:\\demo\\name-b.txt",
+      "C:\\demo\\path-a.txt",
+      "D:\\demo\\path-b.txt",
+    ],
+  );
 });
 
 test("preview candidate helpers detect supported file types", () => {

--- a/plugins/local-search-neo/src/Finder/core/finderLogic.ts
+++ b/plugins/local-search-neo/src/Finder/core/finderLogic.ts
@@ -168,6 +168,23 @@ export function getRestoredSelectedPath(results: FinderResult[], currentPath: st
   return results[0]?.fullPath ?? "";
 }
 
+export function mergeResultsByMatchPathPriority<
+  T extends Pick<FinderResult, "name" | "path" | "fullPath">,
+>(nameResults: T[], matchPathResults: T[]): T[] {
+  const seen = new Set<string>();
+  const merged: T[] = [];
+
+  for (const item of [...nameResults, ...matchPathResults]) {
+    const key = getResultDedupeKey(item);
+    if (seen.has(key)) continue;
+
+    seen.add(key);
+    merged.push(item);
+  }
+
+  return merged;
+}
+
 export function isImagePreviewCandidate(
   file: Pick<FinderResult, "name" | "extension" | "isDirectory">,
 ): boolean {
@@ -263,6 +280,10 @@ export function formatBytes(bytes?: number): string {
   }
 
   return `${formatNumber(value)} ${units[unitIndex]}`;
+}
+
+function getResultDedupeKey(item: Pick<FinderResult, "name" | "path" | "fullPath">): string {
+  return (item.fullPath || `${item.path ?? ""}\\${item.name}`).toLowerCase();
 }
 
 function normalizeCategoryRule(rule: string): string {

--- a/plugins/local-search-neo/src/Finder/index.vue
+++ b/plugins/local-search-neo/src/Finder/index.vue
@@ -124,8 +124,6 @@ watch(
 
 onMounted(() => {
   bindSubInput();
-  syncSubInputValue();
-  startEverythingStatusPolling();
   void ensureEverythingReady();
   window.ztools.onPluginOut(closeTransientState);
 });


### PR DESCRIPTION
## 插件信息

- **名称**: 本地搜索Neo
- **插件ID**: local-search-neo
- **版本**: 1.0.0
- **描述**: 借助 Everything 来进行文件搜索
- **作者**: the_tree
- **类型**: 更新

## 本次变更
- 优化`匹配路径`搜索逻辑，优先显示文件名匹配条目，路径匹配项作为补充
- 修复在插件因搜索栏推送而首次启动时，会清除一次搜索内容的问题


## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/local-search-neo/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
