### PR TITLE
Update plugin ZTools 提供商 v1.0.2

### DIFF
--- a/plugins/f-provider/package.json
+++ b/plugins/f-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechat-ocr-provider",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "基于微信内置 OCR 引擎的离线图片文字识别 ZTools Provider",
   "type": "module",
   "scripts": {

--- a/plugins/f-provider/public/plugin.json
+++ b/plugins/f-provider/public/plugin.json
@@ -4,12 +4,12 @@
   "title": "ZTools 提供商",
   "description": "OCR + 翻译提供商集合（百度/谷歌/有道/微软翻译、微信 OCR）",
   "author": "kaineooo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "index.html",
   "preload": "preload/services.js",
   "logo": "logo.png",
   "development": {
-    "main": "http://localhost:5173"
+    "main": "http://localhost:5179"
   },
   "providers": {
     "ocr": {
@@ -58,7 +58,7 @@
         {
           "type": "regex",
           "label": "翻译",
-          "match": "^[\\s\\S]*$",
+          "match": "/^[\\s\\S]*$/",
           "minLength": 1
         }
       ]
@@ -71,7 +71,7 @@
         {
           "type": "regex",
           "label": "代码翻译",
-          "match": "^[\\s\\S]*$",
+          "match": "/^[\\s\\S]*$/",
           "minLength": 1
         }
       ]

--- a/plugins/f-provider/src/views/Translate.vue
+++ b/plugins/f-provider/src/views/Translate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue'
 import { ZInput, ZSelect, ZButton, ZSwitch, ZTabs, ZTabPane, useToast } from 'ztools-ui'
 
 /**
@@ -99,6 +99,20 @@ const sourceLang = ref('auto')
 const targetLang = ref('auto') // auto = 走 preload 自动推断（中→英 / 其余→中）
 const sourceText = ref('') // 左侧原文（可编辑）
 const autoTranslate = ref(true) // 自动翻译开关，默认开启
+
+// 原文输入框引用：用于挂载/前台时聚焦 + 全选
+const sourceTextareaRef = ref<HTMLTextAreaElement | null>(null)
+
+/**
+ * 聚焦原文输入框并选中全部文本。
+ * 每次进入（挂载）翻译视图时调用，方便用户直接覆盖输入。
+ */
+function focusAndSelectAll() {
+  const el = sourceTextareaRef.value
+  if (!el) return
+  el.focus()
+  el.select()
+}
 
 const result = ref<{ loading: boolean; text: string; error: string; ms: number }>({
   loading: false,
@@ -225,9 +239,31 @@ watch(
 onMounted(() => {
   refreshProviderStatus()
   provider.value = pickDefaultProvider()
+  // 进入/回到翻译视图时默认聚焦输入框并选中全文，便于直接覆盖输入。
+  // nextTick 确保 DOM（含 v-model 文本）已渲染完成后再 select。
+  nextTick(focusAndSelectAll)
+  // 兜底：窗口被宿主隐藏→恢复（未触发 onPluginEnter、组件未重建）的场景。
+  // Electron 下用 win.hide() 隐藏窗口不会触发 document 的 visibilitychange，
+  // 但会触发 window 的 blur/focus，故监听 window 级 focus：仅当此前确实失焦过
+  // （即窗口曾进入后台）才在恢复时重新聚焦 + 全选，避免页面内交互误触发。
+  window.addEventListener('blur', onWinBlur)
+  window.addEventListener('focus', onWinFocus)
 })
 
+// 记录窗口是否进入过后台。仅当为 true 时，下一次 focus 才视为「从后台恢复」。
+let winWasBlurred = false
+function onWinBlur() {
+  winWasBlurred = true
+}
+function onWinFocus() {
+  if (!winWasBlurred) return
+  winWasBlurred = false
+  nextTick(focusAndSelectAll)
+}
+
 onUnmounted(() => {
+  window.removeEventListener('blur', onWinBlur)
+  window.removeEventListener('focus', onWinFocus)
   if (autoTimer) {
     clearTimeout(autoTimer)
     autoTimer = null
@@ -284,6 +320,7 @@ onUnmounted(() => {
           <span class="tr-col-meta">{{ sourceText.length }} 字</span>
         </div>
         <textarea
+          ref="sourceTextareaRef"
           v-model="sourceText"
           class="tr-textarea"
           placeholder="输入要翻译的文本…"

--- a/plugins/f-provider/vite.config.js
+++ b/plugins/f-provider/vite.config.js
@@ -11,6 +11,9 @@ import vue from '@vitejs/plugin-vue'
 export default defineConfig({
   plugins: [vue()],
   base: './',
+  server: {
+    port: 5179
+  },
   build: {
     // dist/ 内含手动放置的 native/（.node 原生模块，运行中的 ZTools 会加载并锁定）
     // 与 preload/，不能被 emptyOutDir 清空，否则构建时会因文件被占用而失败。


### PR DESCRIPTION
## 插件信息

- **名称**: ZTools 提供商
- **插件ID**: f-provider
- **版本**: 1.0.2
- **描述**: OCR + 翻译提供商集合（百度/谷歌/有道/微软翻译、微信 OCR）
- **作者**: kaineooo
- **类型**: 更新

## 本次变更

- feat: ZTools OCR + 翻译提供商插件（截图识别 / 代码翻译 / manage）
- chore: 调整插件命名空间
- chore: 调整资源url
- feat: 微信 OCR 原生模块支持 macOS（libwxocr.dylib）
- feat: 截图识别结果改为独立窗口展示（左图右文 + 拖动缩放）
- feat: 翻译视图进入/恢复时自动聚焦并全选原文
- fix: 翻译/代码翻译命令的 regex match 补回 /…/ 边界
- chore: 版本号升至 1.0.2，开发端口改为 5179

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/f-provider/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
