### PR TITLE
Update plugin 词匠 v1.1.0

### DIFF
--- a/plugins/prompt-forge/CHANGELOG.md
+++ b/plugins/prompt-forge/CHANGELOG.md
@@ -15,11 +15,15 @@
 * **排序不生效修复** — `sortBy`/`sortDir` 等筛选状态定义在 `usePromptStore()` 函数内部，每次调用创建新 ref，导致 PromptList 与 SpaceView 使用不同实例。将所有筛选/排序状态提升到模块级别，确保全局共享
 * **autoFocus 设置未生效** — `appSettings.autoFocus` 定义了但 SpaceView 搜索框 focus 是硬编码的 `setTimeout`，现已读取设置值
 * **版本恢复语义修复** — 恢复快照时复用 `saveEdit()` 导致备注为「编辑 V4」语义不清，改为独立保存逻辑，备注为「保存于恢复前」/「编辑前保存」；版本 tab 新增当前版本卡片
+* **版本恢复幽灵变量** — 恢复快照时保留了旧模板中存在但新模板中不存在的变量，导致 UI 显示无用输入框。改为只提取新模板实际包含的变量
+* **历史记录变量污染** — 保存历史时解构整个 `variableValues` 可能包含其他提示词残留的变量值，改为只过滤当前提示词实际声明的变量
+* **历史查看按钮空值保护** — 原始提示词被硬删除后「查看」按钮自动禁用，避免导航到空管理页面
 
 ### ♻️ Refactor
 
 * **平台 API 类型声明** — 新建 `src/types/ztools.d.ts`，`platform.ts` 和 `storage.ts` 中 `window as any` 替换为类型安全访问
 * **存储错误处理统一** — `storage.ts` 所有 `catch` 块统一添加 `console.error` 日志，`save` 函数补全 `try-catch`
+* **ManageView 搜索性能优化** — `filteredItems` 拆分为 `baseItems` + `fuseInstance` + `filteredItems` 三层计算属性，Fuse 索引仅在基础列表变化时重建，避免每次按键重新实例化
 
 ## \[1.0.0] - 2026-07-11
 

--- a/plugins/prompt-forge/src/views/ManageView.vue
+++ b/plugins/prompt-forge/src/views/ManageView.vue
@@ -35,25 +35,25 @@ const viewingSnapshot = ref<number | null>(null)
 
 const selectedUnit = computed(() => prompt.rawItems.value.find(i => i.id === selectedId.value) || null)
 
