### PR TITLE
fix(image-batch-studio): 兼容 ZTools 3.0.1

### DIFF
--- a/plugins/image-batch-studio/plugin.json
+++ b/plugins/image-batch-studio/plugin.json
@@ -7,6 +7,7 @@
   "version": "0.1.0",
   "main": "index.html",
   "preload": "preload/services.js",
+  "unpack": "*.dylib",
   "logo": "logo.svg",
   "platform": ["darwin"],
   "categories": ["media"],

--- a/plugins/image-batch-studio/scripts/install-local.mjs
+++ b/plugins/image-batch-studio/scripts/install-local.mjs
@@ -8,15 +8,18 @@ import { open } from "lmdb";
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const source = path.join(root, "dist");
-const target = path.join(
-  os.homedir(),
-  "Library",
-  "Application Support",
-  "ZTools",
-  "plugins",
-  "image-batch-studio"
-);
-const dbPath = path.join(os.homedir(), "Library", "Application Support", "ZTools", "lmdb");
+const home = os.homedir();
+const modernRoot = path.join(home, ".ztools");
+const legacyRoot = path.join(home, "Library", "Application Support", "ZTools");
+const modernLayout = await fs
+  .access(path.join(modernRoot, "version.json"))
+  .then(() => true)
+  .catch(() => false);
+const dataRoot = modernLayout ? modernRoot : legacyRoot;
+const target = path.join(dataRoot, "plugins", "image-batch-studio");
+const dbPath = modernLayout
+  ? path.join(dataRoot, "lmdb", "device")
+  : path.join(dataRoot, "lmdb");
 const pluginName = "image-batch-studio";
 
 function parseJson(value) {
@@ -52,7 +55,7 @@ function openZToolsDb() {
   const env = open({
     path: dbPath,
     mapSize: 2 * 1024 * 1024 * 1024,
-    maxDbs: 3,
+    maxDbs: modernLayout ? 6 : 3,
     compression: false,
     encoding: "binary"
   });
@@ -76,6 +79,7 @@ function buildPluginRecord(pluginConfig) {
     preload: pluginConfig.preload,
     features: Array.isArray(pluginConfig.features) ? pluginConfig.features : [],
     path: target,
+    storageKind: "directory",
     isDevelopment: false,
     installedAt: new Date().toISOString(),
     installedFrom: "local"
@@ -101,4 +105,4 @@ await fs.rm(target, { recursive: true, force: true });
 await fs.mkdir(path.dirname(target), { recursive: true });
 await fs.cp(source, target, { recursive: true });
 await registerInstalledPlugin(JSON.parse(await fs.readFile(path.join(target, "plugin.json"), "utf8")));
-console.log(target);
+console.log(JSON.stringify({ target, dbPath, layout: modernLayout ? "3.x" : "legacy" }, null, 2));

--- a/plugins/image-batch-studio/scripts/smoke-installed.mjs
+++ b/plugins/image-batch-studio/scripts/smoke-installed.mjs
@@ -7,21 +7,25 @@ import { PDFDocument } from "pdf-lib";
 import { open } from "lmdb";
 
 const require = createRequire(import.meta.url);
-const installedPlugin = path.join(
-  os.homedir(),
-  "Library",
-  "Application Support",
-  "ZTools",
-  "plugins",
-  "image-batch-studio"
-);
+const home = os.homedir();
+const modernRoot = path.join(home, ".ztools");
+const legacyRoot = path.join(home, "Library", "Application Support", "ZTools");
+const modernLayout = await fs
+  .access(path.join(modernRoot, "version.json"))
+  .then(() => true)
+  .catch(() => false);
+const dataRoot = modernLayout ? modernRoot : legacyRoot;
+const installedPlugin = path.join(dataRoot, "plugins", "image-batch-studio");
+const dbPath = modernLayout
+  ? path.join(dataRoot, "lmdb", "device")
+  : path.join(dataRoot, "lmdb");
 const processor = require(path.join(installedPlugin, "preload", "processor.js"));
 
 function readInstalledPluginRecord() {
   const env = open({
-    path: path.join(os.homedir(), "Library", "Application Support", "ZTools", "lmdb"),
+    path: dbPath,
     mapSize: 2 * 1024 * 1024 * 1024,
-    maxDbs: 3,
+    maxDbs: modernLayout ? 6 : 3,
     compression: false,
     encoding: "binary"
   });

--- a/plugins/image-batch-studio/scripts/verify-darwin-sharp-runtimes.mjs
+++ b/plugins/image-batch-studio/scripts/verify-darwin-sharp-runtimes.mjs
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 
 const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const imgModules = path.join(root, "dist", "preload", "node_modules", "@img");
+const manifest = JSON.parse(await fs.readFile(path.join(root, "dist", "plugin.json"), "utf8"));
 const requiredPackages = [
   "sharp-darwin-arm64",
   "sharp-libvips-darwin-arm64",
@@ -24,4 +25,8 @@ if (missing.length > 0) {
   throw new Error(`Missing macOS sharp runtime packages: ${missing.join(", ")}`);
 }
 
-console.log(JSON.stringify({ ok: true, packages: requiredPackages }, null, 2));
+if (manifest.unpack !== "*.dylib") {
+  throw new Error("plugin.json must unpack Sharp's libvips dylibs for ZTools 3.0.1 ASAR installs");
+}
+
+console.log(JSON.stringify({ ok: true, packages: requiredPackages, unpack: manifest.unpack }, null, 2));


### PR DESCRIPTION
## 变更内容

- 适配 ZTools 3.x 的 ~/.ztools 数据目录和设备 LMDB
- 为插件注册记录补充 storageKind: directory
- 声明解包 Sharp 的 libvips dylib，兼容 ZPX/ASAR 安装
- 更新本地安装、已安装冒烟测试和运行时校验脚本

## 验证

- 54 项单元测试通过
- TypeScript 类型检查和生产构建通过
- ZTools 3.0.1 Electron 运行时成功加载 Sharp 0.34.5
- ASAR unpack 布局及图片处理冒烟测试通过