### PR TITLE
Update plugin 简单便签 v1.4.0

### DIFF
--- a/plugins/easynote/CHANGELOG.md
+++ b/plugins/easynote/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/1.1.0/)。
 
+## [1.4.0] - 2026-07-21
+
+### 新增
+
+- **直接新建便签指令**：新增 `新建便签` / `新便签` / `new-note` 三个指令，在 ZTools 中直接触发即可打开空白便利贴，无需经过管理主页。由 `plugin.json` 中新增的 `new-note` feature 实现，`App.vue` 的 `onPluginEnter` 处理器按 action code 分发，`new-note` 直接调用 `openEditor(null)` 跳过 Home 页面。
+
 ## [1.3.0] - 2026-07-20
 
 ### 修复

--- a/plugins/easynote/package.json
+++ b/plugins/easynote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easynote",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "轻量、简单的便签应用，支持 Markdown 所见即所得/双栏、纯文本复制、字号控制",
   "type": "module",
   "scripts": {

--- a/plugins/easynote/public/plugin.json
+++ b/plugins/easynote/public/plugin.json
@@ -4,7 +4,7 @@
   "title": "简单便签",
   "description": "轻量、简单的便签应用，支持 Markdown 所见即所得/双栏、纯文本复制、字号控制",
   "author": "咖啡八杯",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "categories": "效率工具",
   "main": "index.html",
   "preload": "preload/services.js",
@@ -18,6 +18,12 @@
       "explain": "便签：Markdown 所见即所得/双栏、纯文本复制、字号控制",
       "icon": "logo.png",
       "cmds": ["便签", "note", "bj"]
+    },
+    {
+      "code": "new-note",
+      "explain": "直接新建便签：跳过主页面，打开空白便利贴",
+      "icon": "logo.png",
+      "cmds": ["新建便签", "新便签", "new-note"]
     }
   ]
 }

--- a/plugins/easynote/src/App.vue
+++ b/plugins/easynote/src/App.vue
@@ -23,10 +23,16 @@ onMounted(() => {
   window.ztools.setExpendHeight?.(560)
 
   window.ztools.onPluginEnter((action) => {
-    if (action.code !== 'note') return
-    reloadNotes()
-    view.value = 'home'
-    window.ztools.setExpendHeight?.(560)
+    if (action.code === 'note') {
+      reloadNotes()
+      view.value = 'home'
+      window.ztools.setExpendHeight?.(560)
+      return
+    }
+    if (action.code === 'new-note') {
+      openEditor(null)
+      return
+    }
   })
 
   // 拦截主窗口关闭：如果便利贴正在打开，阻止关闭并隐藏主窗口


### PR DESCRIPTION
## 插件信息

- **名称**: 简单便签
- **插件ID**: easynote
- **版本**: 1.4.0
- **描述**: 轻量、简单的便签应用，支持 Markdown 所见即所得/双栏、纯文本复制、字号控制
- **作者**: 咖啡八杯
- **类型**: 更新

## 本次变更

### 新增

- **直接新建便签指令**：新增 `新建便签` / `新便签` / `new-note` 三个指令，在 ZTools 中直接触发即可打开空白便利贴，无需经过管理主页。由 `plugin.json` 中新增的 `new-note` feature 实现，`App.vue` 的 `onPluginEnter` 处理器按 action code 分发，`new-note` 直接调用 `openEditor(null)` 跳过 Home 页面。

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/easynote/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
