### PR TITLE
Update plugin Scripty 任务库 v1.0.1

### DIFF
--- a/plugins/scripty/package.json
+++ b/plugins/scripty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scripty",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "ZTools 本地脚本任务管理器，支持安全执行、Cron 调度、环境变量、运行日志和备份迁移",
   "type": "module",
   "scripts": {

--- a/plugins/scripty/public/plugin.json
+++ b/plugins/scripty/public/plugin.json
@@ -4,7 +4,7 @@
   "title": "Scripty 任务库",
   "description": "本地管理、运行和定时调度脚本，支持环境变量、运行日志与备份迁移",
   "author": "皮皮虾我们走",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.html",
   "preload": "preload/services.js",
   "logo": "logo.png",

--- a/plugins/scripty/public/preload/run-service.js
+++ b/plugins/scripty/public/preload/run-service.js
@@ -307,6 +307,7 @@ function createRunService(metadataRepository, managedScriptRepository, logFileRe
   const api = {
     /**
      * Starts one persisted task using executable plus an argument array and returns once spawn emits.
+     * The run record snapshots the script's full filename (including extension) for historical details.
      * The renderer cannot provide an executable, source path, command string, shell option, or Cron trigger.
      */
     start(taskId, trigger = 'manual', scheduledToken) {
@@ -354,7 +355,7 @@ function createRunService(metadataRepository, managedScriptRepository, logFileRe
             id: runId,
             taskId: task.id,
             taskNameSnapshot: task.name,
-            scriptNameSnapshot: script.name,
+            scriptNameSnapshot: script.relativePath.split('/').pop() || script.name,
             trigger,
             startedAt,
             finishedAt: null,

--- a/plugins/scripty/src/App.vue
+++ b/plugins/scripty/src/App.vue
@@ -60,7 +60,7 @@ const sections = [
   { id: 'scripts', label: '脚本', icon: ScriptsIcon, title: '还没有脚本', description: '新建脚本后，源码将由 Scripty 统一托管。' },
   { id: 'dependencies', label: '依赖', icon: DependenciesIcon, title: '还没有依赖', description: '在这里管理所有脚本共享的 Node.js 与 Python 直接依赖。' },
   { id: 'environments', label: '环境变量', icon: EnvironmentsIcon, title: '还没有环境变量', description: '在这里维护任务运行时需要注入的全局变量和任务变量。' },
-  { id: 'history', label: '运行历史', icon: HistoryIcon, title: '暂无运行记录', description: '任务执行后，可在这里查看运行中任务、状态、耗时、退出码和日志。' },
+  { id: 'history', label: '运行历史', icon: HistoryIcon, title: '暂无运行记录', description: '任务执行后，可在这里查看运行中任务、状态、执行时间、耗时和日志。' },
   { id: 'backups', label: '备份', icon: BackupsIcon, title: '尚未生成备份', description: '选择需要迁移的数据后，可在这里导出备份。' }
 ] as const
 

--- a/plugins/scripty/src/components/HistoryView.vue
+++ b/plugins/scripty/src/components/HistoryView.vue
@@ -3,6 +3,7 @@ import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { LogChunk, RunEvent } from '../types/api'
 import type { RunRecord, RunStatus, RunTrigger } from '../types/domain'
 import RunStatusTag from './RunStatusTag.vue'
+import ImageViewer from './ImageViewer.vue'
 
 interface ActiveLogEntry {
   timestamp: string
@@ -28,6 +29,8 @@ const records = ref<RunRecord[]>([])
 const total = ref(0)
 const page = ref(1)
 const pageSize = 20
+/** Chunk size used when auto-loading to close an unclosed image marker; the backend caps single reads at 256 KiB. */
+const autoImageChunkBytes = 256 * 1024
 const search = ref('')
 const status = ref<RunStatus | 'all'>('all')
 const trigger = ref<RunTrigger | 'all'>('all')
@@ -41,6 +44,8 @@ const logContent = ref('')
 const logLoading = ref(false)
 const retryingId = ref<string | null>(null)
 const cleaning = ref(false)
+/** 详情图片放大预览的 data URL；非空时挂载全屏 ImageViewer。 */
+const previewSrc = ref<string | null>(null)
 const triggerLabels = { manual: '手动', cron: '定时', retry: '重跑' } as const
 const statusOptions = [
   { label: '全部状态', value: 'all' }, { label: '成功', value: 'success' }, { label: '失败', value: 'failed' },
@@ -51,7 +56,7 @@ const pageCount = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
 
 /** Run ids known to be active, kept reactive so cards and the detail drawer reflect live state. */
 const activeRunIds = ref(new Set<string>())
-/** Live log buffers for active runs, capped at ~1 MiB each; released on finish unless a live detail holds them. */
+/** Live log buffers for active runs, held in full so multi-chunk images can reassemble; released on finish unless a live detail holds them. */
 const activeLogs = ref<Record<string, ActiveLogEntry[]>>({})
 const stoppingRunIds = ref(new Set<string>())
 /** Highest sequence seen per run, so stale events from a superseded snapshot are ignored. */
@@ -66,11 +71,6 @@ function formatTime(timestamp: string): string {
 
 /** True when the open detail is streaming a live run rather than reading a persisted log. */
 const isLiveDetail = computed(() => detailMode.value === 'live')
-
-/** Detects if content is a data URL image (base64 encoded). */
-function isDataUrlImage(content: string): boolean {
-  return /^data:image\/(png|jpe?g|gif|webp|svg\+xml);base64,/.test(content.trim())
-}
 
 /**
  * 图片标记协议：脚本输出图片时用标记框住 base64 数据，避免按行分块后无法拼接。
@@ -142,47 +142,64 @@ function parseImageMarkers(entries: LogLine[]): LogLine[] {
   return result
 }
 
-/** Splits the persisted log buffer into `[hh:mm:ss] [type]` meta plus content entries, anchoring on the persisted line prefix. */
+/**
+ * Splits the persisted log buffer into entries.
+ * 图片标记可能单独成行（无时间戳前缀），需要作为独立条目参与解析；
+ * 否则 parseImageMarkers 会因为 START/END 被合并到前后条目尾巴而无法闭合。
+ * 不在此阶段判断图片，统一交给 parseImageMarkers 处理标记协议。
+ */
 const logEntries = computed<LogLine[]>(() => {
   const text = logContent.value
   if (!text) return []
-  const prefix = /(?:^|\n)\d{4}-\d{2}-\d{2} (\d{2}:\d{2}:\d{2}) \[(stdout|stderr)\] /g
-  const matches = [...text.matchAll(prefix)]
-  return matches.map((match, index) => {
-    const contentStart = match.index! + match[0].length
-    const contentEnd = index + 1 < matches.length ? matches[index + 1].index! : text.length
-    const content = text.slice(contentStart, contentEnd).replace(/\n$/, '')
-    const isImage = isDataUrlImage(content)
-    return {
-      time: match[1],
-      type: match[2] as 'stdout' | 'stderr',
-      content,
-      isImage,
-      imageDataUrl: isImage ? content.trim() : undefined
+  const lines = text.split('\n')
+  const result: LogLine[] = []
+  const prefix = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}) \[(stdout|stderr)\] /
+
+  let currentTime = '00:00:00'
+  let currentType: 'stdout' | 'stderr' = 'stdout'
+
+  for (const line of lines) {
+    const match = line.match(prefix)
+    if (match) {
+      currentTime = match[2]
+      currentType = match[3] as 'stdout' | 'stderr'
+      const content = line.slice(match[0].length)
+      result.push({
+        time: currentTime,
+        type: currentType,
+        content
+      })
+    } else if (line.trim()) {
+      // 无时间戳前缀的非空行（如图片标记），继承上一条的时间和类型
+      result.push({
+        time: currentTime,
+        type: currentType,
+        content: line
+      })
     }
-  })
+  }
+  return result
 })
 
-/** Live log entries for the open run, reversed so the newest output stays pinned to the top. */
+/** Live log entries in emit order; image markers are parsed forward and displayed in chronological order. */
 const liveLogEntries = computed<LogLine[]>(() => {
   if (detailMode.value !== 'live' || !selected.value) return []
   const entries = activeLogs.value[selected.value.id] ?? []
-  return [...entries].reverse().map(entry => {
-    const isImage = isDataUrlImage(entry.content)
-    return {
-      time: formatTime(entry.timestamp),
-      type: entry.type,
-      content: entry.content,
-      isImage,
-      imageDataUrl: isImage ? entry.content.trim() : undefined
-    }
-  })
+  return entries.map(entry => ({
+    time: formatTime(entry.timestamp),
+    type: entry.type,
+    content: entry.content
+  }))
 })
 
-/** Entries rendered in the detail log grid, switching between live and persisted sources. */
+/**
+ * Entries rendered in the detail log grid, switching between live and persisted sources.
+ * 图片标记解析必须在原始 emit 顺序上进行（前向状态机：START → base64 → END）；
+ * 无论运行中还是运行完成，都按时间顺序从上到下输出，不再反转。
+ */
 const visibleLogEntries = computed<LogLine[]>(() => {
-  const raw = detailMode.value === 'live' ? liveLogEntries.value : logEntries.value
-  return parseImageMarkers(raw)
+  const input = detailMode.value === 'live' ? liveLogEntries.value : logEntries.value
+  return parseImageMarkers(input)
 })
 
 let historyRequestSequence = 0
@@ -204,7 +221,7 @@ async function loadHistory() {
   } else if (result?.ok === false) emit('feedback', 'error', result.error.message)
 }
 
-/** Opens one run detail; active runs stream live reverse logs, terminal runs read persisted chunks. */
+/** Opens one run detail from its history card; active runs stream live logs, terminal runs read persisted chunks. */
 async function openDetail(record: RunRecord) {
   const detail = await window.scripty.history.get(record.id)
   if (detail.ok === false) return emit('feedback', 'error', detail.error.message)
@@ -216,16 +233,22 @@ async function openDetail(record: RunRecord) {
   if (detailMode.value === 'persisted') await loadNextLogChunk()
 }
 
-/** Appends one bounded 64 KiB persisted log chunk while capping renderer memory at 1 MiB. */
-async function loadNextLogChunk() {
+/**
+ * Appends one persisted log chunk without truncation, so a base64 image split across many chunks
+ * can reassemble inside `logContent` and close its END marker.
+ * `length` defaults to 64 KiB for manual paging; the image-auto-load watcher passes a larger block.
+ * The template binds this directly to `@click`, which passes the DOM event as the first argument,
+ * so a non-number `length` is coerced back to the default rather than sent to the backend.
+ */
+async function loadNextLogChunk(length: number = 64 * 1024) {
   if (!selected.value || logLoading.value || log.value?.end) return
+  const readLength = typeof length === 'number' ? length : 64 * 1024
   logLoading.value = true
-  const chunk = await window.scripty.history.readLog(selected.value.id, { offset: log.value?.nextOffset ?? 0, length: 64 * 1024 })
+  const chunk = await window.scripty.history.readLog(selected.value.id, { offset: log.value?.nextOffset ?? 0, length: readLength })
   logLoading.value = false
   if (chunk.ok === false) return emit('feedback', 'error', chunk.error.message)
   log.value = chunk.data
-  const combined = logContent.value + chunk.data.content
-  logContent.value = combined.length > 1024 * 1024 ? combined.slice(combined.length - 1024 * 1024) : combined
+  logContent.value += chunk.data.content
 }
 
 /** Closes the detail and releases any live buffer held open for a finished run. */
@@ -240,6 +263,12 @@ function closeDetail() {
   detailMode.value = null
   log.value = null
   logContent.value = ''
+  previewSrc.value = null
+}
+
+/** Opens the fullscreen zoom/pan viewer for one log image entry. */
+function openImagePreview(entry: LogLine) {
+  if (entry.imageDataUrl) previewSrc.value = entry.imageDataUrl
 }
 
 /** Starts a failed historical task through its current persisted configuration and refreshes the page afterward. */
@@ -308,16 +337,6 @@ function markInactive(runId: string) {
   activeRunIds.value = next
 }
 
-/** Keeps the most recent live log entries within a byte budget, always retaining the latest entry. */
-function capLogEntries(entries: ActiveLogEntry[], maxBytes: number): ActiveLogEntry[] {
-  let total = 0
-  for (let i = entries.length - 1; i >= 0; i--) {
-    total += entries[i].content.length
-    if (total > maxBytes) return entries.slice(Math.min(i + 1, entries.length - 1))
-  }
-  return entries
-}
-
 /** Stops one active process tree and keeps the button locked until preload confirms a terminal record. */
 async function stopActiveRun(runId: string) {
   const api = window.scripty?.runs
@@ -350,7 +369,7 @@ function handleRunEvent(event: RunEvent) {
   } else if (event.type === 'stdout' || event.type === 'stderr') {
     const current = activeLogs.value[event.runId] ?? []
     const appended = [...current, { timestamp: new Date().toISOString(), type: event.type, content: event.chunk }]
-    activeLogs.value = { ...activeLogs.value, [event.runId]: capLogEntries(appended, 1024 * 1024) }
+    activeLogs.value = { ...activeLogs.value, [event.runId]: appended }
   }
 }
 
@@ -387,6 +406,17 @@ function disposeHistory() {
 }
 
 watch([search, status, trigger], () => { page.value = 1; void loadHistory() })
+/**
+ * 持久化日志按块读取，单张截图的 base64 通常远超一块；开始标记落在当前块而结束标记还在后续块时，
+ * parseImageMarkers 会留下 isPending 占位条目（显示"图片数据接收中…"）。只要还没读到文件末尾就自动
+ * 续读更大的块，直到图片闭合或日志读完，兑现 README 承诺的"跨日志块自动重组"。运行中的实时流不走此分支。
+ */
+watch(visibleLogEntries, entries => {
+  if (detailMode.value !== 'persisted') return
+  if (!entries.some(entry => entry.isPending)) return
+  if (!log.value || log.value.end || logLoading.value) return
+  void loadNextLogChunk(autoImageChunkBytes)
+})
 onMounted(initializeHistory)
 onBeforeUnmount(disposeHistory)
 </script>
@@ -404,13 +434,26 @@ onBeforeUnmount(disposeHistory)
     <p v-if="loading" class="task-message" role="status">正在加载运行历史…</p>
     <div v-else-if="records.length === 0" class="empty-state"><div class="empty-state__mark">H</div><h3>暂无运行记录</h3><p>任务完成或失败后会保留摘要。</p></div>
     <ul v-else class="history-list">
-      <li v-for="record in records" :key="record.id" class="history-row">
-        <div><strong>{{ record.taskNameSnapshot }}</strong><span>{{ record.scriptNameSnapshot }}</span></div>
-        <RunStatusTag :status="record.status" />
-        <dl><div><dt>触发</dt><dd>{{ triggerLabels[record.trigger] }}</dd></div><div><dt>耗时</dt><dd>{{ formatDuration(record.durationMs) }}</dd></div><div><dt>退出码</dt><dd>{{ record.exitCode ?? '—' }}</dd></div></dl>
+      <li
+        v-for="record in records"
+        :key="record.id"
+        class="history-row"
+        role="button"
+        tabindex="0"
+        :aria-label="`查看${record.taskNameSnapshot}的运行详情`"
+        @click="openDetail(record)"
+        @keydown.enter="openDetail(record)"
+        @keydown.space.prevent="openDetail(record)"
+      >
+        <div class="history-row__summary">
+          <strong class="history-row__name">{{ record.taskNameSnapshot }}</strong>
+          <RunStatusTag :status="record.status" />
+          <span class="history-row__tag">{{ triggerLabels[record.trigger] }}</span>
+          <span class="history-row__tag">{{ formatDuration(record.durationMs) }}</span>
+        </div>
+        <time class="history-row__time" :datetime="record.startedAt">{{ formatDateTime(record.startedAt) }}</time>
         <p v-if="record.errorSummary" class="history-error">{{ record.errorSummary }}</p>
-        <div class="history-row__actions">
-          <ZButton size="small" @click="openDetail(record)">查看详情</ZButton>
+        <div v-if="activeRunIds.has(record.id) || record.status === 'failed'" class="history-row__actions" @click.stop @keydown.stop>
           <ZButton v-if="activeRunIds.has(record.id)" type="danger" size="small" :loading="stoppingRunIds.has(record.id)" @click="stopActiveRun(record.id)">停止</ZButton>
           <ZButton v-if="record.status === 'failed'" size="small" type="primary" :loading="retryingId === record.id" @click="retry(record)">快速重跑</ZButton>
         </div>
@@ -440,18 +483,19 @@ onBeforeUnmount(disposeHistory)
               <template v-for="(entry, index) in visibleLogEntries" :key="index">
                 <span class="history-log__meta" :class="`history-log__meta--${entry.type}`">[{{ entry.time }}] [{{ entry.type }}]</span>
                 <div v-if="entry.isImage" class="history-log__content history-log__content--image">
-                  <img v-if="entry.imageDataUrl" :src="entry.imageDataUrl" alt="运行截图" class="history-log__image" />
+                  <img v-if="entry.imageDataUrl" :src="entry.imageDataUrl" alt="运行截图" title="点击放大" class="history-log__image" @click="openImagePreview(entry)" />
                   <span v-else class="history-log__image-pending">图片数据接收中…</span>
                 </div>
                 <span v-else class="history-log__content">{{ entry.content }}</span>
               </template>
             </div>
             <pre v-else class="history-log">{{ isLiveDetail ? '等待输出…' : (logContent || '暂无日志') }}</pre>
-            <p v-if="!isLiveDetail && logContent.length >= 1024 * 1024" class="task-message">页面仅保留最近 1 MiB 日志内容。</p>
           </section>
         </div>
       </ZDrawerContent>
     </ZDrawer>
+
+    <ImageViewer v-if="previewSrc" :src="previewSrc" @close="previewSrc = null" />
   </section>
 </template>
 
@@ -477,6 +521,7 @@ onBeforeUnmount(disposeHistory)
 
 .history-row__actions {
   justify-content: flex-start;
+  grid-column: 1 / -1;
 }
 
 /* zt-button--primary is a class on the ztools-ui button internals; reach it via :deep. */
@@ -560,6 +605,12 @@ onBeforeUnmount(disposeHistory)
   border: 1px solid var(--border-color);
   border-radius: 6px;
   display: block;
+  cursor: zoom-in;
+  transition: filter 0.15s ease;
+}
+
+.history-log__image:hover {
+  filter: brightness(0.92);
 }
 
 .history-log__image-pending {
@@ -590,40 +641,59 @@ onBeforeUnmount(disposeHistory)
 .history-row {
   max-height: 150px;
   display: grid;
-  grid-template-columns: minmax(160px, 1fr) auto minmax(120px, 1fr);
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 16px;
   padding: 16px 18px;
   border: 1px solid var(--border-color);
   border-radius: 14px;
   background: var(--card-bg);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.history-row > div:first-child {
-  display: grid;
-  gap: 4px;
+.history-row:hover {
+  border-color: color-mix(in srgb, var(--primary-color) 40%, var(--border-color));
+  background: var(--hover-bg);
 }
 
-.history-row > div:first-child span,
-.history-row dt {
+.history-row:focus-visible {
+  outline: none;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px var(--primary-light-bg);
+}
+
+.history-row__summary {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.history-row__name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-row__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 9px;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  background: var(--card-bg);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.history-row__time {
+  justify-self: end;
   color: var(--text-secondary);
   font-size: 12px;
-}
-
-.history-row dl {
-  display: flex;
-  justify-content: flex-end;
-  gap: 20px;
-  margin: 0;
-}
-
-.history-row dl div {
-  display: grid;
-  gap: 4px;
-}
-
-.history-row dd {
-  margin: 0;
+  white-space: nowrap;
 }
 
 .history-error {

--- a/plugins/scripty/src/components/ImageViewer.vue
+++ b/plugins/scripty/src/components/ImageViewer.vue
@@ -1,0 +1,269 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+
+/**
+ * 全屏图片预览：点击图片后浮于所有抽屉/弹窗之上，支持滚轮/按钮缩放与自由拖拽平移。
+ * 通过 Teleport 挂到 body 并使用高于 ZDrawer(10000) 的 z-index，确保覆盖详情抽屉。
+ * 缩放围绕光标位置进行（标准图片查看器体验），拖拽用 Pointer Events 以兼容鼠标与触屏。
+ */
+const props = defineProps<{
+  src: string
+  alt?: string
+}>()
+const emit = defineEmits<{ (event: 'close'): void }>()
+
+/** 全屏覆盖层；其中心即图片静止位置，也是滚轮缩放的坐标原点参考。 */
+const overlayRef = ref<HTMLDivElement | null>(null)
+/** 当前缩放倍数；1 表示图片以 max-box 适配后的原始尺寸展示。 */
+const scale = ref(1)
+/** 相对居中静止位置的像素位移。 */
+const translateX = ref(0)
+const translateY = ref(0)
+/** 主指针按下并在拖动图片时为真，用于切换光标样式。 */
+const dragging = ref(false)
+
+const MIN_SCALE = 0.2
+const MAX_SCALE = 12
+/** 单次缩放倍率（滚轮一格、按钮一次、键盘 +/- 一次）。 */
+const ZOOM_STEP = 1.2
+
+const imageStyle = computed(() => ({
+  transform: `translate(${translateX.value}px, ${translateY.value}px) scale(${scale.value})`
+}))
+
+const scaleLabel = computed(() => `${Math.round(scale.value * 100)}%`)
+
+let pointerId: number | null = null
+let startPointerX = 0
+let startPointerY = 0
+let startTranslateX = 0
+let startTranslateY = 0
+
+/** 把候选缩放值限制在支持区间内，避免归零或过度放大。 */
+function clampScale(value: number): number {
+  return Math.min(MAX_SCALE, Math.max(MIN_SCALE, value))
+}
+
+/** 开始拖拽：记录起始指针与当前位移，pointermove 据此计算增量。 */
+function onPointerDown(event: PointerEvent) {
+  if (event.pointerType === 'mouse' && event.button !== 0) return
+  pointerId = event.pointerId
+  startPointerX = event.clientX
+  startPointerY = event.clientY
+  startTranslateX = translateX.value
+  startTranslateY = translateY.value
+  dragging.value = true
+  ;(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId)
+}
+
+function onPointerMove(event: PointerEvent) {
+  if (!dragging.value || event.pointerId !== pointerId) return
+  translateX.value = startTranslateX + (event.clientX - startPointerX)
+  translateY.value = startTranslateY + (event.clientY - startPointerY)
+}
+
+function onPointerUp(event: PointerEvent) {
+  if (event.pointerId !== pointerId) return
+  dragging.value = false
+  pointerId = null
+}
+
+/**
+ * 滚轮缩放保持光标下方的点不动。默认中心 transform-origin 下，
+ * `transform: translate(t) scale(s)` 将本地点 p 投影到 `中心 + t + s·p`；
+ * 反解出缩放后仍锚定光标的位移即得下式。
+ */
+function onWheel(event: WheelEvent) {
+  event.preventDefault()
+  const overlay = overlayRef.value
+  if (!overlay) return
+  const rect = overlay.getBoundingClientRect()
+  const cursorFromCenterX = event.clientX - (rect.left + rect.width / 2)
+  const cursorFromCenterY = event.clientY - (rect.top + rect.height / 2)
+  const factor = event.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP
+  zoomToward(cursorFromCenterX, cursorFromCenterY, factor)
+}
+
+/**
+ * 按指定倍率缩放，并保持 (anchorX, anchorY)（相对覆盖层中心）这点不动。
+ * 按钮缩放传入 (0, 0) 即围绕图片中心；滚轮缩放传入光标坐标。
+ */
+function zoomToward(anchorX: number, anchorY: number, factor: number) {
+  const newScale = clampScale(scale.value * factor)
+  if (newScale === scale.value) return
+  const ratio = newScale / scale.value
+  translateX.value = anchorX * (1 - ratio) + ratio * translateX.value
+  translateY.value = anchorY * (1 - ratio) + ratio * translateY.value
+  scale.value = newScale
+}
+
+/** 重置为居中适配视图。 */
+function resetView() {
+  scale.value = 1
+  translateX.value = 0
+  translateY.value = 0
+}
+
+/** 围绕图片中心缩放一步，供工具栏按钮复用。 */
+function zoomByStep(factor: number) {
+  zoomToward(0, 0, factor)
+}
+
+/** 键盘等价：Esc 关闭、0 重置、+/- 缩放。 */
+function onKeydown(event: KeyboardEvent) {
+  switch (event.key) {
+    case 'Escape':
+      emit('close')
+      break
+    case '0':
+      resetView()
+      break
+    case '+':
+    case '=':
+      zoomByStep(ZOOM_STEP)
+      break
+    case '-':
+    case '_':
+      zoomByStep(1 / ZOOM_STEP)
+      break
+    default:
+      return
+  }
+  event.stopPropagation()
+  event.preventDefault()
+}
+
+/** 点击空白背板关闭；点击图片或工具栏不关闭。 */
+function onBackdropClick(event: MouseEvent) {
+  if (event.target === overlayRef.value) emit('close')
+}
+
+onMounted(() => {
+  // 捕获阶段监听，使 Esc 在此先行处理并阻止冒泡，避免详情抽屉的按键逻辑误关抽屉。
+  document.addEventListener('keydown', onKeydown, true)
+})
+onBeforeUnmount(() => {
+  document.removeEventListener('keydown', onKeydown, true)
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      ref="overlayRef"
+      class="image-viewer"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="props.alt ?? '图片预览'"
+      @click="onBackdropClick"
+      @wheel="onWheel"
+    >
+      <img
+        :src="props.src"
+        :alt="props.alt ?? '图片预览'"
+        class="image-viewer__img"
+        :class="{ 'image-viewer__img--grabbing': dragging }"
+        draggable="false"
+        :style="imageStyle"
+        @pointerdown="onPointerDown"
+        @pointermove="onPointerMove"
+        @pointerup="onPointerUp"
+        @pointercancel="onPointerUp"
+        @dblclick="resetView"
+      />
+      <div class="image-viewer__toolbar" @click.stop>
+        <button class="image-viewer__btn" type="button" aria-label="缩小" title="缩小（− 或滚轮下）" @click="zoomByStep(1 / ZOOM_STEP)">−</button>
+        <span class="image-viewer__scale">{{ scaleLabel }}</span>
+        <button class="image-viewer__btn" type="button" aria-label="放大" title="放大（+ 或滚轮上）" @click="zoomByStep(ZOOM_STEP)">+</button>
+        <button class="image-viewer__btn" type="button" aria-label="重置" title="重置（0 或双击）" @click="resetView">⟲</button>
+        <button class="image-viewer__btn image-viewer__btn--close" type="button" aria-label="关闭" title="关闭（Esc）" @click="emit('close')">×</button>
+      </div>
+      <p class="image-viewer__hint">滚轮缩放 · 拖拽移动 · 双击重置 · Esc 关闭</p>
+    </div>
+  </Teleport>
+</template>
+
+<style scoped lang="scss">
+.image-viewer {
+  position: fixed;
+  inset: 0;
+  z-index: 100000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.88);
+  user-select: none;
+}
+
+.image-viewer__img {
+  max-width: 92vw;
+  max-height: 92vh;
+  object-fit: contain;
+  transform-origin: center center;
+  will-change: transform;
+  touch-action: none;
+  cursor: grab;
+}
+
+.image-viewer__img--grabbing {
+  cursor: grabbing;
+}
+
+.image-viewer__toolbar {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: rgba(32, 32, 32, 0.82);
+  color: #fff;
+  font-size: 13px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.image-viewer__btn {
+  display: grid;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  place-items: center;
+  background: transparent;
+  color: #fff;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.image-viewer__btn:hover {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.image-viewer__btn--close {
+  margin-left: 6px;
+  font-size: 22px;
+}
+
+.image-viewer__scale {
+  min-width: 46px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.image-viewer__hint {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  margin: 0;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 12px;
+  pointer-events: none;
+}
+</style>

--- a/plugins/scripty/src/composables/cmCompletion.ts
+++ b/plugins/scripty/src/composables/cmCompletion.ts
@@ -35,8 +35,9 @@ function cmType(detail: string | undefined): string {
  * `getCompletionContext` regex (word chars, $, - and .) so dotted/PowerShell
  * tokens still complete as one unit.
  *
- * `collectCompletions` already filters and ranks by prefix, so this source opts
- * out of CM's own filtering (`filter: false`) and returns the pre-sorted list.
+ * `collectCompletions` narrows the initial candidate pool by prefix. CodeMirror's
+ * filtering stays enabled so `validFor` can synchronously rescore and reorder
+ * that full pool against every additional character the user types.
  */
 function buildCompletionSource(getLanguage: () => ScriptLanguage | null) {
   return (ctx: CompletionContext): CompletionResult | null => {
@@ -52,7 +53,7 @@ function buildCompletionSource(getLanguage: () => ScriptLanguage | null) {
       detail: item.detail,
       type: cmType(item.detail)
     }))
-    return { from: word.from, to: word.to, options, filter: false, validFor: /^[\w$.-]*$/ }
+    return { from: word.from, to: word.to, options, validFor: /^[\w$.-]*$/ }
   }
 }
 
@@ -61,5 +62,7 @@ export const cmAutocomplete = (getLanguage: () => ScriptLanguage | null) =>
   autocompletion({
     override: [buildCompletionSource(getLanguage)],
     activateOnTyping: true,
-    closeOnBlur: true
+    closeOnBlur: true,
+    filterStrict: true,
+    maxRenderedOptions: 24
   })

--- a/plugins/scripty/src/composables/cmTheme.ts
+++ b/plugins/scripty/src/composables/cmTheme.ts
@@ -40,7 +40,7 @@ const editorTheme = EditorView.theme({
     outline: 'none'
   },
   '.cm-tooltip, .cm-tooltipAutocomplete > ul > li[aria-selected]': {
-    backgroundColor: 'var(--card-bg)',
+    backgroundColor: 'var(--dialog-bg, var(--input-bg))',
     border: '1px solid var(--border-color)'
   },
   '.cm-tooltip-autocomplete > ul > li[aria-selected]': {

--- a/plugins/scripty/src/composables/scriptCompletions.ts
+++ b/plugins/scripty/src/composables/scriptCompletions.ts
@@ -204,6 +204,8 @@ function matchesPrefix(label: string, prefix: string): boolean {
 /**
  * Builds the merged, filtered and ranked suggestion list for the current prefix.
  * Exact case match ranks first, then static (curated) entries, then alphabetical.
+ * The complete matched pool is returned so CodeMirror can rescore it as the user
+ * continues typing; the editor configuration limits how many rows are rendered.
  */
 export function collectCompletions(code: string, language: ScriptLanguage, prefix: string): CompletionItem[] {
   if (!prefix) return []
@@ -228,5 +230,5 @@ export function collectCompletions(code: string, language: ScriptLanguage, prefi
     return left.label.localeCompare(right.label, 'en')
   })
 
-  return matched.slice(0, 24)
+  return matched
 }


### PR DESCRIPTION
## 插件信息

- **名称**: Scripty 任务库
- **插件ID**: scripty
- **版本**: 1.0.1
- **描述**: 本地管理、运行和定时调度脚本，支持环境变量、运行日志与备份迁移
- **作者**: 皮皮虾我们走
- **类型**: 更新

## 本次变更

- init: 初始化项目
- feat: 实现 Scripty 脚本任务管理器首个 MVP
- style: 优化各视图布局与调度状态展示
- feat: 新增依赖管理与脚本目录树编辑器
- refactor: 优化依赖安装逻辑与 npm CLI 路径解析
- feat: 实现通用跨平台可执行文件查找器
- feat: 实现任务日志抽屉查看器与日志流式展示
- refactor: 优化筛选器默认值与搜索提示文案
- feat: 桥接脚本任务能力为 MCP 工具并优化任务卡片布局
- feat: 引入文件类型图标并将编辑器高亮与执行语言解耦
- refactor: 精简脚本管理流程并统一运行历史与解释器发现
- chore: 添加预览图片资源
- docs: 重写 README 面向用户介绍插件并补充预览图与 MCP 工具说明
- refactor: 将构建产物整理为可直接导入的自包含 dist
- fix: 修复 Windows 下备份导入的兼容性与健壮性
- fix: 让依赖安装兼容 mise/Volta 等 Node shim 启动器
- fix: 为 preload 沙箱补齐 setImmediate/clearImmediate 兜底
- refactor: 移除依赖视图中冗余的"安装中"标签
- feat: dev 命令改为启动测试服并监听 public 变化实时打包 dist
- feat: 桥接环境变量管理为 MCP 工具并保证值不外泄
- refactor: 移除任务就绪状态标签并清理 verify:clean 脚本
- feat: 新增依赖后处理命令支持并在历史日志中展示 base64 图片
- feat: 引入图片标记协议跨日志块重组运行截图并同步文档与 MCP 工具描述
- fix: 移除日志截断与条目反转以闭合跨块图片标记并自动续读未闭合截图
- feat: 新增历史截图全屏预览组件支持滚轮缩放与拖拽平移
- feat: 优化运行历史交互并完善脚本补全体验
- release: 更新发布1.0.1版本

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/scripty/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