-const filteredItems = computed(() => {
+const baseItems = computed(() => {
   let items = prompt.liveItems.value
-  // 类型筛选
   if (filterType.value) items = items.filter(i => i.type === filterType.value)
-  // 归属筛选
   if (filterScope.value === 'project') items = items.filter(i => i.projectId)
   else if (filterScope.value === 'asset') items = items.filter(i => !i.projectId)
-  // Fuse.js 模糊搜索
-  const q = prompt.query.value.trim()
-  if (q) {
-    const fuse = new Fuse(items, {
-      keys: ['title', 'content', 'tags'],
-      threshold: 0.4,
-      ignoreLocation: true,
-      minMatchCharLength: 1,
-    })
-    items = fuse.search(q).map(r => r.item)
-  }
   return items
+})
+
+const fuseInstance = computed(() => new Fuse(baseItems.value, {
+  keys: ['title', 'content', 'tags'],
+  threshold: 0.4,
+  ignoreLocation: true,
+  minMatchCharLength: 1,
+}))
+
+const filteredItems = computed(() => {
+  const q = prompt.query.value.trim()
+  if (!q) return baseItems.value
+  return fuseInstance.value.search(q).map(r => r.item)
 })
 
 watch(selectedUnit, (u) => {
@@ -138,16 +138,12 @@ function restoreSnapshot(snap: { version: number; body: string }) {
     note: `保存于恢复前`,
     createdAt: now,
   })
-  // 从快照内容重新提取变量
+  // 从快照内容重新提取变量（只保留模板中实际存在的变量）
   const detected = extractVariables(snap.body)
-  const seen = new Set<string>()
-  const vars: Variable[] = []
-  for (const d of detected) {
+  const vars: Variable[] = detected.map(d => {
     const existing = u.variables?.find(v => v.name === d.name)
-    vars.push({ name: d.name, required: existing?.required ?? d.required, defaultValue: existing?.defaultValue ?? d.defaultValue })
-    seen.add(d.name)
-  }
-  if (u.variables) for (const v of u.variables) { if (!seen.has(v.name)) { vars.push({ ...v }); seen.add(v.name) } }
+    return { name: d.name, required: existing?.required ?? d.required, defaultValue: existing?.defaultValue ?? d.defaultValue }
+  })
   const newVersion = (u.version || 1) + 1
   prompt.updateItem(u.id, {
     content: snap.body,

--- a/plugins/prompt-forge/src/views/SpaceView.vue
+++ b/plugins/prompt-forge/src/views/SpaceView.vue
@@ -126,7 +126,14 @@ async function handleCopy() {
       promptId: unit.id,
       promptTitle: unit.title,
       copiedContent: text,
-      variableValues: unit.variables?.length ? { ...prompt.variableValues.value } : undefined,
+      variableValues: unit.variables?.length
+        ? unit.variables.reduce((acc, v) => {
+            if (prompt.variableValues.value[v.name] !== undefined) {
+              acc[v.name] = prompt.variableValues.value[v.name]
+            }
+            return acc
+          }, {} as Record<string, string>)
+        : undefined,
     })
     if (appSettings.settings.value.closeAfterCopy) hideMainWindow()
     prompt.resetSelection()
@@ -327,7 +334,7 @@ onUnmounted(() => {
                 </div>
               </div>
               <div class="history-item-actions">
-                <button class="btn" @click="router.navigateToManage(h.promptId)" title="查看原始提示词">查看</button>
+                <button class="btn" :disabled="!prompt.liveItems.value.some(i => i.id === h.promptId)" @click="router.navigateToManage(h.promptId)" title="查看原始提示词">查看</button>
                 <button class="btn" @click="copyText(h.copiedContent); showNotification('✓ 已复制')">复制</button>
                 <button class="btn icon-btn" title="删除" @click="prompt.deleteHistoryEntry(h.id)">✕</button>
               </div>


### PR DESCRIPTION
## 插件信息

- **名称**: 词匠
- **插件ID**: prompt-forge
- **版本**: 1.1.0
- **描述**: 词匠 (PromptForge) 是一款专为AI创作者与开发者打造的提示词资产管理插件，集模板化编排、变量注入、版本控制与一键调用为一体，助你像工匠打磨作品一样，系统化地沉淀、优化并复用高质量提示词。
- **作者**: lunan
- **类型**: 更新

## 本次变更

### ✨ Features

* **使用历史记录** — 每次复制提示词自动记录历史（最多 200 条，可在设置中调节），支持查看、重新复制、单条删除、清空，历史条目可跳转到原始提示词
* **Fuse.js 模糊搜索** — 搜索引擎替换为 Fuse.js，支持容错匹配、拼音、权重排序（标题 > 内容 > 标签），SpaceView 和 ManageView 均已生效
* **提示词排序增强** — 排序栏新增「名称」按钮，支持按标题字母顺序排序
* **MAX\_HISTORY 可配置** — 设置页新增「历史记录上限」滑块控件（50–500），替代原来硬编码的 200 条限制
* **空状态引导** — 「最近」和「收藏」tab 无数据时显示针对性引导文案，而非通用的「没有找到提示词」

### 🐛 Bug Fixes

* **排序不生效修复** — `sortBy`/`sortDir` 等筛选状态定义在 `usePromptStore()` 函数内部，每次调用创建新 ref，导致 PromptList 与 SpaceView 使用不同实例。将所有筛选/排序状态提升到模块级别，确保全局共享
* **autoFocus 设置未生效** — `appSettings.autoFocus` 定义了但 SpaceView 搜索框 focus 是硬编码的 `setTimeout`，现已读取设置值
* **版本恢复语义修复** — 恢复快照时复用 `saveEdit()` 导致备注为「编辑 V4」语义不清，改为独立保存逻辑，备注为「保存于恢复前」/「编辑前保存」；版本 tab 新增当前版本卡片
* **版本恢复幽灵变量** — 恢复快照时保留了旧模板中存在但新模板中不存在的变量，导致 UI 显示无用输入框。改为只提取新模板实际包含的变量
* **历史记录变量污染** — 保存历史时解构整个 `variableValues` 可能包含其他提示词残留的变量值，改为只过滤当前提示词实际声明的变量
* **历史查看按钮空值保护** — 原始提示词被硬删除后「查看」按钮自动禁用，避免导航到空管理页面

### ♻️ Refactor

* **平台 API 类型声明** — 新建 `src/types/ztools.d.ts`，`platform.ts` 和 `storage.ts` 中 `window as any` 替换为类型安全访问
* **存储错误处理统一** — `storage.ts` 所有 `catch` 块统一添加 `console.error` 日志，`save` 函数补全 `try-catch`
* **ManageView 搜索性能优化** — `filteredItems` 拆分为 `baseItems` + `fuseInstance` + `filteredItems` 三层计算属性，Fuse 索引仅在基础列表变化时重建，避免每次按键重新实例化

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [ ] plugin.json 的 name / title / version / description / author 字段均已检查
- [ ] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [ ] 本次 PR 的 diff 仅涉及 `plugins/prompt-forge/` 目录
- [ ] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [ ] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
