### PR TITLE
Add plugin office-suite-workbench v0.1.0

### DIFF
--- a/plugins/office-suite-workbench/.gitignore
+++ b/plugins/office-suite-workbench/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/plugins/office-suite-workbench/LICENSE
+++ b/plugins/office-suite-workbench/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 harris
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/office-suite-workbench/README.md
+++ b/plugins/office-suite-workbench/README.md
@@ -1,0 +1,123 @@
+# Office 全家桶
+
+一个基于 [iOfficeAI/OfficeCLI](https://github.com/iOfficeAI/OfficeCLI) 的 ZTools 本地文档工作台，覆盖 Word、Excel、PowerPoint 的读取、检查、编辑、批处理与 MCP 调用。
+
+> 当前范围是 OOXML 三件套：`.docx`、`.xlsx`、`.pptx`。它不等同于 Microsoft 365 全部产品，不包含 Outlook、Access、OneNote、Visio，也不承诺旧格式 `.doc/.xls/.ppt`。
+
+## 已实现
+
+- Word / Excel / PowerPoint 分区工作站与文件触发入口。
+- 结构速览、正文提取、统计、问题扫描、OpenXML 校验、视觉预览。
+- 受控 OfficeCLI 命令台和三种格式的常用命令配方。
+- `shell:false` 的 preload 执行桥；UI 不接触 `child_process`、`fs` 或任意 shell。
+- OfficeCLI 环境变量/常见路径自动发现、超时和输出上限。
+- MCP 原生握手探测、客户端配置生成和显式注册/移除。
+- ZTools HTTP MCP 工具 `office_document`，以及 OfficeCLI 原生 stdio 兼容通道。
+- React / TypeScript / Vite UI、Node preload 测试和真实 OfficeCLI 冒烟测试。
+
+## 运行依赖
+
+插件首版不捆绑 OfficeCLI 二进制，避免把所有平台资产塞进插件包，也不会静默执行远程安装脚本。请先安装 OfficeCLI：
+
+```bash
+# macOS / Linux
+curl -fsSL https://d.officecli.ai/install.sh | bash
+
+# Windows PowerShell
+irm https://d.officecli.ai/install.ps1 | iex
+```
+
+然后验证：
+
+```bash
+officecli --version
+```
+
+插件会依次检查只读环境变量 `OFFICECLI_PATH`、当前 `PATH`、`~/.local/bin`、Homebrew/Scoop 与 Windows 官方 `%LOCALAPPDATA%\OfficeCLI` 等常见目录。renderer 不能指定任意可执行文件。当前开发机实测版本为 `1.0.139`；上游能力与许可审计基线为 `1.0.141`。
+
+## MCP：推荐使用 ZTools 网关
+
+`plugin.json` 声明 `office_document`，preload 启动后立即调用 `window.ztools.registerTool()`。ZTools 会把它聚合到本地 HTTP MCP：
+
+```text
+http://127.0.0.1:36579/mcp
+```
+
+在 ZTools 设置 → MCP 服务中启用服务并复制 API Key。Codex 示例：
+
+```toml
+[mcp_servers.ztools]
+url = "http://127.0.0.1:36579/mcp"
+http_headers = { Authorization = "Bearer <ZTOOLS_API_KEY>" }
+```
+
+工具的外部名称由宿主生成，通常类似：
+
+```text
+office_suite_workbench_office_document
+```
+
+以客户端实际返回的 `tools/list` 为准。调用时优先传 argv 数组：
+
+```json
+{
+  "command": [
+    "view",
+    "/absolute/path/report.docx",
+    "issues",
+    "--json"
+  ]
+}
+```
+
+ZTools 2.4.0 起支持当前工具命名和多模态透传；推荐使用 ZTools 3.0.1 或更高版本。
+
+### OfficeCLI 原生 stdio（高级兼容模式）
+
+不经过 ZTools 时，可让 MCP 客户端直接启动：
+
+```json
+{
+  "command": "/absolute/path/to/officecli",
+  "args": ["mcp"]
+}
+```
+
+原生 server 暴露单个 `officecli(command)` 工具。此模式拥有 OfficeCLI 的完整进程权限，会绕过插件侧命令策略，仅建议用于可信的本机 MCP 客户端。
+
+## 安全边界
+
+- 所有文档命令通过 argv 调用固定 OfficeCLI 二进制，始终 `shell:false`。
+- 命令、参数、超时和输出大小均有限制；`install`、`plugins`、`skills`、`mcp` 等管理命令不能从通用执行器调用。
+- ZTools MCP 工具只接收 `command`，不接受二进制路径、工作目录或环境变量覆盖。
+- 外部 MCP 调用禁用隐式 resident，并阻止 `import`、`merge`、`raw-set`、`add-part`、`open`、`--out`、`--save` 和拉起浏览器等高风险路径。
+- 持有有效 MCP Key 的客户端仍可读取或修改当前 OS 用户有权访问的 Office 文件；首版不提供目录级授权沙箱。
+- MCP Key 不能提交到 Git、截图或聊天记录。ZTools 设置页虽然显示回环地址，仍建议同时使用系统防火墙并只在可信设备启用。
+- 高风险任务请先复制原文件；`validate` 通过不代表 Word / Excel / PowerPoint 的最终视觉效果正确。
+
+详细设计见 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)，MCP 验收步骤见 [docs/MCP.md](docs/MCP.md)。
+
+## 开发与验证
+
+```bash
+npm install
+npm run dev
+npm run typecheck
+npm test
+npm run test:integration
+npm run build
+```
+
+构建产物在 `dist/`，其中 preload 和 MCP 辅助源码保持可读，不压缩、不混淆。根仓库的发布脚本会在检测到该插件变更后打包 `dist/`。
+
+## 已知边界
+
+- PowerPoint 使用绝对定位，复杂版式必须截图并在 PowerPoint / Keynote / WPS 中复核。
+- Word 页码、目录和交叉引用可能依赖真实 Word 分页引擎刷新。
+- Excel 复杂公式、动态数组和图表缓存不能只依赖 OpenXML 校验。
+- 动画、Morph、3D、SmartArt、OLE 与 speaker notes 视为实验能力。
+- PDF 导出和其他格式需要 OfficeCLI 的额外插件，不属于首版内置能力。
+
+## 许可与归属
+
+OfficeCLI 采用 Apache-2.0 许可。本插件使用 “Powered by OfficeCLI” 表述，不代表 iOfficeAI 官方发行版；首版不重新分发其二进制。若未来加入内置运行时下载，发布物必须同时携带 OfficeCLI 的 `LICENSE`、`NOTICE` 和第三方许可声明并校验官方 SHA-256 清单。

--- a/plugins/office-suite-workbench/THIRD_PARTY_NOTICES.md
+++ b/plugins/office-suite-workbench/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,63 @@
+# Third-party notices
+
+The production bundle includes the following packages:
+
+- React 19.2.6, ReactDOM 19.2.6 and Scheduler 0.27.0 — MIT — Copyright Meta Platforms, Inc. and affiliates — <https://react.dev/>
+- lucide-react 1.17.0 — ISC — Copyright 2026 Lucide Icons and Contributors — <https://lucide.dev/>
+- Some Lucide icons are derived from Feather — MIT — Copyright 2013-present Cole Bemis.
+
+OfficeCLI is an external runtime dependency and is not included in this plugin bundle. It is licensed under Apache-2.0: <https://github.com/iOfficeAI/OfficeCLI>.
+
+## React / ReactDOM / Scheduler — MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Lucide — ISC
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+## Feather-derived icons — MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/office-suite-workbench/docs/ARCHITECTURE.md
+++ b/plugins/office-suite-workbench/docs/ARCHITECTURE.md
@@ -1,0 +1,81 @@
+# 架构说明
+
+## 目标
+
+同一套 Office 文档能力同时服务于 ZTools UI、ZTools HTTP MCP 和独立 stdio MCP 客户端；本地进程权限只存在于可审核的 preload 层。
+
+```mermaid
+flowchart LR
+  UI["React 工作台"] --> Bridge["window.officeSuite 窄接口"]
+  HTTP["ZTools HTTP MCP :36579"] --> Tool["registerTool: office_document"]
+  Bridge --> Runner["OfficeCLI Runner"]
+  Tool --> Policy["MCP Policy Guard"] --> Runner
+  Runner -->|"spawn / shell:false"| CLI["OfficeCLI binary"]
+  CLI --> DOCX[".docx"]
+  CLI --> XLSX[".xlsx"]
+  CLI --> PPTX[".pptx"]
+  STDIO["独立 MCP 客户端"] -. "高级直连" .-> Native["officecli mcp"] --> CLI
+```
+
+## 分层
+
+### UI
+
+React 只负责文件选择、命令构建、状态显示和结果可视化。快捷操作使用 argv 数组，避免文件名中的空格、引号、反斜杠和 `$` 被再次解析。
+
+### Preload bridge
+
+`preload/services.cjs` 只暴露业务方法，不把 `fs`、`child_process` 或 runner 对象交给页面。返回值固定为可序列化 envelope：
+
+```js
+{ ok: true, data: value }
+{ ok: false, error: { code, message, details? } }
+```
+
+### Runner
+
+`preload/officecli-runner.cjs` 负责：
+
+- 发现并验证可执行文件。
+- 将字符串安全分词，或直接接收 argv。
+- 命令 allowlist、参数数量和长度校验。
+- 固定 `shell:false`，设置超时与 stdout/stderr 上限。
+- 解析 `--json` 输出。
+- 探测 OfficeCLI 原生 MCP 的 `initialize` 与 `tools/list`。
+
+### ZTools MCP tool
+
+`plugin.json.tools.office_document` 是宿主发现契约；preload 顶层立即注册同名 handler。MCP 可能在 UI 从未打开时后台唤起插件，因此该 handler 不读取 React 状态。`backgroundRunning: true` 避免隐藏 WebContents 节流影响子进程事件和超时。
+
+## 运行时策略
+
+首版使用系统安装的 OfficeCLI，不重新分发二进制。后续若提供内置 RuntimeManager，应满足：
+
+1. 锁定精确版本和平台资产。
+2. 下载 `SHA256SUMS` 并 fail-closed 校验。
+3. 写入插件数据目录的版本化子目录。
+4. 校验成功后原子替换，保留上一个已验证版本回滚。
+5. 随分发物提供 Apache-2.0 `LICENSE`、`NOTICE` 和第三方声明。
+
+## 写操作一致性
+
+- 三个以上的同文件修改优先使用 OfficeCLI 原子 `batch`。
+- UI 默认禁用自动 resident；需要长会话时显式 `open`，完成后 `save` / `close`。
+- 生产级批处理应先复制到临时输出，完成 `validate`、`view issues` 和视觉审计后再交付。
+- 同一文件的并发写应在未来版本增加路径级串行队列；首版由 UI 单任务 busy 状态和 OfficeCLI 文件锁共同防护。
+
+## 威胁模型
+
+受信任边界内包括当前 OS 用户、ZTools preload 和指定 OfficeCLI 二进制。网页页面、MCP 请求参数和文档内容均视为不可信输入。
+
+主要控制：
+
+- 不调用 shell。
+- 不允许 MCP 覆盖 binary path / cwd / env。
+- 禁止 OfficeCLI 安装、升级、插件、skill 安装和 MCP 配置管理命令进入通用文档 runner。
+- MCP Key 使用 Authorization header，不放 query string。
+- 对超时和输出上限 fail closed。
+
+ZTools 3.0.1 的 MCP 后端实际监听 `0.0.0.0`；启用它意味着局域网可达性取决于防火墙和 API Key。该风险属于宿主边界，插件仍通过收窄命令面降低影响。
+
+首版没有目录级授权列表：持有有效 Key 的调用方仍可操作当前 OS 用户可访问的绝对路径 Office 文件。后续版本应把用户选择的工作区根目录持久化到插件存储，并以 realpath + symlink 检查强制执行。

--- a/plugins/office-suite-workbench/docs/MCP.md
+++ b/plugins/office-suite-workbench/docs/MCP.md
@@ -1,0 +1,51 @@
+# MCP 接入与验收
+
+## 通道 A：ZTools HTTP MCP（推荐）
+
+1. 安装并启动 ZTools 3.0.1 或更高版本。
+2. 安装本插件，确认 `plugin.json` 和 `preload/services.cjs` 位于同一发布目录。
+3. 打开 ZTools 设置 → MCP 服务并启用服务。
+4. 复制 endpoint 和 API Key；客户端优先使用 `Authorization: Bearer KEY`。
+5. 调用 `initialize`、`notifications/initialized`、`tools/list`。
+6. 在工具列表中查找 `office_suite_workbench_office_document` 一类名称。
+7. 依次调用：
+
+```json
+{ "command": ["help", "docx", "paragraph"] }
+```
+
+```json
+{ "command": ["view", "/absolute/path/report.docx", "text"] }
+```
+
+```json
+{ "command": ["validate", "/absolute/path/report.docx", "--json"] }
+```
+
+错误 Key 必须返回未授权；禁用插件后，工具应从 `tools/list` 消失。
+
+## 通道 B：OfficeCLI stdio
+
+```json
+{
+  "command": "/absolute/path/to/officecli",
+  "args": ["mcp"]
+}
+```
+
+协议为一行一个 JSON-RPC 2.0 消息。握手顺序：
+
+1. `initialize`（OfficeCLI 当前返回协议 `2024-11-05`）。
+2. `notifications/initialized`。
+3. `tools/list`，应只包含 `officecli`。
+4. `tools/call`，参数为 `{ "command": string | string[] }`。
+
+## 金样验收矩阵
+
+| 格式 | 创建 | 读取 | 修改 | 交付门禁 |
+|---|---|---|---|---|
+| DOCX | `create` | `view text` / `get` | paragraph / run / table | `validate` + `view issues` + Word/WPS 复核 |
+| XLSX | `create` | `get` / `query` | cell / formula / table | `validate` + cachedValue 抽检 + Excel/WPS 复核 |
+| PPTX | `create` | `get / --depth 2` | slide / shape / chart | `validate` + `view issues` + screenshot + PowerPoint 复核 |
+
+还应覆盖：带空格和中文的绝对路径、错误扩展名、被占用文件、超时、超大输出、并发写、进程被杀和插件后台首次加载。

--- a/plugins/office-suite-workbench/index.html
+++ b/plugins/office-suite-workbench/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
+    <link rel="icon" href="./logo.svg" />
+    <title>Office 全家桶</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/plugins/office-suite-workbench/logo.svg
+++ b/plugins/office-suite-workbench/logo.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-label="Office 全家桶">
+  <rect width="128" height="128" rx="26" fill="#101719"/>
+  <path d="M28 29h44c8 0 14 6 14 14v57H42c-8 0-14-6-14-14V29Z" fill="#1768d4"/>
+  <path d="M43 20h43c8 0 14 6 14 14v66H57c-8 0-14-6-14-14V20Z" fill="#18864b" opacity=".94"/>
+  <path d="M58 29h28c8 0 14 6 14 14v57H72c-8 0-14-6-14-14V29Z" fill="#ee5b2b"/>
+  <path d="M43 46h42M43 62h31M43 78h21" stroke="#fff8e8" stroke-width="7" stroke-linecap="round"/>
+  <path d="M86 95h18" stroke="#f6d44a" stroke-width="7" stroke-linecap="round"/>
+</svg>

--- a/plugins/office-suite-workbench/mcp/README.md
+++ b/plugins/office-suite-workbench/mcp/README.md
@@ -1,0 +1,8 @@
+# MCP compatibility note
+
+This plugin does not ship a second JSON-RPC proxy process.
+
+- Recommended: ZTools loads `preload/services.cjs`, registers `office_document`, and exposes it through the host HTTP MCP service.
+- Compatibility mode: configure the resolved OfficeCLI binary directly with `args: ["mcp"]`.
+
+Keeping both paths on the same OfficeCLI runtime avoids an extra resident process and a redundant JSON-RPC hop.

--- a/plugins/office-suite-workbench/package-lock.json
+++ b/plugins/office-suite-workbench/package-lock.json
@@ -1,0 +1,1399 @@
+{
+  "name": "ztools-office-suite-workbench",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ztools-office-suite-workbench",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "lucide-react": "1.17.0",
+        "react": "19.2.6",
+        "react-dom": "19.2.6"
+      },
+      "devDependencies": {
+        "@types/node": "25.9.1",
+        "@types/react": "19.2.15",
+        "@types/react-dom": "19.2.3",
+        "@vitejs/plugin-react": "6.0.2",
+        "typescript": "6.0.3",
+        "vite": "^8.1.5",
+        "vitest": "4.1.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmmirror.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmmirror.com/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmmirror.com/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmmirror.com/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmmirror.com/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmmirror.com/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
+      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmmirror.com/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmmirror.com/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmmirror.com/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmmirror.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmmirror.com/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmmirror.com/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmmirror.com/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.22",
+      "resolved": "https://registry.npmmirror.com/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmmirror.com/react/-/react-19.2.6.tgz",
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.6",
+      "resolved": "https://registry.npmmirror.com/react-dom/-/react-dom-19.2.6.tgz",
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.6"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmmirror.com/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmmirror.com/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmmirror.com/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmmirror.com/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmmirror.com/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/plugins/office-suite-workbench/package.json
+++ b/plugins/office-suite-workbench/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "ztools-office-suite-workbench",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "A ZTools workbench for Word, Excel and PowerPoint powered by OfficeCLI, with native MCP access.",
+  "license": "MIT",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1 --port 5188",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run test:unit && npm run test:preload",
+    "test:unit": "vitest run tests/unit",
+    "test:preload": "node --test tests/preload/*.test.cjs",
+    "test:integration": "node --test tests/integration/*.test.cjs",
+    "build": "npm test && npm run typecheck && vite build && node scripts/prepare-dist.mjs && npm run verify:dist",
+    "verify:dist": "node scripts/verify-dist.mjs",
+    "preview": "vite preview --host 127.0.0.1 --port 4188"
+  },
+  "dependencies": {
+    "lucide-react": "1.17.0",
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
+  },
+  "devDependencies": {
+    "@types/node": "25.9.1",
+    "@types/react": "19.2.15",
+    "@types/react-dom": "19.2.3",
+    "@vitejs/plugin-react": "6.0.2",
+    "typescript": "6.0.3",
+    "vite": "^8.1.5",
+    "vitest": "4.1.7"
+  },
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  }
+}

--- a/plugins/office-suite-workbench/plugin.json
+++ b/plugins/office-suite-workbench/plugin.json
@@ -1,0 +1,97 @@
+{
+  "name": "office-suite-workbench",
+  "title": "Office 全家桶",
+  "description": "基于 OfficeCLI 的 Word、Excel、PowerPoint 文档工作台，支持检查、编辑、批处理与 MCP 调用。",
+  "author": "harris",
+  "version": "0.1.0",
+  "main": "index.html",
+  "preload": "preload/services.cjs",
+  "logo": "logo.svg",
+  "categories": ["productivity", "text"],
+  "development": {
+    "main": "http://127.0.0.1:5188"
+  },
+  "pluginSetting": {
+    "single": true,
+    "height": 780,
+    "backgroundRunning": true
+  },
+  "features": [
+    {
+      "code": "office-suite-workbench",
+      "explain": "打开 Office 全家桶工作台",
+      "icon": "logo.svg",
+      "cmds": [
+        "Office 全家桶",
+        "OfficeCLI",
+        "Word 工具",
+        "Excel 工具",
+        "PPT 工具",
+        "Office MCP",
+        "文档体检",
+        {
+          "type": "files",
+          "fileType": "file",
+          "label": "用 Office 全家桶处理",
+          "extensions": ["docx", "xlsx", "pptx"],
+          "maxLength": 100
+        }
+      ]
+    }
+  ],
+  "tools": {
+    "office_document": {
+      "title": "Office 文档操作",
+      "description": "通过 OfficeCLI 创建、读取、检查和修改 Word (.docx)、Excel (.xlsx) 与 PowerPoint (.pptx) 文档。command 使用 OfficeCLI 命令行语法或 argv 数组；不确定语法时先调用 help，修改文档前先调用 load_skill word|excel|pptx。管理类命令和任意 shell 执行被禁用。",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "command": {
+            "oneOf": [
+              {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 65536
+              },
+              {
+                "type": "array",
+                "minItems": 1,
+                "maxItems": 256,
+                "items": {
+                  "type": "string",
+                  "maxLength": 65536
+                }
+              }
+            ],
+            "description": "OfficeCLI 命令，例如 `help pptx shape`、`view report.docx issues --json`，或预拆分 argv 数组。"
+          }
+        },
+        "required": ["command"]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": { "type": "boolean" },
+          "command": { "type": "string" },
+          "args": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "exitCode": { "type": "integer" },
+          "stdout": { "type": "string" },
+          "stderr": { "type": "string" },
+          "json": {},
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": { "type": "string" },
+              "message": { "type": "string" }
+            }
+          }
+        },
+        "required": ["ok"]
+      }
+    }
+  }
+}

--- a/plugins/office-suite-workbench/preload/command-parser.cjs
+++ b/plugins/office-suite-workbench/preload/command-parser.cjs
@@ -1,0 +1,306 @@
+'use strict'
+
+/**
+ * Parse the small, auditable subset of OfficeCLI that the ZTools UI may run.
+ *
+ * This module deliberately does not try to emulate a shell. Quoting is only a
+ * convenience for turning a command string into argv; the resulting arguments
+ * are passed directly to child_process.spawn with shell:false by the runner.
+ */
+
+const MAX_COMMAND_LENGTH = 64 * 1024
+const MAX_ARGUMENTS = 512
+const MAX_ARGUMENT_LENGTH = 16 * 1024
+
+const DOCUMENT_COMMANDS = Object.freeze([
+  'add',
+  'add-part',
+  'batch',
+  'close',
+  'create',
+  'dump',
+  'get',
+  'help',
+  'import',
+  'load_skill',
+  'merge',
+  'move',
+  'open',
+  'query',
+  'raw',
+  'raw-set',
+  'refresh',
+  'remove',
+  'save',
+  'set',
+  'swap',
+  'validate',
+  'view'
+])
+const DOCUMENT_COMMAND_SET = new Set(DOCUMENT_COMMANDS)
+
+// These commands change OfficeCLI itself, install integrations, start a
+// protocol server, or expose internal process plumbing. They are available only
+// through purpose-built runner methods (MCP registration/probing) when needed.
+const BLOCKED_MANAGEMENT_COMMANDS = Object.freeze([
+  '__resident-serve__',
+  'config',
+  'install',
+  'load-skill',
+  'mcp',
+  'plugin',
+  'plugins',
+  'serve',
+  'skill',
+  'skills',
+  'uninstall',
+  'update',
+  'upgrade',
+  'watch',
+  'unwatch'
+])
+const BLOCKED_MANAGEMENT_COMMAND_SET = new Set(BLOCKED_MANAGEMENT_COMMANDS)
+
+const MIN_ARGUMENTS = Object.freeze({
+  add: 2,
+  'add-part': 2,
+  batch: 1,
+  close: 1,
+  create: 1,
+  dump: 1,
+  get: 1,
+  help: 0,
+  import: 2,
+  load_skill: 1,
+  merge: 2,
+  move: 2,
+  open: 1,
+  query: 2,
+  raw: 1,
+  'raw-set': 2,
+  refresh: 1,
+  remove: 2,
+  save: 1,
+  set: 2,
+  swap: 3,
+  validate: 1,
+  view: 2
+})
+
+class CommandValidationError extends Error {
+  constructor(code, message, details) {
+    super(message)
+    this.name = 'CommandValidationError'
+    this.code = code
+    if (details !== undefined) this.details = details
+  }
+}
+
+function tokenizeCommand(command) {
+  if (typeof command !== 'string') {
+    throw new CommandValidationError('INVALID_COMMAND_TYPE', 'Command must be a string or an argv array.')
+  }
+  if (command.length > MAX_COMMAND_LENGTH) {
+    throw new CommandValidationError('COMMAND_TOO_LONG', `Command exceeds ${MAX_COMMAND_LENGTH} characters.`)
+  }
+  if (command.includes('\0')) {
+    throw new CommandValidationError('INVALID_CHARACTER', 'Command must not contain NUL characters.')
+  }
+
+  const tokens = []
+  let value = ''
+  let quote = null
+  let tokenStarted = false
+
+  const pushToken = () => {
+    if (!tokenStarted) return
+    tokens.push(value)
+    value = ''
+    tokenStarted = false
+    if (tokens.length > MAX_ARGUMENTS) {
+      throw new CommandValidationError('TOO_MANY_ARGUMENTS', `Command exceeds ${MAX_ARGUMENTS} arguments.`)
+    }
+  }
+
+  for (let index = 0; index < command.length; index += 1) {
+    const character = command[index]
+
+    if (quote === "'") {
+      if (character === "'") {
+        quote = null
+      } else {
+        value += character
+      }
+      tokenStarted = true
+      continue
+    }
+
+    if (quote === '"') {
+      if (character === '"') {
+        quote = null
+      } else if (character === '\\') {
+        if (index + 1 >= command.length) {
+          throw new CommandValidationError('DANGLING_ESCAPE', 'Command ends with an incomplete escape sequence.')
+        }
+        const next = command[index + 1]
+        // Match normal double-quote semantics without swallowing OfficeCLI's
+        // meaningful sequences such as \n and \t in property values.
+        if (next === '"') {
+          value += next
+          index += 1
+        } else {
+          value += `\\${next}`
+          index += 1
+        }
+      } else {
+        value += character
+      }
+      tokenStarted = true
+      continue
+    }
+
+    if (/\s/u.test(character)) {
+      pushToken()
+      continue
+    }
+    if (character === "'" || character === '"') {
+      quote = character
+      tokenStarted = true
+      continue
+    }
+    if (character === '\\') {
+      if (index + 1 >= command.length) {
+        throw new CommandValidationError('DANGLING_ESCAPE', 'Command ends with an incomplete escape sequence.')
+      }
+      const next = command[index + 1]
+      if (/\s/u.test(next) || next === "'" || next === '"') {
+        value += next
+        index += 1
+      } else {
+        // Preserve ordinary Windows/path backslashes. Only characters that
+        // affect tokenization are treated as escaped outside quotes.
+        value += '\\'
+      }
+      tokenStarted = true
+      continue
+    }
+
+    value += character
+    tokenStarted = true
+  }
+
+  if (quote !== null) {
+    throw new CommandValidationError('UNTERMINATED_QUOTE', `Command contains an unterminated ${quote} quote.`)
+  }
+  pushToken()
+  return tokens
+}
+
+function normalizeArgv(input) {
+  if (typeof input === 'string') return tokenizeCommand(input)
+  if (!Array.isArray(input)) {
+    throw new CommandValidationError('INVALID_COMMAND_TYPE', 'Command must be a string or an argv array.')
+  }
+  if (input.length > MAX_ARGUMENTS) {
+    throw new CommandValidationError('TOO_MANY_ARGUMENTS', `Command exceeds ${MAX_ARGUMENTS} arguments.`)
+  }
+
+  let totalLength = 0
+  return input.map((argument, index) => {
+    if (typeof argument !== 'string') {
+      throw new CommandValidationError(
+        'INVALID_ARGUMENT_TYPE',
+        `Argument ${index + 1} must be a string.`,
+        { index }
+      )
+    }
+    if (argument.includes('\0')) {
+      throw new CommandValidationError('INVALID_CHARACTER', `Argument ${index + 1} contains a NUL character.`)
+    }
+    totalLength += argument.length
+    if (totalLength > MAX_COMMAND_LENGTH) {
+      throw new CommandValidationError('COMMAND_TOO_LONG', `Command exceeds ${MAX_COMMAND_LENGTH} characters.`)
+    }
+    return argument
+  })
+}
+
+function isOfficeCliPrefix(value) {
+  if (typeof value !== 'string' || value.length === 0) return false
+  const basename = value.replaceAll('\\', '/').split('/').pop().toLowerCase()
+  return basename === 'officecli' || basename === 'officecli.exe'
+}
+
+function validateToken(token, index) {
+  if (token.length === 0) {
+    throw new CommandValidationError('EMPTY_ARGUMENT', `Argument ${index + 1} must not be empty.`, { index })
+  }
+  if (token.length > MAX_ARGUMENT_LENGTH) {
+    throw new CommandValidationError(
+      'ARGUMENT_TOO_LONG',
+      `Argument ${index + 1} exceeds ${MAX_ARGUMENT_LENGTH} characters.`,
+      { index }
+    )
+  }
+}
+
+function parseCommand(input) {
+  const argv = normalizeArgv(input)
+  if (argv.length > 0 && isOfficeCliPrefix(argv[0])) argv.shift()
+  if (argv.length === 0) {
+    throw new CommandValidationError('EMPTY_COMMAND', 'An OfficeCLI document command is required.')
+  }
+
+  argv.forEach(validateToken)
+  const command = argv[0].toLowerCase()
+
+  if (BLOCKED_MANAGEMENT_COMMAND_SET.has(command)) {
+    throw new CommandValidationError(
+      'COMMAND_BLOCKED',
+      `OfficeCLI management command "${command}" is not available through the document runner.`,
+      { command }
+    )
+  }
+  if (!DOCUMENT_COMMAND_SET.has(command)) {
+    throw new CommandValidationError(
+      'COMMAND_NOT_ALLOWED',
+      `OfficeCLI command "${command}" is not in the document-operation allowlist.`,
+      { command }
+    )
+  }
+
+  const args = argv.slice(1)
+  const requiredCount = MIN_ARGUMENTS[command] ?? 0
+  if (args.length < requiredCount) {
+    throw new CommandValidationError(
+      'MISSING_ARGUMENTS',
+      `OfficeCLI command "${command}" requires at least ${requiredCount} argument${requiredCount === 1 ? '' : 's'}.`,
+      { command, minimum: requiredCount, received: args.length }
+    )
+  }
+  if (requiredCount > 0 && command !== 'load_skill' && args[0].startsWith('-')) {
+    throw new CommandValidationError(
+      'MISSING_DOCUMENT_PATH',
+      `OfficeCLI command "${command}" requires a document path before options.`,
+      { command }
+    )
+  }
+
+  return Object.freeze({
+    command,
+    args: Object.freeze(args.slice()),
+    argv: Object.freeze([command, ...args])
+  })
+}
+
+module.exports = {
+  BLOCKED_MANAGEMENT_COMMANDS,
+  CommandValidationError,
+  DOCUMENT_COMMANDS,
+  MAX_ARGUMENTS,
+  MAX_ARGUMENT_LENGTH,
+  MAX_COMMAND_LENGTH,
+  isOfficeCliPrefix,
+  parseCommand,
+  tokenizeCommand
+}

--- a/plugins/office-suite-workbench/preload/officecli-runner.cjs
+++ b/plugins/office-suite-workbench/preload/officecli-runner.cjs
@@ -1,0 +1,805 @@
+'use strict'
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { spawn: defaultSpawn } = require('node:child_process')
+const { StringDecoder } = require('node:string_decoder')
+const { parseCommand } = require('./command-parser.cjs')
+
+const DEFAULT_TIMEOUT_MS = 120_000
+const DEFAULT_MCP_TIMEOUT_MS = 15_000
+const DEFAULT_MAX_OUTPUT_BYTES = 4 * 1024 * 1024
+const MAX_TIMEOUT_MS = 15 * 60 * 1000
+const MAX_OUTPUT_BYTES = 32 * 1024 * 1024
+const MCP_TARGETS = Object.freeze(['lms', 'claude', 'cursor', 'vscode'])
+const MCP_TARGET_SET = new Set(MCP_TARGETS)
+
+class OfficeCliRunnerError extends Error {
+  constructor(code, message, details) {
+    super(message)
+    this.name = 'OfficeCliRunnerError'
+    this.code = code
+    if (details !== undefined) this.details = details
+  }
+}
+
+function success(data) {
+  return { ok: true, data }
+}
+
+function serializableDetails(value) {
+  if (value === undefined) return undefined
+  try {
+    return JSON.parse(JSON.stringify(value))
+  } catch {
+    return undefined
+  }
+}
+
+function failure(error, fallbackCode = 'OFFICECLI_ERROR') {
+  const normalized = error instanceof Error ? error : new Error(String(error))
+  const result = {
+    ok: false,
+    error: {
+      code: typeof normalized.code === 'string' ? normalized.code : fallbackCode,
+      message: String(normalized.message || 'OfficeCLI operation failed.')
+    }
+  }
+  const details = serializableDetails(normalized.details)
+  if (details !== undefined) result.error.details = details
+  return result
+}
+
+function normalizeOptions(options) {
+  if (options == null) return {}
+  if (typeof options !== 'object' || Array.isArray(options)) {
+    throw new OfficeCliRunnerError('INVALID_OPTIONS', 'Options must be an object.')
+  }
+  return options
+}
+
+function boundedInteger(value, fallback, maximum, name) {
+  if (value == null) return fallback
+  const number = Number(value)
+  if (!Number.isSafeInteger(number) || number <= 0 || number > maximum) {
+    throw new OfficeCliRunnerError(
+      'INVALID_OPTIONS',
+      `${name} must be a positive integer no greater than ${maximum}.`,
+      { name, maximum }
+    )
+  }
+  return number
+}
+
+function normalizeEnvironment(input) {
+  if (input == null) return {}
+  if (typeof input !== 'object' || Array.isArray(input)) {
+    throw new OfficeCliRunnerError('INVALID_ENVIRONMENT', 'env must be an object of environment variables.')
+  }
+
+  const output = Object.create(null)
+  for (const [key, rawValue] of Object.entries(input)) {
+    if (!key || key.includes('=') || key.includes('\0')) {
+      throw new OfficeCliRunnerError('INVALID_ENVIRONMENT', `Invalid environment variable name: ${key || '(empty)'}.`)
+    }
+    if (!['string', 'number', 'boolean'].includes(typeof rawValue)) {
+      throw new OfficeCliRunnerError('INVALID_ENVIRONMENT', `Environment variable ${key} must be a string, number, or boolean.`)
+    }
+    const value = String(rawValue)
+    if (value.includes('\0')) {
+      throw new OfficeCliRunnerError('INVALID_ENVIRONMENT', `Environment variable ${key} contains a NUL character.`)
+    }
+    output[key] = value
+  }
+  return output
+}
+
+function normalizeDirectoryList(input, name) {
+  if (input == null) return []
+  if (!Array.isArray(input)) {
+    throw new OfficeCliRunnerError('INVALID_OPTIONS', `${name} must be an array of directories.`)
+  }
+  return input.map((directory, index) => {
+    if (typeof directory !== 'string' || directory.length === 0 || directory.includes('\0')) {
+      throw new OfficeCliRunnerError('INVALID_OPTIONS', `${name}[${index}] must be a non-empty path string.`)
+    }
+    return path.resolve(directory)
+  })
+}
+
+function defaultCommonDirectories(platform, homeDir, environment) {
+  if (platform === 'win32') {
+    return [
+      path.join(homeDir, '.local', 'bin'),
+      path.join(homeDir, 'scoop', 'shims'),
+      environment.APPDATA && path.join(environment.APPDATA, 'npm'),
+      environment.LOCALAPPDATA && path.join(environment.LOCALAPPDATA, 'OfficeCLI'),
+      environment.LOCALAPPDATA && path.join(environment.LOCALAPPDATA, 'Microsoft', 'WinGet', 'Links')
+    ].filter(Boolean)
+  }
+
+  return [
+    path.join(homeDir, '.local', 'bin'),
+    path.join(homeDir, 'bin'),
+    path.join(homeDir, '.npm-global', 'bin'),
+    path.join(homeDir, '.volta', 'bin'),
+    path.join(homeDir, '.bun', 'bin'),
+    '/opt/homebrew/bin',
+    '/home/linuxbrew/.linuxbrew/bin',
+    '/usr/local/bin',
+    '/usr/bin',
+    '/bin'
+  ]
+}
+
+function executableNames(platform) {
+  return platform === 'win32' ? ['officecli.exe', 'officecli'] : ['officecli']
+}
+
+function extractVersion(output) {
+  const text = String(output || '').trim()
+  if (!text) return null
+  return text.match(/\bv?(\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?)/u)?.[1] || text.split(/\s+/u)[0]
+}
+
+function parseJsonOutput(stdout) {
+  const text = String(stdout || '').trim()
+  if (!text) return undefined
+  try {
+    return JSON.parse(text)
+  } catch {
+    return undefined
+  }
+}
+
+function validateMcpTarget(target) {
+  if (typeof target !== 'string') {
+    throw new OfficeCliRunnerError('INVALID_MCP_TARGET', 'MCP target must be one of: lms, claude, cursor, vscode.')
+  }
+  const normalized = target.trim().toLowerCase()
+  if (!MCP_TARGET_SET.has(normalized)) {
+    throw new OfficeCliRunnerError(
+      'INVALID_MCP_TARGET',
+      `Unsupported MCP target "${target}". Allowed targets: ${MCP_TARGETS.join(', ')}.`,
+      { target }
+    )
+  }
+  return normalized
+}
+
+function parseMcpTargets(raw) {
+  const targets = {}
+  for (const line of String(raw || '').split(/\r?\n/u)) {
+    const lower = line.toLowerCase()
+    let target = null
+    if (lower.includes('lm studio')) target = 'lms'
+    else if (lower.includes('claude')) target = 'claude'
+    else if (lower.includes('cursor')) target = 'cursor'
+    else if (lower.includes('vs code') || lower.includes('vscode')) target = 'vscode'
+    if (!target || !lower.includes('registered')) continue
+    targets[target] = !lower.includes('not registered')
+  }
+  return targets
+}
+
+function tomlString(value) {
+  // JSON double-quoted strings are valid TOML basic strings for paths and keep
+  // backslashes/quotes escaped on Windows.
+  return JSON.stringify(String(value))
+}
+
+function createMcpConfigs(binaryPath) {
+  const entry = () => ({ command: binaryPath, args: ['mcp'] })
+  return {
+    generic: entry(),
+    claude: { mcpServers: { officecli: entry() } },
+    cursor: { mcpServers: { officecli: entry() } },
+    vscode: { servers: { officecli: { type: 'stdio', ...entry() } } },
+    codex: `[mcp_servers.officecli]\ncommand = ${tomlString(binaryPath)}\nargs = ["mcp"]\n`
+  }
+}
+
+function createOfficeCliRunner(dependencies = {}) {
+  const spawnImpl = dependencies.spawn || defaultSpawn
+  const fsImpl = dependencies.fs || fs
+  const platform = dependencies.platform || process.platform
+  const homeDir = path.resolve(dependencies.homeDir || os.homedir())
+  const baseEnvironment = { ...(dependencies.env || process.env) }
+  const now = dependencies.now || Date.now
+  const dependencyCommonPaths = normalizeDirectoryList(dependencies.commonPaths, 'commonPaths')
+
+  function buildEnvironment(options) {
+    const overrides = normalizeEnvironment(options.env)
+    const environment = { ...baseEnvironment, ...overrides }
+    const environmentPathKeys = Object.keys(environment).filter((key) => key.toLowerCase() === 'path')
+    const overridePathKey = Object.keys(overrides).find((key) => key.toLowerCase() === 'path')
+    if (options.pathEnv != null) {
+      if (typeof options.pathEnv !== 'string' || options.pathEnv.includes('\0')) {
+        throw new OfficeCliRunnerError('INVALID_OPTIONS', 'pathEnv must be a PATH string.')
+      }
+      for (const key of environmentPathKeys) delete environment[key]
+      environment[platform === 'win32' ? 'Path' : 'PATH'] = options.pathEnv
+    } else if (overridePathKey) {
+      const overridePath = overrides[overridePathKey]
+      for (const key of environmentPathKeys) delete environment[key]
+      environment[platform === 'win32' ? 'Path' : 'PATH'] = overridePath
+    }
+    // The plugin must not trigger a binary self-update or leave an implicit
+    // resident behind. Explicit `open` remains available when the user asks.
+    if (environment.OFFICECLI_SKIP_UPDATE == null) environment.OFFICECLI_SKIP_UPDATE = '1'
+    if (environment.OFFICECLI_NO_AUTO_RESIDENT == null) environment.OFFICECLI_NO_AUTO_RESIDENT = '1'
+    return environment
+  }
+
+  function pathEnvironment(environment, options) {
+    if (typeof options.pathEnv === 'string') return options.pathEnv
+    if (platform === 'win32') return environment.Path || environment.PATH || ''
+    return environment.PATH || ''
+  }
+
+  function isExecutable(filePath) {
+    try {
+      const stat = fsImpl.statSync(filePath)
+      if (!stat.isFile()) return false
+      fsImpl.accessSync(filePath, platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  function requestedBinaryPath(options) {
+    if (options.binaryPath == null) return null
+    if (typeof options.binaryPath !== 'string' || options.binaryPath.length === 0 || options.binaryPath.includes('\0')) {
+      throw new OfficeCliRunnerError('INVALID_BINARY_PATH', 'binaryPath must be a non-empty path string.')
+    }
+    return path.resolve(options.binaryPath)
+  }
+
+  function environmentBinaryPath(options) {
+    const environment = buildEnvironment(options)
+    const value = environment.OFFICECLI_PATH
+    if (value == null || value === '') return null
+    if (typeof value !== 'string' || value.includes('\0')) {
+      throw new OfficeCliRunnerError('INVALID_BINARY_PATH', 'OFFICECLI_PATH must be a path string.')
+    }
+    return path.resolve(value)
+  }
+
+  function findBinary(options) {
+    const requested = requestedBinaryPath(options)
+    if (requested) return isExecutable(requested) ? requested : null
+
+    const environmentRequested = environmentBinaryPath(options)
+    if (environmentRequested) return isExecutable(environmentRequested) ? environmentRequested : null
+
+    const environment = buildEnvironment(options)
+    const delimiter = platform === 'win32' ? ';' : ':'
+    const searchPaths = [
+      ...normalizeDirectoryList(options.searchPaths, 'searchPaths'),
+      ...pathEnvironment(environment, options).split(delimiter).filter(Boolean).map((item) => path.resolve(item)),
+      ...dependencyCommonPaths,
+      ...defaultCommonDirectories(platform, homeDir, environment)
+    ]
+
+    const seen = new Set()
+    for (const directory of searchPaths) {
+      for (const name of executableNames(platform)) {
+        const candidate = path.resolve(directory, name)
+        if (seen.has(candidate)) continue
+        seen.add(candidate)
+        if (isExecutable(candidate)) return candidate
+      }
+    }
+    return null
+  }
+
+  function requireBinary(options) {
+    const binaryPath = findBinary(options)
+    if (binaryPath) return binaryPath
+    throw new OfficeCliRunnerError(
+      'OFFICECLI_NOT_FOUND',
+      options.binaryPath
+        ? `OfficeCLI is not executable at ${path.resolve(options.binaryPath)}.`
+        : 'OfficeCLI was not found in PATH or the supported common install locations.'
+    )
+  }
+
+  function processSettings(options, fallbackTimeout = DEFAULT_TIMEOUT_MS) {
+    const timeoutMs = boundedInteger(options.timeoutMs, fallbackTimeout, MAX_TIMEOUT_MS, 'timeoutMs')
+    const maxOutputBytes = boundedInteger(
+      options.maxOutputBytes,
+      DEFAULT_MAX_OUTPUT_BYTES,
+      MAX_OUTPUT_BYTES,
+      'maxOutputBytes'
+    )
+    let cwd
+    if (options.cwd != null) {
+      if (typeof options.cwd !== 'string' || options.cwd.length === 0 || options.cwd.includes('\0')) {
+        throw new OfficeCliRunnerError('INVALID_OPTIONS', 'cwd must be a non-empty path string.')
+      }
+      cwd = path.resolve(options.cwd)
+    }
+    return { timeoutMs, maxOutputBytes, cwd, env: buildEnvironment(options) }
+  }
+
+  function execute(binaryPath, args, options, input, fallbackTimeout = DEFAULT_TIMEOUT_MS) {
+    const settings = processSettings(options, fallbackTimeout)
+    return new Promise((resolve, reject) => {
+      const startedAt = now()
+      let child
+      try {
+        child = spawnImpl(binaryPath, args, {
+          cwd: settings.cwd,
+          env: settings.env,
+          shell: false,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true
+        })
+      } catch (error) {
+        reject(new OfficeCliRunnerError('OFFICECLI_SPAWN_FAILED', `Unable to start OfficeCLI: ${error.message}`))
+        return
+      }
+
+      let stdout = ''
+      let stderr = ''
+      let stdoutBytes = 0
+      let stderrBytes = 0
+      let settled = false
+      let timer = null
+      let forceKillTimer = null
+      let exitWaitTimer = null
+      let terminationError = null
+      const stdoutDecoder = new StringDecoder('utf8')
+      const stderrDecoder = new StringDecoder('utf8')
+
+      const finish = (error, result) => {
+        if (settled) return
+        settled = true
+        if (timer) clearTimeout(timer)
+        if (forceKillTimer) clearTimeout(forceKillTimer)
+        if (exitWaitTimer) clearTimeout(exitWaitTimer)
+        if (error) reject(error)
+        else resolve(result)
+      }
+
+      const terminateWithError = (error) => {
+        if (settled || terminationError) return
+        terminationError = error
+        if (timer) clearTimeout(timer)
+        // Node exposes a portable signal API only for the direct child. We
+        // therefore wait for that child to be reaped and use TERM -> KILL, but
+        // cannot promise cross-platform process-tree termination for helpers an
+        // upstream OfficeCLI renderer may detach. NO_AUTO_RESIDENT and the MCP
+        // command policy minimize that surface.
+        try {
+          child.kill('SIGTERM')
+        } catch {
+          // Continue to the forced-kill fallback below.
+        }
+        forceKillTimer = setTimeout(() => {
+          try { child.kill('SIGKILL') } catch { }
+        }, 250)
+        // Normally `close` settles the promise after the process is reaped. A
+        // broken/mock child must not keep the UI waiting forever.
+        exitWaitTimer = setTimeout(() => finish(error), 2_000)
+      }
+
+      const append = (stream, chunk) => {
+        if (terminationError) return
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), 'utf8')
+        const bytes = buffer.length
+        if (stream === 'stdout') {
+          stdoutBytes += bytes
+          if (stdoutBytes > settings.maxOutputBytes) {
+            terminateWithError(new OfficeCliRunnerError(
+              'OUTPUT_LIMIT_EXCEEDED',
+              `OfficeCLI stdout exceeded ${settings.maxOutputBytes} bytes.`,
+              { stream: 'stdout', maxOutputBytes: settings.maxOutputBytes }
+            ))
+            return
+          }
+          stdout += stdoutDecoder.write(buffer)
+        } else {
+          stderrBytes += bytes
+          if (stderrBytes > settings.maxOutputBytes) {
+            terminateWithError(new OfficeCliRunnerError(
+              'OUTPUT_LIMIT_EXCEEDED',
+              `OfficeCLI stderr exceeded ${settings.maxOutputBytes} bytes.`,
+              { stream: 'stderr', maxOutputBytes: settings.maxOutputBytes }
+            ))
+            return
+          }
+          stderr += stderrDecoder.write(buffer)
+        }
+      }
+
+      if (!child || !child.stdout || !child.stderr || !child.stdin || typeof child.on !== 'function') {
+        finish(new OfficeCliRunnerError('OFFICECLI_SPAWN_FAILED', 'OfficeCLI process did not expose piped stdio.'))
+        return
+      }
+
+      child.stdout.on('data', (chunk) => append('stdout', chunk))
+      child.stderr.on('data', (chunk) => append('stderr', chunk))
+      child.on('error', (error) => {
+        finish(new OfficeCliRunnerError('OFFICECLI_SPAWN_FAILED', `Unable to start OfficeCLI: ${error.message}`))
+      })
+      child.on('close', (exitCode, signal) => {
+        if (!terminationError) {
+          stdout += stdoutDecoder.end()
+          stderr += stderrDecoder.end()
+        }
+        if (terminationError) {
+          finish(terminationError)
+          return
+        }
+        finish(null, {
+          exitCode: Number.isInteger(exitCode) ? exitCode : null,
+          signal: signal || null,
+          stdout,
+          stderr,
+          durationMs: Math.max(0, now() - startedAt)
+        })
+      })
+
+      timer = setTimeout(() => {
+        terminateWithError(new OfficeCliRunnerError(
+          'OFFICECLI_TIMEOUT',
+          `OfficeCLI did not finish within ${settings.timeoutMs} ms.`,
+          { timeoutMs: settings.timeoutMs }
+        ))
+      }, settings.timeoutMs)
+
+      child.stdin.on('error', () => undefined)
+      child.stdin.end(input == null ? undefined : String(input))
+    })
+  }
+
+  function executeMcpHandshake(binaryPath, options) {
+    const settings = processSettings(options, DEFAULT_MCP_TIMEOUT_MS)
+    const initializeId = 'ztools-officecli-initialize'
+    const toolsId = 'ztools-officecli-tools'
+
+    return new Promise((resolve, reject) => {
+      let child
+      try {
+        child = spawnImpl(binaryPath, ['mcp'], {
+          cwd: settings.cwd,
+          env: settings.env,
+          shell: false,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true
+        })
+      } catch (error) {
+        reject(new OfficeCliRunnerError('OFFICECLI_SPAWN_FAILED', `Unable to start OfficeCLI MCP: ${error.message}`))
+        return
+      }
+
+      let settled = false
+      let closed = false
+      let terminationError = null
+      let timer = null
+      let forceKillTimer = null
+      let exitWaitTimer = null
+      let stdoutBytes = 0
+      let stderrBytes = 0
+      let lineBuffer = ''
+      let stderr = ''
+      let initializeResponse = null
+      let toolsResponse = null
+      const stdoutDecoder = new StringDecoder('utf8')
+      const stderrDecoder = new StringDecoder('utf8')
+
+      const finish = (error, data) => {
+        if (settled) return
+        settled = true
+        if (timer) clearTimeout(timer)
+        if (forceKillTimer) clearTimeout(forceKillTimer)
+        if (exitWaitTimer) clearTimeout(exitWaitTimer)
+        if (error) reject(error)
+        else resolve(data)
+      }
+
+      const terminateWithError = (error) => {
+        if (settled || terminationError) return
+        if (closed) {
+          finish(error)
+          return
+        }
+        terminationError = error
+        if (timer) clearTimeout(timer)
+        // See execute(): cross-platform Node can reliably signal the direct
+        // OfficeCLI child, not every independently detached descendant.
+        try { child.kill('SIGTERM') } catch { }
+        forceKillTimer = setTimeout(() => {
+          try { child.kill('SIGKILL') } catch { }
+        }, 250)
+        exitWaitTimer = setTimeout(() => finish(error), 2_000)
+      }
+
+      const writeMessage = (message) => {
+        if (settled || terminationError) return
+        try {
+          child.stdin.write(`${JSON.stringify(message)}\n`)
+        } catch (error) {
+          terminateWithError(new OfficeCliRunnerError('MCP_PROBE_FAILED', `Unable to write to OfficeCLI MCP: ${error.message}`))
+        }
+      }
+
+      const handleLine = (line) => {
+        if (settled || terminationError || !line.trim()) return
+        let response
+        try {
+          response = JSON.parse(line)
+        } catch {
+          terminateWithError(new OfficeCliRunnerError('MCP_PROTOCOL_ERROR', 'OfficeCLI MCP returned a non-JSON response line.'))
+          return
+        }
+        if (response?.id === initializeId) {
+          if (initializeResponse) {
+            terminateWithError(new OfficeCliRunnerError('MCP_PROTOCOL_ERROR', 'OfficeCLI MCP returned duplicate initialize responses.'))
+            return
+          }
+          if (response.error) {
+            terminateWithError(new OfficeCliRunnerError(
+              'MCP_PROTOCOL_ERROR',
+              String(response.error.message || 'OfficeCLI MCP initialize failed.'),
+              { protocolError: response.error }
+            ))
+            return
+          }
+          initializeResponse = response
+          // MCP lifecycle ordering is significant: only advertise initialized
+          // and request tools after the initialize response has arrived.
+          writeMessage({ jsonrpc: '2.0', method: 'notifications/initialized', params: {} })
+          writeMessage({ jsonrpc: '2.0', id: toolsId, method: 'tools/list', params: {} })
+          return
+        }
+        if (response?.id === toolsId) {
+          toolsResponse = response
+          try { child.stdin.end() } catch { }
+        }
+      }
+
+      const appendStdout = (chunk) => {
+        if (terminationError) return
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), 'utf8')
+        stdoutBytes += buffer.length
+        if (stdoutBytes > settings.maxOutputBytes) {
+          terminateWithError(new OfficeCliRunnerError(
+            'OUTPUT_LIMIT_EXCEEDED',
+            `OfficeCLI MCP stdout exceeded ${settings.maxOutputBytes} bytes.`,
+            { stream: 'stdout', maxOutputBytes: settings.maxOutputBytes }
+          ))
+          return
+        }
+        lineBuffer += stdoutDecoder.write(buffer)
+        let newlineIndex
+        while ((newlineIndex = lineBuffer.indexOf('\n')) >= 0) {
+          const line = lineBuffer.slice(0, newlineIndex).replace(/\r$/u, '')
+          lineBuffer = lineBuffer.slice(newlineIndex + 1)
+          handleLine(line)
+        }
+      }
+
+      const appendStderr = (chunk) => {
+        if (terminationError) return
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), 'utf8')
+        stderrBytes += buffer.length
+        if (stderrBytes > settings.maxOutputBytes) {
+          terminateWithError(new OfficeCliRunnerError(
+            'OUTPUT_LIMIT_EXCEEDED',
+            `OfficeCLI MCP stderr exceeded ${settings.maxOutputBytes} bytes.`,
+            { stream: 'stderr', maxOutputBytes: settings.maxOutputBytes }
+          ))
+          return
+        }
+        stderr += stderrDecoder.write(buffer)
+      }
+
+      if (!child || !child.stdout || !child.stderr || !child.stdin || typeof child.on !== 'function') {
+        finish(new OfficeCliRunnerError('OFFICECLI_SPAWN_FAILED', 'OfficeCLI MCP process did not expose piped stdio.'))
+        return
+      }
+
+      child.stdout.on('data', appendStdout)
+      child.stderr.on('data', appendStderr)
+      child.stdin.on('error', (error) => {
+        if (!closed && !settled) {
+          terminateWithError(new OfficeCliRunnerError('MCP_PROBE_FAILED', `OfficeCLI MCP stdin failed: ${error.message}`))
+        }
+      })
+      child.on('error', (error) => {
+        finish(new OfficeCliRunnerError('OFFICECLI_SPAWN_FAILED', `Unable to start OfficeCLI MCP: ${error.message}`))
+      })
+      child.on('close', (exitCode) => {
+        closed = true
+        if (!terminationError) {
+          lineBuffer += stdoutDecoder.end()
+          stderr += stderrDecoder.end()
+          if (lineBuffer.trim()) handleLine(lineBuffer.replace(/\r$/u, ''))
+        }
+        if (terminationError) {
+          finish(terminationError)
+          return
+        }
+        if (exitCode !== 0) {
+          finish(new OfficeCliRunnerError(
+            'MCP_PROBE_FAILED',
+            stderr.trim() || `OfficeCLI MCP server exited with code ${exitCode}.`,
+            { exitCode, stderr }
+          ))
+          return
+        }
+        if (!initializeResponse || !toolsResponse) {
+          finish(new OfficeCliRunnerError(
+            'MCP_PROTOCOL_ERROR',
+            'OfficeCLI MCP did not return both initialize and tools/list responses.'
+          ))
+          return
+        }
+        if (toolsResponse.error) {
+          finish(new OfficeCliRunnerError(
+            'MCP_PROTOCOL_ERROR',
+            String(toolsResponse.error.message || 'OfficeCLI MCP tools/list failed.'),
+            { protocolError: toolsResponse.error }
+          ))
+          return
+        }
+        const listedTools = Array.isArray(toolsResponse.result?.tools) ? toolsResponse.result.tools : []
+        finish(null, {
+          serverInfo: initializeResponse.result?.serverInfo || null,
+          protocolVersion: initializeResponse.result?.protocolVersion || null,
+          toolNames: listedTools.map((tool) => tool?.name).filter((name) => typeof name === 'string')
+        })
+      })
+
+      timer = setTimeout(() => {
+        terminateWithError(new OfficeCliRunnerError(
+          'OFFICECLI_TIMEOUT',
+          `OfficeCLI MCP handshake did not finish within ${settings.timeoutMs} ms.`,
+          { timeoutMs: settings.timeoutMs }
+        ))
+      }, settings.timeoutMs)
+
+      writeMessage({
+        jsonrpc: '2.0',
+        id: initializeId,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'ztools-office-suite-workbench', version: '0.1.0' }
+        }
+      })
+    })
+  }
+
+  async function runRaw(args, options, fallbackTimeout) {
+    const binaryPath = requireBinary(options)
+    const result = await execute(binaryPath, args, options, undefined, fallbackTimeout)
+    if (result.exitCode !== 0) {
+      throw new OfficeCliRunnerError(
+        'OFFICECLI_EXIT',
+        result.stderr.trim() || result.stdout.trim() || `OfficeCLI exited with code ${result.exitCode}.`,
+        { binaryPath, args, ...result }
+      )
+    }
+    return { binaryPath, ...result }
+  }
+
+  async function getStatusData(options) {
+    const requested = requestedBinaryPath(options) || environmentBinaryPath(options)
+    const binaryPath = findBinary(options)
+    if (!binaryPath) return { installed: false, binaryPath: requested, version: null }
+    const result = await execute(binaryPath, ['--version'], options, undefined, 8_000)
+    if (result.exitCode !== 0) {
+      throw new OfficeCliRunnerError(
+        'OFFICECLI_EXIT',
+        result.stderr.trim() || result.stdout.trim() || `OfficeCLI --version exited with code ${result.exitCode}.`,
+        { binaryPath, exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr }
+      )
+    }
+    return { installed: true, binaryPath, version: extractVersion(result.stdout || result.stderr) }
+  }
+
+  async function runDocumentData(commandInput, options) {
+    const parsed = parseCommand(commandInput)
+    const binaryPath = requireBinary(options)
+    const result = await execute(binaryPath, parsed.argv, options)
+    const data = {
+      command: parsed.command,
+      args: parsed.args.slice(),
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      durationMs: result.durationMs
+    }
+    const json = parseJsonOutput(result.stdout)
+    if (json !== undefined) data.json = json
+    if (result.exitCode !== 0) {
+      throw new OfficeCliRunnerError(
+        'OFFICECLI_EXIT',
+        result.stderr.trim() || result.stdout.trim() || `OfficeCLI exited with code ${result.exitCode}.`,
+        data
+      )
+    }
+    return data
+  }
+
+  async function getMcpStatusData(options) {
+    const result = await runRaw(['mcp', 'list'], options, DEFAULT_MCP_TIMEOUT_MS)
+    const raw = [result.stdout, result.stderr].filter(Boolean).join(result.stdout && result.stderr ? '\n' : '').trim()
+    return { raw, targets: parseMcpTargets(raw) }
+  }
+
+  async function registerMcpData(targetInput, options) {
+    const target = validateMcpTarget(targetInput)
+    const result = await runRaw(['mcp', target], options, DEFAULT_MCP_TIMEOUT_MS)
+    return { target, stdout: result.stdout, stderr: result.stderr }
+  }
+
+  async function unregisterMcpData(targetInput, options) {
+    const target = validateMcpTarget(targetInput)
+    const result = await runRaw(['mcp', 'uninstall', target], options, DEFAULT_MCP_TIMEOUT_MS)
+    return { target, stdout: result.stdout, stderr: result.stderr }
+  }
+
+  async function probeMcpData(options) {
+    const binaryPath = requireBinary(options)
+    return executeMcpHandshake(binaryPath, options)
+  }
+
+  async function getMcpConfigsData(options) {
+    const binaryPath = requireBinary(options)
+    return { binaryPath, configs: createMcpConfigs(binaryPath) }
+  }
+
+  async function wrap(work) {
+    try {
+      return success(await work())
+    } catch (error) {
+      return failure(error)
+    }
+  }
+
+  return Object.freeze({
+    getStatus(options) {
+      return wrap(() => getStatusData(normalizeOptions(options)))
+    },
+    run(command, options) {
+      return wrap(() => runDocumentData(command, normalizeOptions(options)))
+    },
+    getMcpStatus(options) {
+      return wrap(() => getMcpStatusData(normalizeOptions(options)))
+    },
+    registerMcp(target, options) {
+      return wrap(() => registerMcpData(target, normalizeOptions(options)))
+    },
+    unregisterMcp(target, options) {
+      return wrap(() => unregisterMcpData(target, normalizeOptions(options)))
+    },
+    probeMcp(options) {
+      return wrap(() => probeMcpData(normalizeOptions(options)))
+    },
+    getMcpConfigs(options) {
+      return wrap(() => getMcpConfigsData(normalizeOptions(options)))
+    }
+  })
+}
+
+module.exports = {
+  DEFAULT_MAX_OUTPUT_BYTES,
+  DEFAULT_MCP_TIMEOUT_MS,
+  DEFAULT_TIMEOUT_MS,
+  MCP_TARGETS,
+  OfficeCliRunnerError,
+  createMcpConfigs,
+  createOfficeCliRunner,
+  extractVersion,
+  failure,
+  parseMcpTargets,
+  success,
+  validateMcpTarget
+}

--- a/plugins/office-suite-workbench/preload/services.cjs
+++ b/plugins/office-suite-workbench/preload/services.cjs
@@ -1,5 +1,6 @@
 'use strict'
 
+const fs = require('node:fs')
 const path = require('node:path')
 const { parseCommand } = require('./command-parser.cjs')
 const {
@@ -15,6 +16,9 @@ const EXTERNAL_MCP_BLOCKED_COMMANDS = new Set(['add-part', 'import', 'merge', 'o
 const EXTERNAL_MCP_NON_FILE_COMMANDS = new Set(['help', 'load_skill'])
 const STATUS_OPTION_FIELDS = new Set()
 const RUN_OPTION_FIELDS = new Set(['timeoutMs'])
+const MAX_PREVIEW_IMAGE_BYTES = 12 * 1024 * 1024
+const MAX_PREVIEW_TOTAL_BYTES = 24 * 1024 * 1024
+const MAX_PREVIEW_IMAGES = 8
 const EXTERNAL_MCP_BLOCKED_OPTIONS = new Set(['-o', '--out', '--output', '--save', '--browser'])
 const EXTERNAL_MCP_BLOCKED_PROPERTY_KEYS = new Set([
   'fallback',
@@ -69,13 +73,104 @@ function safeUiInvoke(runner, method, args, options, allowedFields) {
   }
 }
 
+function previewMimeType(buffer) {
+  if (buffer.length >= 8 && buffer.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))) {
+    return 'image/png'
+  }
+  if (buffer.length >= 3 && buffer[0] === 255 && buffer[1] === 216 && buffer[2] === 255) {
+    return 'image/jpeg'
+  }
+  if (buffer.length >= 6) {
+    const signature = buffer.subarray(0, 6).toString('ascii')
+    if (signature === 'GIF87a' || signature === 'GIF89a') return 'image/gif'
+  }
+  if (
+    buffer.length >= 12 &&
+    buffer.subarray(0, 4).toString('ascii') === 'RIFF' &&
+    buffer.subarray(8, 12).toString('ascii') === 'WEBP'
+  ) {
+    return 'image/webp'
+  }
+  return null
+}
+
+function previewPathCandidates(stdout) {
+  const candidates = []
+  for (const line of String(stdout || '').split(/\r?\n/u)) {
+    const candidate = line.trim().replace(/^(['"])(.*)\1$/u, '$2')
+    if (!candidate || !path.isAbsolute(candidate)) continue
+    candidates.push(candidate)
+  }
+  return candidates
+}
+
+function collectPreviewImages(output) {
+  if (!output || typeof output !== 'object') return []
+  const previews = []
+  const seen = new Set()
+  let totalBytes = 0
+
+  for (const candidate of previewPathCandidates(output.stdout)) {
+    if (previews.length >= MAX_PREVIEW_IMAGES) break
+    try {
+      const sourceStat = fs.lstatSync(candidate)
+      if (!sourceStat.isFile() || sourceStat.isSymbolicLink()) continue
+      if (sourceStat.size <= 0 || sourceStat.size > MAX_PREVIEW_IMAGE_BYTES) continue
+      if (totalBytes + sourceStat.size > MAX_PREVIEW_TOTAL_BYTES) continue
+
+      const resolvedPath = fs.realpathSync(candidate)
+      if (seen.has(resolvedPath)) continue
+      const buffer = fs.readFileSync(resolvedPath)
+      const mimeType = previewMimeType(buffer)
+      if (!mimeType) continue
+
+      seen.add(resolvedPath)
+      totalBytes += buffer.length
+      previews.push({
+        path: resolvedPath,
+        mimeType,
+        size: buffer.length,
+        dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}`
+      })
+    } catch {
+      // Command output remains available even when a transient preview file disappears.
+    }
+  }
+  return previews
+}
+
+function withPreviewImages(result) {
+  if (!result?.ok || !result.data || typeof result.data !== 'object') return result
+  const previewImages = collectPreviewImages(result.data)
+  if (!previewImages.length) return result
+  return {
+    ...result,
+    data: {
+      ...result.data,
+      previewImages
+    }
+  }
+}
+
+async function safeUiRun(runner, command, options) {
+  let sanitizedOptions
+  try {
+    sanitizedOptions = sanitizeUiOptions(options, RUN_OPTION_FIELDS)
+  } catch (error) {
+    return failure(error, 'OFFICE_SUITE_BRIDGE_ERROR')
+  }
+
+  const result = await safeInvoke(runner, 'run', [command, sanitizedOptions])
+  return withPreviewImages(result)
+}
+
 function createOfficeSuiteServices(runner = createOfficeCliRunner()) {
   return Object.freeze({
     getStatus(options) {
       return safeUiInvoke(runner, 'getStatus', [], options, STATUS_OPTION_FIELDS)
     },
     run(command, options) {
-      return safeUiInvoke(runner, 'run', [command], options, RUN_OPTION_FIELDS)
+      return safeUiRun(runner, command, options)
     },
     getMcpStatus(options) {
       return safeUiInvoke(runner, 'getMcpStatus', [], options, STATUS_OPTION_FIELDS)
@@ -347,6 +442,7 @@ module.exports = {
   MCP_TOOL_TIMEOUT_MS,
   OFFICE_DOCUMENT_TOOL,
   attachOfficeSuite,
+  collectPreviewImages,
   createOfficeSuiteServices,
   defaultServices,
   registerOfficeDocumentTool,

--- a/plugins/office-suite-workbench/preload/services.cjs
+++ b/plugins/office-suite-workbench/preload/services.cjs
@@ -19,6 +19,19 @@ const RUN_OPTION_FIELDS = new Set(['timeoutMs'])
 const MAX_PREVIEW_IMAGE_BYTES = 12 * 1024 * 1024
 const MAX_PREVIEW_TOTAL_BYTES = 24 * 1024 * 1024
 const MAX_PREVIEW_IMAGES = 8
+const AI_TOOL_TIMEOUT_MS = 120_000
+const AI_WRITE_COMMANDS = new Set([
+  'add',
+  'batch',
+  'close',
+  'create',
+  'move',
+  'refresh',
+  'remove',
+  'save',
+  'set',
+  'swap'
+])
 const EXTERNAL_MCP_BLOCKED_OPTIONS = new Set(['-o', '--out', '--output', '--save', '--browser'])
 const EXTERNAL_MCP_BLOCKED_PROPERTY_KEYS = new Set([
   'fallback',
@@ -164,6 +177,36 @@ async function safeUiRun(runner, command, options) {
   return withPreviewImages(result)
 }
 
+async function safeAiRun(runner, command, options) {
+  try {
+    if (!options || typeof options !== 'object' || Array.isArray(options)) {
+      throw new OfficeCliRunnerError('INVALID_OPTIONS', 'AI tool options must be an object.')
+    }
+    const optionKeys = Object.keys(options)
+    if (optionKeys.some((key) => key !== 'allowWrite') || typeof options.allowWrite !== 'boolean') {
+      throw new OfficeCliRunnerError(
+        'INVALID_OPTIONS',
+        'AI tool options accept only the boolean allowWrite field.'
+      )
+    }
+    const parsed = validateExternalToolCommand(command)
+    if (AI_WRITE_COMMANDS.has(parsed.command) && !options.allowWrite) {
+      throw new OfficeCliRunnerError(
+        'AI_WRITE_APPROVAL_REQUIRED',
+        `OfficeCLI command "${parsed.command}" requires the user to enable file modifications for this AI turn.`,
+        { command: parsed.command }
+      )
+    }
+    const result = await safeInvoke(runner, 'run', [parsed.argv, {
+      timeoutMs: AI_TOOL_TIMEOUT_MS,
+      env: { OFFICECLI_NO_AUTO_RESIDENT: '1' }
+    }])
+    return withPreviewImages(result)
+  } catch (error) {
+    return failure(error, 'OFFICE_SUITE_AI_TOOL_ERROR')
+  }
+}
+
 function createOfficeSuiteServices(runner = createOfficeCliRunner()) {
   return Object.freeze({
     getStatus(options) {
@@ -171,6 +214,9 @@ function createOfficeSuiteServices(runner = createOfficeCliRunner()) {
     },
     run(command, options) {
       return safeUiRun(runner, command, options)
+    },
+    runForAi(command, options) {
+      return safeAiRun(runner, command, options)
     },
     getMcpStatus(options) {
       return safeUiInvoke(runner, 'getMcpStatus', [], options, STATUS_OPTION_FIELDS)
@@ -440,6 +486,7 @@ if (typeof window !== 'undefined') {
 
 module.exports = {
   MCP_TOOL_TIMEOUT_MS,
+  AI_TOOL_TIMEOUT_MS,
   OFFICE_DOCUMENT_TOOL,
   attachOfficeSuite,
   collectPreviewImages,

--- a/plugins/office-suite-workbench/preload/services.cjs
+++ b/plugins/office-suite-workbench/preload/services.cjs
@@ -1,0 +1,356 @@
+'use strict'
+
+const path = require('node:path')
+const { parseCommand } = require('./command-parser.cjs')
+const {
+  OfficeCliRunnerError,
+  createOfficeCliRunner,
+  failure
+} = require('./officecli-runner.cjs')
+
+const OFFICE_DOCUMENT_TOOL = 'office_document'
+const MCP_TOOL_TIMEOUT_MS = 120_000
+const registeredToolHosts = new WeakMap()
+const EXTERNAL_MCP_BLOCKED_COMMANDS = new Set(['add-part', 'import', 'merge', 'open', 'raw-set'])
+const EXTERNAL_MCP_NON_FILE_COMMANDS = new Set(['help', 'load_skill'])
+const STATUS_OPTION_FIELDS = new Set()
+const RUN_OPTION_FIELDS = new Set(['timeoutMs'])
+const EXTERNAL_MCP_BLOCKED_OPTIONS = new Set(['-o', '--out', '--output', '--save', '--browser'])
+const EXTERNAL_MCP_BLOCKED_PROPERTY_KEYS = new Set([
+  'fallback',
+  'image',
+  'path',
+  'poster',
+  'preview',
+  'src'
+])
+const EXTERNAL_MCP_IMAGE_VALUE_KEYS = new Set(['background', 'fill'])
+
+async function safeInvoke(runner, method, args) {
+  try {
+    const handler = runner?.[method]
+    if (typeof handler !== 'function') {
+      throw new OfficeCliRunnerError('BRIDGE_UNAVAILABLE', `Office suite runner method ${method} is unavailable.`)
+    }
+    const result = await handler.apply(runner, args)
+    if (!result || typeof result !== 'object' || typeof result.ok !== 'boolean') {
+      throw new OfficeCliRunnerError('INVALID_RUNNER_RESPONSE', `Office suite runner method ${method} returned an invalid response.`)
+    }
+    return result
+  } catch (error) {
+    return failure(error, 'OFFICE_SUITE_BRIDGE_ERROR')
+  }
+}
+
+function sanitizeUiOptions(options, allowedFields) {
+  if (options == null) return undefined
+  if (typeof options !== 'object' || Array.isArray(options)) {
+    throw new OfficeCliRunnerError('INVALID_OPTIONS', 'Bridge options must be an object.')
+  }
+  const output = {}
+  for (const [key, value] of Object.entries(options)) {
+    if (!allowedFields.has(key)) {
+      throw new OfficeCliRunnerError(
+        'OPTION_BLOCKED',
+        `Bridge option "${key}" is not exposed to the renderer.`,
+        { option: key }
+      )
+    }
+    output[key] = value
+  }
+  return output
+}
+
+function safeUiInvoke(runner, method, args, options, allowedFields) {
+  try {
+    return safeInvoke(runner, method, [...args, sanitizeUiOptions(options, allowedFields)])
+  } catch (error) {
+    return Promise.resolve(failure(error, 'OFFICE_SUITE_BRIDGE_ERROR'))
+  }
+}
+
+function createOfficeSuiteServices(runner = createOfficeCliRunner()) {
+  return Object.freeze({
+    getStatus(options) {
+      return safeUiInvoke(runner, 'getStatus', [], options, STATUS_OPTION_FIELDS)
+    },
+    run(command, options) {
+      return safeUiInvoke(runner, 'run', [command], options, RUN_OPTION_FIELDS)
+    },
+    getMcpStatus(options) {
+      return safeUiInvoke(runner, 'getMcpStatus', [], options, STATUS_OPTION_FIELDS)
+    },
+    registerMcp(target, options) {
+      return safeUiInvoke(runner, 'registerMcp', [target], options, STATUS_OPTION_FIELDS)
+    },
+    unregisterMcp(target, options) {
+      return safeUiInvoke(runner, 'unregisterMcp', [target], options, STATUS_OPTION_FIELDS)
+    },
+    probeMcp(options) {
+      return safeUiInvoke(runner, 'probeMcp', [], options, STATUS_OPTION_FIELDS)
+    },
+    getMcpConfigs(options) {
+      return safeUiInvoke(runner, 'getMcpConfigs', [], options, STATUS_OPTION_FIELDS)
+    }
+  })
+}
+
+function validateToolInput(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new OfficeCliRunnerError('INVALID_TOOL_INPUT', 'office_document input must be an object containing command.')
+  }
+  const keys = Object.keys(input)
+  if (keys.length !== 1 || keys[0] !== 'command') {
+    throw new OfficeCliRunnerError(
+      'INVALID_TOOL_INPUT',
+      'office_document accepts only the command field.',
+      { allowedFields: ['command'] }
+    )
+  }
+  if (typeof input.command !== 'string' && !Array.isArray(input.command)) {
+    throw new OfficeCliRunnerError('INVALID_TOOL_INPUT', 'office_document command must be a string or argv array.')
+  }
+  return input.command
+}
+
+function batchCommandsValue(args, index) {
+  const argument = args[index]
+  const lower = argument.toLowerCase()
+  if (lower === '--commands') {
+    if (index + 1 >= args.length) {
+      throw new OfficeCliRunnerError('MCP_BATCH_UNSAFE', 'batch --commands requires inline JSON.')
+    }
+    return args[index + 1]
+  }
+  if (lower.startsWith('--commands=') || lower.startsWith('--commands:')) {
+    return argument.slice('--commands='.length)
+  }
+  return null
+}
+
+function batchOperationName(item) {
+  if (!item || typeof item !== 'object') return null
+  const commandEntries = Object.entries(item).filter(([key]) => ['command', 'op'].includes(key.toLowerCase()))
+  if (commandEntries.length !== 1) return null
+  const value = commandEntries[0][1]
+  if (typeof value !== 'string' || !/^[a-z][a-z0-9_-]*$/iu.test(value.trim())) return null
+  return value.trim().toLowerCase()
+}
+
+function validateExternalPropertyValue(keyInput, value) {
+  const key = String(keyInput || '').trim().toLowerCase()
+  const terminalKey = key.split('.').pop()
+  const readsExternalResource = EXTERNAL_MCP_BLOCKED_PROPERTY_KEYS.has(key) ||
+    EXTERNAL_MCP_BLOCKED_PROPERTY_KEYS.has(terminalKey)
+  const embedsImageValue = EXTERNAL_MCP_IMAGE_VALUE_KEYS.has(key) &&
+    typeof value === 'string' && /^(?:image|url)\s*[:(]/iu.test(value.trim())
+
+  if (!readsExternalResource && !embedsImageValue) return
+  throw new OfficeCliRunnerError(
+    'MCP_EXTERNAL_RESOURCE_BLOCKED',
+    `OfficeCLI property "${key || '(empty)'}" may not read a file or URL in external MCP calls.`,
+    { property: key }
+  )
+}
+
+function validateExternalPropertyToken(input) {
+  if (typeof input !== 'string') return
+  const separatorIndex = input.search(/[=:]/u)
+  if (separatorIndex <= 0) return
+  validateExternalPropertyValue(input.slice(0, separatorIndex), input.slice(separatorIndex + 1))
+}
+
+function validateExternalCommandProperties(args) {
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    const lower = argument.toLowerCase()
+    if (lower === '--prop') {
+      if (index + 1 < args.length) validateExternalPropertyToken(args[index + 1])
+      index += 1
+      continue
+    }
+    if (lower.startsWith('--prop=') || lower.startsWith('--prop:')) {
+      validateExternalPropertyToken(argument.slice('--prop='.length))
+    }
+  }
+}
+
+function validateExternalBatchOperation(operation) {
+  if (!operation || typeof operation !== 'object' || Array.isArray(operation)) {
+    throw new OfficeCliRunnerError('MCP_BATCH_UNSAFE', 'External MCP batch commands must contain operation objects.')
+  }
+
+  const name = batchOperationName(operation)
+  if (!name) {
+    throw new OfficeCliRunnerError('MCP_BATCH_UNSAFE', 'Every external MCP batch operation requires a command name.')
+  }
+  if (EXTERNAL_MCP_BLOCKED_COMMANDS.has(name)) {
+    throw new OfficeCliRunnerError(
+      'MCP_COMMAND_BLOCKED',
+      `OfficeCLI command "${name}" is disabled for external MCP calls.`,
+      { command: name }
+    )
+  }
+
+  const blockedOutputField = Object.keys(operation).find((key) =>
+    ['out', 'output', 'outputpath', 'save'].includes(key.toLowerCase())
+  )
+  if (blockedOutputField) {
+    throw new OfficeCliRunnerError(
+      'MCP_OUTPUT_PATH_BLOCKED',
+      'External MCP batch commands must not write auxiliary output files.',
+      { field: blockedOutputField }
+    )
+  }
+
+  const propsEntries = Object.entries(operation).filter(([key]) =>
+    ['props', 'properties'].includes(key.toLowerCase())
+  )
+  for (const [, props] of propsEntries) {
+    if (!props || typeof props !== 'object' || Array.isArray(props)) {
+      throw new OfficeCliRunnerError('MCP_BATCH_UNSAFE', 'External MCP batch props must be an object.')
+    }
+    for (const [key, value] of Object.entries(props)) {
+      validateExternalPropertyValue(key, value)
+    }
+  }
+
+  for (const [key, value] of Object.entries(operation)) {
+    const normalized = key.toLowerCase()
+    if (normalized === 'path' || ['props', 'properties'].includes(normalized)) continue
+    validateExternalPropertyValue(key, value)
+  }
+}
+
+function validateExternalBatch(args) {
+  let hasInlineCommands = false
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]
+    const lower = argument.toLowerCase()
+    if (lower === '--input' || lower.startsWith('--input=') || lower.startsWith('--input:')) {
+      throw new OfficeCliRunnerError(
+        'MCP_BATCH_INPUT_BLOCKED',
+        'External MCP calls must use inline batch commands; batch --input is disabled.'
+      )
+    }
+
+    const commandsValue = batchCommandsValue(args, index)
+    if (commandsValue == null) continue
+    hasInlineCommands = true
+    let operations
+    try {
+      operations = JSON.parse(commandsValue)
+    } catch {
+      throw new OfficeCliRunnerError('MCP_BATCH_UNSAFE', 'batch --commands must contain valid inline JSON.')
+    }
+    if (!Array.isArray(operations)) {
+      throw new OfficeCliRunnerError('MCP_BATCH_UNSAFE', 'batch --commands must be a JSON array.')
+    }
+    operations.forEach(validateExternalBatchOperation)
+    if (lower === '--commands') index += 1
+  }
+  if (!hasInlineCommands) {
+    throw new OfficeCliRunnerError(
+      'MCP_BATCH_INPUT_BLOCKED',
+      'External MCP batch calls must provide inline --commands JSON.'
+    )
+  }
+}
+
+function validateExternalToolCommand(commandInput) {
+  const parsed = parseCommand(commandInput)
+  if (EXTERNAL_MCP_BLOCKED_COMMANDS.has(parsed.command)) {
+    throw new OfficeCliRunnerError(
+      'MCP_COMMAND_BLOCKED',
+      `OfficeCLI command "${parsed.command}" is disabled for external MCP calls.`,
+      { command: parsed.command }
+    )
+  }
+  if (!EXTERNAL_MCP_NON_FILE_COMMANDS.has(parsed.command) && !path.isAbsolute(parsed.args[0])) {
+    throw new OfficeCliRunnerError(
+      'MCP_ABSOLUTE_PATH_REQUIRED',
+      'External MCP document commands require an absolute path as their first argument.',
+      { command: parsed.command }
+    )
+  }
+  const blockedOption = parsed.args.find((argument) => {
+    const lower = argument.toLowerCase()
+    return EXTERNAL_MCP_BLOCKED_OPTIONS.has(lower) || [...EXTERNAL_MCP_BLOCKED_OPTIONS].some(
+      (option) => lower.startsWith(`${option}=`) || lower.startsWith(`${option}:`)
+    )
+  })
+  if (blockedOption) {
+    throw new OfficeCliRunnerError(
+      'MCP_OUTPUT_PATH_BLOCKED',
+      `OfficeCLI option "${blockedOption}" is disabled for external MCP calls.`,
+      { option: blockedOption }
+    )
+  }
+  validateExternalCommandProperties(parsed.args)
+  if (parsed.command === 'batch') validateExternalBatch(parsed.args)
+  return parsed
+}
+
+function throwToolFailure(result) {
+  const error = new Error(result?.error?.message || 'Office document tool failed.')
+  error.code = result?.error?.code || 'OFFICE_DOCUMENT_ERROR'
+  if (result?.error?.details !== undefined) error.details = result.error.details
+  throw error
+}
+
+function registerOfficeDocumentTool(target, runner) {
+  const ztools = target?.ztools
+  if (!ztools || typeof ztools.registerTool !== 'function') return false
+  const existing = registeredToolHosts.get(ztools)
+  if (existing) {
+    existing.runner = runner
+    return false
+  }
+
+  const registration = { runner }
+
+  const handler = async (input) => {
+    const command = validateToolInput(input)
+    validateExternalToolCommand(command)
+    const result = await safeInvoke(registration.runner, 'run', [
+      command,
+      {
+        timeoutMs: MCP_TOOL_TIMEOUT_MS,
+        env: { OFFICECLI_NO_AUTO_RESIDENT: '1' }
+      }
+    ])
+    if (!result.ok) throwToolFailure(result)
+    return { ok: true, ...result.data }
+  }
+
+  ztools.registerTool.call(ztools, OFFICE_DOCUMENT_TOOL, handler)
+  registeredToolHosts.set(ztools, registration)
+  return true
+}
+
+function attachOfficeSuite(target, runner = createOfficeCliRunner()) {
+  if (!target || (typeof target !== 'object' && typeof target !== 'function')) {
+    throw new OfficeCliRunnerError('INVALID_BRIDGE_TARGET', 'A window-like bridge target is required.')
+  }
+  const services = createOfficeSuiteServices(runner)
+  target.officeSuite = services
+  registerOfficeDocumentTool(target, runner)
+  return services
+}
+
+let defaultServices = null
+if (typeof window !== 'undefined') {
+  defaultServices = attachOfficeSuite(window)
+}
+
+module.exports = {
+  MCP_TOOL_TIMEOUT_MS,
+  OFFICE_DOCUMENT_TOOL,
+  attachOfficeSuite,
+  createOfficeSuiteServices,
+  defaultServices,
+  registerOfficeDocumentTool,
+  sanitizeUiOptions,
+  validateExternalToolCommand,
+  validateToolInput
+}

--- a/plugins/office-suite-workbench/scripts/prepare-dist.mjs
+++ b/plugins/office-suite-workbench/scripts/prepare-dist.mjs
@@ -1,0 +1,35 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const dist = path.join(root, "dist");
+
+const pluginConfig = JSON.parse(
+  await fs.readFile(path.join(root, "plugin.json"), "utf8")
+);
+delete pluginConfig.development;
+
+await fs.writeFile(
+  path.join(dist, "plugin.json"),
+  `${JSON.stringify(pluginConfig, null, 2)}\n`
+);
+await fs.copyFile(path.join(root, "logo.svg"), path.join(dist, "logo.svg"));
+await fs.cp(path.join(root, "preload"), path.join(dist, "preload"), {
+  recursive: true,
+  force: true
+});
+await fs.cp(path.join(root, "mcp"), path.join(dist, "mcp"), {
+  recursive: true,
+  force: true
+});
+await fs.cp(path.join(root, "docs"), path.join(dist, "docs"), {
+  recursive: true,
+  force: true
+});
+await fs.copyFile(path.join(root, "README.md"), path.join(dist, "README.md"));
+await fs.copyFile(path.join(root, "LICENSE"), path.join(dist, "LICENSE"));
+await fs.copyFile(
+  path.join(root, "THIRD_PARTY_NOTICES.md"),
+  path.join(dist, "THIRD_PARTY_NOTICES.md")
+);

--- a/plugins/office-suite-workbench/scripts/verify-dist.mjs
+++ b/plugins/office-suite-workbench/scripts/verify-dist.mjs
@@ -1,0 +1,73 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const dist = path.join(root, "dist");
+const failures = [];
+
+async function requireFile(relativePath) {
+  const absolutePath = path.join(dist, relativePath);
+  try {
+    const stat = await fs.stat(absolutePath);
+    if (!stat.isFile() || stat.size === 0) failures.push(`${relativePath} is empty or not a file`);
+  } catch {
+    failures.push(`${relativePath} is missing`);
+  }
+}
+
+for (const file of [
+  "index.html",
+  "plugin.json",
+  "logo.svg",
+  "preload/services.cjs",
+  "preload/officecli-runner.cjs",
+  "preload/command-parser.cjs",
+  "README.md",
+  "LICENSE",
+  "THIRD_PARTY_NOTICES.md"
+]) {
+  await requireFile(file);
+}
+
+let manifest;
+try {
+  manifest = JSON.parse(await fs.readFile(path.join(dist, "plugin.json"), "utf8"));
+} catch (error) {
+  failures.push(`plugin.json is not valid JSON: ${error.message}`);
+}
+
+if (manifest) {
+  if (manifest.name !== "office-suite-workbench") failures.push("plugin.json has an unexpected name");
+  if (manifest.main !== "index.html") failures.push("plugin.json main must point to index.html");
+  if (manifest.preload !== "preload/services.cjs") failures.push("plugin.json preload path is incorrect");
+  if (manifest.development !== undefined) failures.push("release plugin.json must not contain development settings");
+  if (!manifest.tools?.office_document) failures.push("office_document tool declaration is missing");
+  if (manifest.pluginSetting?.backgroundRunning !== true) failures.push("MCP plugin must enable backgroundRunning");
+}
+
+for (const file of ["services.cjs", "officecli-runner.cjs", "command-parser.cjs"]) {
+  const source = await fs.readFile(path.join(root, "preload", file), "utf8");
+  const packaged = await fs.readFile(path.join(dist, "preload", file), "utf8");
+  if (source !== packaged) failures.push(`dist/preload/${file} is stale`);
+  try {
+    execFileSync(process.execPath, ["--check", path.join(dist, "preload", file)], { stdio: "pipe" });
+  } catch {
+    failures.push(`dist/preload/${file} does not parse as CommonJS`);
+  }
+}
+
+try {
+  await fs.access(path.join(dist, "node_modules"));
+  failures.push("dist must not contain node_modules")
+} catch {
+  // Expected: the release preload has no third-party Node dependencies.
+}
+
+if (failures.length) {
+  for (const failure of failures) console.error(`✗ ${failure}`);
+  process.exitCode = 1;
+} else {
+  console.log("✓ dist manifest, assets, readable preload and license notices verified");
+}

--- a/plugins/office-suite-workbench/src/App.tsx
+++ b/plugins/office-suite-workbench/src/App.tsx
@@ -40,6 +40,7 @@ import {
   normalizeFilePayload,
   type QuickActionId
 } from "./lib/commands";
+import { OFFICE_AI_TOOL, normalizeOfficeAiToolInput } from "./lib/ai";
 import { parseStoredHistory, type HistoryItem } from "./lib/history";
 import type {
   ApiResult,
@@ -48,7 +49,9 @@ import type {
   OfficeCliRunOutput,
   OfficeCliStatus,
   OfficeFormat,
-  ViewId
+  ViewId,
+  ZToolsAiModel,
+  ZToolsAiRequest
 } from "./types";
 
 type StatusPhase = "checking" | "ready" | "missing";
@@ -59,6 +62,13 @@ interface LastExecution {
   label: string;
   command: string;
   result: ApiResult<OfficeCliRunOutput>;
+}
+
+interface AiChatMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  reasoning?: string;
 }
 
 const FORMAT_META: Record<OfficeFormat, {
@@ -101,6 +111,7 @@ const FORMAT_META: Record<OfficeFormat, {
 
 const NAV_ITEMS: Array<{ id: ViewId; label: string; icon: typeof Home }> = [
   { id: "home", label: "总览", icon: Home },
+  { id: "ai", label: "AI 助手", icon: Sparkles },
   { id: "word", label: "Word", icon: FileText },
   { id: "excel", label: "Excel", icon: Table2 },
   { id: "powerpoint", label: "PowerPoint", icon: Presentation },
@@ -193,21 +204,37 @@ export default function App() {
   const [mcpClient, setMcpClient] = useState<ClientId>("generic");
   const [mcpTransport, setMcpTransport] = useState<McpTransport>("ztools");
   const [toast, setToast] = useState("");
+  const [aiModels, setAiModels] = useState<ZToolsAiModel[]>([]);
+  const [aiModel, setAiModel] = useState("");
+  const [aiModelsLoading, setAiModelsLoading] = useState(false);
+  const [aiPrompt, setAiPrompt] = useState("");
+  const [aiMessages, setAiMessages] = useState<AiChatMessage[]>([]);
+  const [aiBusy, setAiBusy] = useState(false);
+  const [aiError, setAiError] = useState("");
+  const [allowAiWrite, setAllowAiWrite] = useState(false);
   const activeOperationRef = useRef<{ token: symbol; label: string } | null>(null);
   const statusRequestRef = useRef(0);
   const settingsDialogRef = useRef<HTMLDialogElement>(null);
   const settingsReturnFocusRef = useRef<HTMLElement | null>(null);
+  const aiRequestRef = useRef<ZToolsAiRequest | null>(null);
+  const allowAiWriteRef = useRef(false);
+  const selectedFileRef = useRef("");
 
   const selectedFormat = selectedFile ? detectFormat(selectedFile) : null;
   const resultText = useMemo(() => executionText(lastExecution), [lastExecution]);
 
-  const addFiles = useCallback((incoming: string[]) => {
+  const addFiles = useCallback((
+    incoming: string[],
+    options: { navigate?: boolean; selectFirst?: boolean } = {}
+  ) => {
     const supported = incoming.filter(path => detectFormat(path));
     if (!supported.length) return;
     setFiles(previous => [...new Set([...previous, ...supported])]);
-    setSelectedFile(previous => previous || supported[0]);
-    const firstFormat = detectFormat(supported[0]);
-    if (firstFormat) setView(FORMAT_META[firstFormat].view);
+    setSelectedFile(previous => options.selectFirst ? supported[0] : previous || supported[0]);
+    if (options.navigate !== false) {
+      const firstFormat = detectFormat(supported[0]);
+      if (firstFormat) setView(FORMAT_META[firstFormat].view);
+    }
   }, []);
 
   const refreshStatus = useCallback(async () => {
@@ -254,6 +281,75 @@ export default function App() {
     setMcpProbe(null);
     setMcpStatus(null);
   }, [statusPhase]);
+
+  useEffect(() => {
+    allowAiWriteRef.current = allowAiWrite;
+  }, [allowAiWrite]);
+
+  useEffect(() => {
+    selectedFileRef.current = selectedFile;
+  }, [selectedFile]);
+
+  useEffect(() => {
+    if (view !== "ai") return;
+    if (!window.ztools?.allAiModels) {
+      setAiModels([]);
+      setAiError("当前 ZTools 版本未提供原生 AI API。");
+      return;
+    }
+    let active = true;
+    setAiModelsLoading(true);
+    setAiError("");
+    void window.ztools.allAiModels().then(models => {
+      if (!active) return;
+      setAiModels(models);
+      setAiModel(previous => previous && models.some(model => model.id === previous)
+        ? previous
+        : models[0]?.id ?? "");
+      if (!models.length) setAiError("请先在 ZTools 设置中添加 AI 模型。");
+    }).catch(error => {
+      if (!active) return;
+      setAiModels([]);
+      setAiError(error instanceof Error ? error.message : "读取 ZTools AI 模型失败。");
+    }).finally(() => {
+      if (active) setAiModelsLoading(false);
+    });
+    return () => { active = false; };
+  }, [view]);
+
+  useEffect(() => {
+    const officeDocument = async (input: Record<string, unknown>) => {
+      if (!window.officeSuite) {
+        return { ok: false, error: { code: "BRIDGE_UNAVAILABLE", message: "OfficeCLI bridge unavailable." } };
+      }
+      let command: string | string[];
+      try {
+        command = normalizeOfficeAiToolInput(input, selectedFileRef.current);
+      } catch (error) {
+        const failure: ApiResult<OfficeCliRunOutput> = {
+          ok: false,
+          error: {
+            code: "AI_TOOL_INPUT_INVALID",
+            message: error instanceof Error ? error.message : "Invalid office_document input."
+          }
+        };
+        setLastExecution({ label: "AI 工具调用", command: "参数校验失败", result: failure });
+        return failure;
+      }
+      const result = await window.officeSuite.runForAi(command, {
+        allowWrite: allowAiWriteRef.current
+      });
+      const printable = Array.isArray(command) ? formatCommand(command) : command;
+      setLastExecution({ label: "AI 工具调用", command: printable, result });
+      if (!result.ok) return result;
+      const { previewImages: _previewImages, ...safeOutput } = result.data;
+      return { ok: true, ...safeOutput };
+    };
+    window.office_document = officeDocument;
+    return () => {
+      if (window.office_document === officeDocument) delete window.office_document;
+    };
+  }, []);
 
   useEffect(() => {
     if (view !== "mcp" || !window.officeSuite || statusPhase !== "ready") return;
@@ -314,18 +410,18 @@ export default function App() {
     setBusyLabel("");
   };
 
-  const chooseFiles = async () => {
+  const chooseFiles = async (options: { navigate?: boolean; selectFirst?: boolean } = {}) => {
     if (window.ztools?.showOpenDialog) {
       const result = await window.ztools.showOpenDialog({
         title: "选择 Office 文档",
         properties: ["openFile", "multiSelections"],
         filters: [{ name: "Office Open XML", extensions: ["docx", "xlsx", "pptx"] }]
       });
-      addFiles(normalizeFilePayload(result));
+      addFiles(normalizeFilePayload(result), options);
       return;
     }
     const manual = window.prompt("输入 Office 文件的绝对路径");
-    if (manual) addFiles([manual]);
+    if (manual) addFiles([manual], options);
   };
 
   const chooseOutputPath = async (format: OfficeFormat): Promise<string> => {
@@ -398,6 +494,100 @@ export default function App() {
     if (!filePath) return;
     const item = QUICK_ACTIONS.find(candidate => candidate.id === action);
     await runCommand(buildQuickCommand(action, filePath), item?.label ?? action);
+  };
+
+  const sendAiMessage = async () => {
+    const prompt = aiPrompt.trim();
+    if (!prompt || aiBusy) return;
+    if (!window.ztools?.ai) {
+      setAiError("当前 ZTools 版本未提供原生 AI API。");
+      return;
+    }
+    if (!aiModel) {
+      setAiError("请先在 ZTools 设置中添加并选择 AI 模型。");
+      return;
+    }
+
+    const userMessage: AiChatMessage = {
+      id: `user-${Date.now()}`,
+      role: "user",
+      content: prompt
+    };
+    const assistantId = `assistant-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const assistantMessage: AiChatMessage = {
+      id: assistantId,
+      role: "assistant",
+      content: ""
+    };
+    const conversation = [...aiMessages, userMessage];
+    setAiMessages([...conversation, assistantMessage]);
+    setAiPrompt("");
+    setAiError("");
+    setAiBusy(true);
+
+    const selectedContext = selectedFile
+      ? `The currently selected document is: ${selectedFile}`
+      : "No document is currently selected. Ask for an absolute path when one is required.";
+    const systemPrompt = [
+      "You are the native Office assistant inside ZTools.",
+      "Use the office_document function for factual document inspection and every claimed file operation.",
+      "Call office_document with operation, filePath, and args. To read content use operation=view and args=[\"text\"]; never use read as an operation.",
+      "Use absolute paths and read operations before edits.",
+      "Use help or load_skill when OfficeCLI syntax is uncertain.",
+      "If a tool returns AI_WRITE_APPROVAL_REQUIRED, explain that the user must enable the modification switch; never claim the file changed.",
+      "Summarize successful changes and report tool errors honestly.",
+      selectedContext
+    ].join(" ");
+
+    let request: ZToolsAiRequest;
+    try {
+      request = window.ztools.ai({
+        model: aiModel,
+        messages: [
+          { role: "system", content: systemPrompt },
+          ...conversation.map(message => ({ role: message.role, content: message.content }))
+        ],
+        tools: [OFFICE_AI_TOOL]
+      }, chunk => {
+        const content = typeof chunk.content === "string" ? chunk.content : "";
+        const reasoning = chunk.reasoning_content ?? "";
+        if (!content && !reasoning) return;
+        setAiMessages(previous => previous.map(message => message.id === assistantId
+          ? {
+              ...message,
+              content: message.content + content,
+              reasoning: (message.reasoning ?? "") + reasoning
+            }
+          : message));
+      });
+    } catch (error) {
+      setAiError(error instanceof Error ? error.message : "ZTools AI 请求启动失败。");
+      setAiBusy(false);
+      setAllowAiWrite(false);
+      allowAiWriteRef.current = false;
+      return;
+    }
+    aiRequestRef.current = request;
+
+    try {
+      await request;
+    } catch (error) {
+      setAiError(error instanceof Error ? error.message : "ZTools AI 请求失败。");
+    } finally {
+      if (aiRequestRef.current === request) aiRequestRef.current = null;
+      setAiBusy(false);
+      setAllowAiWrite(false);
+      allowAiWriteRef.current = false;
+    }
+  };
+
+  const stopAiMessage = () => {
+    aiRequestRef.current?.abort();
+    aiRequestRef.current = null;
+    setAiBusy(false);
+    setAllowAiWrite(false);
+    allowAiWriteRef.current = false;
+    setAiError("已停止本次生成。");
   };
 
   const createDocument = async (format: OfficeFormat) => {
@@ -717,6 +907,121 @@ export default function App() {
     </div>
   );
 
+  const renderAi = () => (
+    <div className="view-stack ai-view">
+      <section className="ai-hero reveal">
+        <div>
+          <span className="section-index">ZTOOLS NATIVE AI / OFFICE TOOLS</span>
+          <h1>使用你已经配置的 AI。</h1>
+          <p>模型请求由 ZTools 宿主发送，插件不会读取或保存提供商 API Key。</p>
+        </div>
+        <label className="ai-model-picker">
+          <span>当前模型</span>
+          <select
+            aria-label="ZTools AI 模型"
+            value={aiModel}
+            disabled={aiModelsLoading || !aiModels.length}
+            onChange={event => setAiModel(event.target.value)}
+          >
+            {!aiModels.length && <option value="">{aiModelsLoading ? "正在读取…" : "暂无模型"}</option>}
+            {aiModels.map(model => <option value={model.id} key={model.id}>{model.label}</option>)}
+          </select>
+          <small>{aiModels.find(model => model.id === aiModel)?.description || "来自 ZTools 设置"}</small>
+        </label>
+      </section>
+
+      <div className="ai-workspace reveal delay-1">
+        <section className="ai-chat-panel">
+          <div className="ai-chat-header">
+            <span><Sparkles size={16} /><strong>Office AI 助手</strong></span>
+            <button
+              disabled={!aiMessages.length || aiBusy}
+              onClick={() => { setAiMessages([]); setAiError(""); }}
+            >清空对话</button>
+          </div>
+          <div className="ai-transcript" aria-live="polite">
+            {aiMessages.length ? aiMessages.map(message => (
+              <article className={`ai-message ${message.role}`} key={message.id}>
+                <span>{message.role === "user" ? "YOU" : "AI"}</span>
+                <div>
+                  {message.reasoning && <details><summary>思考过程</summary><p>{message.reasoning}</p></details>}
+                  <p>{message.content || (message.role === "assistant" && aiBusy
+                    ? "正在调用 ZTools AI…"
+                    : "未返回文本。")}</p>
+                </div>
+              </article>
+            )) : (
+              <div className="ai-empty-state">
+                <span><Sparkles size={28} /></span>
+                <strong>让 AI 阅读、检查或修改 Office 文档</strong>
+                <p>例如：“检查当前 Word 文档的格式问题，并给出修复建议。”</p>
+              </div>
+            )}
+          </div>
+          {aiError && <div className="ai-error"><CircleAlert size={15} />{aiError}</div>}
+          <label className={`ai-write-toggle ai-write-inline ${allowAiWrite ? "enabled" : ""}`}>
+            <input
+              type="checkbox"
+              checked={allowAiWrite}
+              disabled={aiBusy}
+              onChange={event => setAllowAiWrite(event.target.checked)}
+            />
+            <span><ShieldCheck size={18} /></span>
+            <div>
+              <strong>{allowAiWrite ? "已允许修改文件" : "需要 AI 修改文件？先开启写入授权"}</strong>
+              <small>仅下一次发送有效；关闭时只允许读取、检查和预览。</small>
+            </div>
+          </label>
+          <div className="ai-composer">
+            <textarea
+              aria-label="向 Office AI 提问"
+              placeholder="描述你要检查、创建或修改的内容…"
+              value={aiPrompt}
+              disabled={aiBusy}
+              onChange={event => setAiPrompt(event.target.value)}
+              onKeyDown={event => {
+                if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                  event.preventDefault();
+                  void sendAiMessage();
+                }
+              }}
+            />
+            {aiBusy ? (
+              <button className="ai-send stop" onClick={stopAiMessage}><X size={16} />停止</button>
+            ) : (
+              <button
+                className="ai-send"
+                disabled={!aiPrompt.trim() || !aiModel || statusPhase !== "ready"}
+                onClick={() => void sendAiMessage()}
+              ><ArrowUpRight size={16} />发送</button>
+            )}
+          </div>
+          <div className="ai-composer-hint">⌘ / Ctrl + Enter 发送 · 工具调用经过 OfficeCLI 安全策略</div>
+        </section>
+
+        <aside className="ai-context-panel">
+          <div className="panel-title"><span>ACTIVE CONTEXT</span><strong>本轮上下文</strong></div>
+          <div className="ai-context-file">
+            <span><FileText size={18} /></span>
+            <div>
+              <strong>{selectedFile ? basename(selectedFile) : "尚未选择文档"}</strong>
+              <small title={selectedFile}>{selectedFile || "AI 会在需要时询问绝对路径"}</small>
+            </div>
+            <button onClick={() => void chooseFiles({ navigate: false, selectFirst: true })}>
+              {selectedFile ? "更换" : "选择"}
+            </button>
+          </div>
+          <div className="ai-capability-list">
+            <div><Check size={15} /><span><strong>ZTools 内置 AI</strong><small>复用设置中的模型与凭据</small></span></div>
+            <div><Check size={15} /><span><strong>OfficeCLI Function Tool</strong><small>自动执行受控文档命令</small></span></div>
+            <div><Check size={15} /><span><strong>ZTools MCP</strong><small>外部客户端入口保持可用</small></span></div>
+          </div>
+          <p className="ai-privacy-note">提示词、所选文件路径及工具结果会发送给当前 AI 提供商；原始 Office 文件不会被自动上传。</p>
+        </aside>
+      </div>
+    </div>
+  );
+
   const renderMcp = () => {
     const configuration = mcpTransport === "ztools"
       ? ZTOOLS_MCP_CONFIGS[mcpClient]
@@ -827,7 +1132,7 @@ export default function App() {
           <img src="./logo.svg" alt="" />
           <span><strong>OFFICE / SUITE</strong><small>powered by OfficeCLI</small></span>
         </button>
-        <div className="topbar-center"><span>LOCAL DOCUMENT OPERATIONS</span><i /><span>MCP READY</span></div>
+        <div className="topbar-center"><span>LOCAL DOCUMENT OPERATIONS</span><i /><span>NATIVE AI + MCP</span></div>
         <button className={`runtime-status ${statusPhase}`} onClick={openSettings}>
           {statusPhase === "checking" && <LoaderCircle className="spin" size={15} />}
           {statusPhase === "ready" && <Check size={15} />}
@@ -856,6 +1161,7 @@ export default function App() {
 
       <main className="main-canvas">
         {view === "home" && renderHome()}
+        {view === "ai" && renderAi()}
         {view === "word" && renderFormatView("word")}
         {view === "excel" && renderFormatView("excel")}
         {view === "powerpoint" && renderFormatView("powerpoint")}

--- a/plugins/office-suite-workbench/src/App.tsx
+++ b/plugins/office-suite-workbench/src/App.tsx
@@ -1,0 +1,1002 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Activity,
+  ArrowUpRight,
+  Check,
+  ChevronRight,
+  CircleAlert,
+  Clipboard,
+  Clock3,
+  Code2,
+  ExternalLink,
+  FileCheck2,
+  FilePlus2,
+  FileText,
+  FolderOpen,
+  Gauge,
+  Home,
+  Layers3,
+  ListTree,
+  LoaderCircle,
+  Play,
+  Presentation,
+  ScanSearch,
+  Settings2,
+  ShieldCheck,
+  Sparkles,
+  SquareTerminal,
+  Table2,
+  Unplug,
+  X
+} from "lucide-react";
+
+import {
+  RECIPES,
+  QUICK_ACTIONS,
+  basename,
+  buildQuickCommand,
+  detectFormat,
+  formatCommand,
+  normalizeFilePayload,
+  type QuickActionId
+} from "./lib/commands";
+import { parseStoredHistory, type HistoryItem } from "./lib/history";
+import type {
+  ApiResult,
+  McpConfigurations,
+  McpProbe,
+  OfficeCliRunOutput,
+  OfficeCliStatus,
+  OfficeFormat,
+  ViewId
+} from "./types";
+
+type StatusPhase = "checking" | "ready" | "missing";
+type ClientId = "generic" | "codex" | "claude" | "cursor" | "vscode";
+type McpTransport = "ztools" | "stdio";
+
+interface LastExecution {
+  label: string;
+  command: string;
+  result: ApiResult<OfficeCliRunOutput>;
+}
+
+const FORMAT_META: Record<OfficeFormat, {
+  label: string;
+  eyebrow: string;
+  extension: string;
+  description: string;
+  view: ViewId;
+  className: string;
+  icon: typeof FileText;
+}> = {
+  word: {
+    label: "Word",
+    eyebrow: "WRITE / REVIEW",
+    extension: ".docx",
+    description: "读取正文、审阅结构、批量改写与格式校验。",
+    view: "word",
+    className: "word",
+    icon: FileText
+  },
+  excel: {
+    label: "Excel",
+    eyebrow: "MODEL / ANALYZE",
+    extension: ".xlsx",
+    description: "单元格、公式、图表、透视表和工作簿自动化。",
+    view: "excel",
+    className: "excel",
+    icon: Table2
+  },
+  powerpoint: {
+    label: "PowerPoint",
+    eyebrow: "PRESENT / INSPECT",
+    extension: ".pptx",
+    description: "幻灯片、形状、图表、动画与视觉审计。",
+    view: "powerpoint",
+    className: "powerpoint",
+    icon: Presentation
+  }
+};
+
+const NAV_ITEMS: Array<{ id: ViewId; label: string; icon: typeof Home }> = [
+  { id: "home", label: "总览", icon: Home },
+  { id: "word", label: "Word", icon: FileText },
+  { id: "excel", label: "Excel", icon: Table2 },
+  { id: "powerpoint", label: "PowerPoint", icon: Presentation },
+  { id: "console", label: "命令台", icon: SquareTerminal },
+  { id: "mcp", label: "MCP 接入", icon: Layers3 }
+];
+
+const CONSOLE_EXAMPLES = [
+  "help docx paragraph",
+  "view report.docx issues --json",
+  "get report.docx /body/p[1] --depth 2 --json",
+  "query book.xlsx \"cell:has(formula)\" --json",
+  "validate deck.pptx --json"
+];
+
+const ZTOOLS_MCP_URL = "http://127.0.0.1:36579/mcp";
+const ZTOOLS_MCP_CONFIGS: Record<ClientId, unknown> = {
+  generic: {
+    type: "http",
+    url: ZTOOLS_MCP_URL,
+    headers: { Authorization: "Bearer <ZTOOLS_API_KEY>" }
+  },
+  codex: `[mcp_servers.ztools]\nurl = "${ZTOOLS_MCP_URL}"\nhttp_headers = { Authorization = "Bearer <ZTOOLS_API_KEY>" }\n`,
+  claude: {
+    mcpServers: {
+      ztools: {
+        type: "http",
+        url: ZTOOLS_MCP_URL,
+        headers: { Authorization: "Bearer <ZTOOLS_API_KEY>" }
+      }
+    }
+  },
+  cursor: {
+    mcpServers: {
+      ztools: {
+        type: "http",
+        url: ZTOOLS_MCP_URL,
+        headers: { Authorization: "Bearer <ZTOOLS_API_KEY>" }
+      }
+    }
+  },
+  vscode: {
+    servers: {
+      ztools: {
+        type: "http",
+        url: ZTOOLS_MCP_URL,
+        headers: { Authorization: "Bearer <ZTOOLS_API_KEY>" }
+      }
+    }
+  }
+};
+
+function loadStoredHistory(): HistoryItem[] {
+  try {
+    return parseStoredHistory(localStorage.getItem("office-suite.history"));
+  } catch {
+    return [];
+  }
+}
+
+function executionText(execution: LastExecution | null): string {
+  if (!execution) return "选择一项操作后，OfficeCLI 的结构化输出会显示在这里。";
+  if (!execution.result.ok) {
+    return JSON.stringify(execution.result.error, null, 2);
+  }
+  const output = execution.result.data;
+  if (output.json !== undefined) return JSON.stringify(output.json, null, 2);
+  return [output.stdout, output.stderr].filter(Boolean).join("\n") || "命令执行成功，没有额外输出。";
+}
+
+function configText(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value ?? {}, null, 2);
+}
+
+export default function App() {
+  const [view, setView] = useState<ViewId>("home");
+  const [files, setFiles] = useState<string[]>([]);
+  const [selectedFile, setSelectedFile] = useState("");
+  const [statusPhase, setStatusPhase] = useState<StatusPhase>("checking");
+  const [status, setStatus] = useState<OfficeCliStatus>({ installed: false });
+  const [showSettings, setShowSettings] = useState(false);
+  const [busyLabel, setBusyLabel] = useState("");
+  const [history, setHistory] = useState<HistoryItem[]>(loadStoredHistory);
+  const [lastExecution, setLastExecution] = useState<LastExecution | null>(null);
+  const [consoleCommand, setConsoleCommand] = useState("help");
+  const [mcpConfigs, setMcpConfigs] = useState<ApiResult<McpConfigurations> | null>(null);
+  const [mcpProbe, setMcpProbe] = useState<ApiResult<McpProbe> | null>(null);
+  const [mcpStatus, setMcpStatus] = useState<ApiResult<unknown> | null>(null);
+  const [mcpClient, setMcpClient] = useState<ClientId>("generic");
+  const [mcpTransport, setMcpTransport] = useState<McpTransport>("ztools");
+  const [toast, setToast] = useState("");
+  const activeOperationRef = useRef<{ token: symbol; label: string } | null>(null);
+  const statusRequestRef = useRef(0);
+  const settingsDialogRef = useRef<HTMLDialogElement>(null);
+  const settingsReturnFocusRef = useRef<HTMLElement | null>(null);
+
+  const selectedFormat = selectedFile ? detectFormat(selectedFile) : null;
+  const resultText = useMemo(() => executionText(lastExecution), [lastExecution]);
+
+  const addFiles = useCallback((incoming: string[]) => {
+    const supported = incoming.filter(path => detectFormat(path));
+    if (!supported.length) return;
+    setFiles(previous => [...new Set([...previous, ...supported])]);
+    setSelectedFile(previous => previous || supported[0]);
+    const firstFormat = detectFormat(supported[0]);
+    if (firstFormat) setView(FORMAT_META[firstFormat].view);
+  }, []);
+
+  const refreshStatus = useCallback(async () => {
+    const requestId = ++statusRequestRef.current;
+    setStatusPhase("checking");
+    if (!window.officeSuite) {
+      if (requestId !== statusRequestRef.current) return;
+      setStatus({ installed: false });
+      setStatusPhase("missing");
+      return;
+    }
+    const response = await window.officeSuite.getStatus();
+    if (requestId !== statusRequestRef.current) return;
+    if (response.ok && response.data.installed) {
+      setStatus(response.data);
+      setStatusPhase("ready");
+    } else {
+      setStatus({ installed: false });
+      setStatusPhase("missing");
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshStatus();
+  }, [refreshStatus]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem("office-suite.history", JSON.stringify(history.slice(0, 12)));
+    } catch {
+      // Storage is an enhancement; the workbench still works when it is unavailable.
+    }
+  }, [history]);
+
+  useEffect(() => {
+    window.ztools?.onPluginEnter?.(launch => {
+      addFiles(normalizeFilePayload(launch));
+    });
+  }, [addFiles]);
+
+  useEffect(() => {
+    if (statusPhase === "ready") return;
+    setMcpConfigs(null);
+    setMcpProbe(null);
+    setMcpStatus(null);
+  }, [statusPhase]);
+
+  useEffect(() => {
+    if (view !== "mcp" || !window.officeSuite || statusPhase !== "ready") return;
+    let active = true;
+    setMcpConfigs(null);
+    setMcpStatus(null);
+    void Promise.all([
+      window.officeSuite.getMcpConfigs(),
+      window.officeSuite.getMcpStatus()
+    ]).then(([configs, currentStatus]) => {
+      if (!active) return;
+      setMcpConfigs(configs);
+      setMcpStatus(currentStatus);
+    }).catch(error => {
+      if (!active) return;
+      const failure = {
+        ok: false,
+        error: {
+          code: "MCP_CONFIG_REJECTED",
+          message: error instanceof Error ? error.message : "MCP 配置读取意外中断。"
+        }
+      } as const;
+      setMcpConfigs(failure);
+      setMcpStatus(failure);
+    });
+    return () => { active = false; };
+  }, [view, statusPhase]);
+
+  useEffect(() => {
+    if (!showSettings) return;
+    const dialog = settingsDialogRef.current;
+    if (!dialog) return;
+    if (!dialog.open) dialog.showModal();
+    return () => {
+      if (dialog.open) dialog.close();
+    };
+  }, [showSettings]);
+
+  const notify = (message: string) => {
+    setToast(message);
+    window.setTimeout(() => setToast(""), 2200);
+  };
+
+  const beginOperation = (label: string): symbol | null => {
+    if (activeOperationRef.current) {
+      notify(`正在执行“${activeOperationRef.current.label}”，请稍候。`);
+      return null;
+    }
+    const token = Symbol(label);
+    activeOperationRef.current = { token, label };
+    setBusyLabel(label);
+    return token;
+  };
+
+  const endOperation = (token: symbol) => {
+    if (activeOperationRef.current?.token !== token) return;
+    activeOperationRef.current = null;
+    setBusyLabel("");
+  };
+
+  const chooseFiles = async () => {
+    if (window.ztools?.showOpenDialog) {
+      const result = await window.ztools.showOpenDialog({
+        title: "选择 Office 文档",
+        properties: ["openFile", "multiSelections"],
+        filters: [{ name: "Office Open XML", extensions: ["docx", "xlsx", "pptx"] }]
+      });
+      addFiles(normalizeFilePayload(result));
+      return;
+    }
+    const manual = window.prompt("输入 Office 文件的绝对路径");
+    if (manual) addFiles([manual]);
+  };
+
+  const chooseOutputPath = async (format: OfficeFormat): Promise<string> => {
+    const meta = FORMAT_META[format];
+    if (window.ztools?.showSaveDialog) {
+      const result = await window.ztools.showSaveDialog({
+        title: `新建 ${meta.label} 文档`,
+        defaultPath: `untitled${meta.extension}`,
+        filters: [{ name: meta.label, extensions: [meta.extension.slice(1)] }]
+      });
+      return normalizeFilePayload(result)[0] ?? "";
+    }
+    return window.prompt(`输入新文件的绝对路径（${meta.extension}）`) ?? "";
+  };
+
+  const runCommand = async (command: string | string[], label: string) => {
+    const printable = Array.isArray(command) ? formatCommand(command) : command;
+    if (!window.officeSuite) {
+      const unavailable: ApiResult<OfficeCliRunOutput> = {
+        ok: false,
+        error: { code: "BRIDGE_UNAVAILABLE", message: "ZTools preload 尚未加载。" }
+      };
+      setLastExecution({
+        label,
+        command: printable,
+        result: unavailable
+      });
+      return unavailable;
+    }
+
+    const token = beginOperation(label);
+    if (!token) {
+      return {
+        ok: false,
+        error: { code: "OPERATION_BUSY", message: "另一个 Office 操作仍在执行。" }
+      } satisfies ApiResult<OfficeCliRunOutput>;
+    }
+
+    try {
+      let response: ApiResult<OfficeCliRunOutput>;
+      try {
+        response = await window.officeSuite.run(command, { timeoutMs: 120_000 });
+      } catch (error) {
+        response = {
+          ok: false,
+          error: {
+            code: "BRIDGE_REJECTED",
+            message: error instanceof Error ? error.message : "Office 操作意外中断。"
+          }
+        };
+      }
+      setLastExecution({ label, command: printable, result: response });
+      setHistory(previous => [
+        {
+          id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+          label,
+          command: printable,
+          ok: response.ok,
+          at: new Date().toISOString()
+        },
+        ...previous
+      ].slice(0, 12));
+      return response;
+    } finally {
+      endOperation(token);
+    }
+  };
+
+  const runQuickAction = async (action: QuickActionId, filePath = selectedFile) => {
+    if (!filePath) return;
+    const item = QUICK_ACTIONS.find(candidate => candidate.id === action);
+    await runCommand(buildQuickCommand(action, filePath), item?.label ?? action);
+  };
+
+  const createDocument = async (format: OfficeFormat) => {
+    const outputPath = await chooseOutputPath(format);
+    if (!outputPath) return;
+    const response = await runCommand(["create", outputPath, "--json"], `新建 ${FORMAT_META[format].label}`);
+    if (response?.ok) addFiles([outputPath]);
+  };
+
+  const copyText = async (text: string) => {
+    if (window.ztools?.copyText) window.ztools.copyText(text);
+    else await navigator.clipboard.writeText(text);
+    notify("已复制到剪贴板");
+  };
+
+  const restoreSettingsFocus = () => {
+    const target = settingsReturnFocusRef.current;
+    settingsReturnFocusRef.current = null;
+    if (target?.isConnected) target.focus();
+  };
+
+  const openSettings = () => {
+    settingsReturnFocusRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    setShowSettings(true);
+  };
+
+  const closeSettings = () => {
+    if (settingsDialogRef.current?.open) settingsDialogRef.current.close();
+    setShowSettings(false);
+    restoreSettingsFocus();
+  };
+
+  const retryRuntimeDiscovery = () => {
+    closeSettings();
+    void refreshStatus();
+  };
+
+  const probeMcp = async () => {
+    if (!window.officeSuite) return;
+    const token = beginOperation("探测 MCP");
+    if (!token) return;
+    try {
+      try {
+        setMcpProbe(await window.officeSuite.probeMcp());
+      } catch (error) {
+        setMcpProbe({
+          ok: false,
+          error: {
+            code: "MCP_PROBE_REJECTED",
+            message: error instanceof Error ? error.message : "MCP 探测意外中断。"
+          }
+        });
+      }
+    } finally {
+      endOperation(token);
+    }
+  };
+
+  const changeMcpRegistration = async (
+    target: "lms" | "claude" | "cursor" | "vscode",
+    mode: "register" | "unregister"
+  ) => {
+    if (!window.officeSuite) return;
+    const label = `${mode === "register" ? "注册" : "移除"} ${target}`;
+    const token = beginOperation(label);
+    if (!token) return;
+    try {
+      try {
+        const response = mode === "register"
+          ? await window.officeSuite.registerMcp(target)
+          : await window.officeSuite.unregisterMcp(target);
+        notify(response.ok ? "MCP 配置已更新" : response.error.message);
+        setMcpStatus(await window.officeSuite.getMcpStatus());
+      } catch (error) {
+        notify(error instanceof Error ? error.message : "MCP 配置更新意外中断。");
+      }
+    } finally {
+      endOperation(token);
+    }
+  };
+
+  const renderHome = () => (
+    <div className="view-stack home-view">
+      <section className="hero-panel reveal">
+        <div className="hero-copy">
+          <span className="section-index">01 — DOCUMENT OPERATIONS</span>
+          <h1>一个工作台，<br /><em>三种文档世界。</em></h1>
+          <p>
+            让 Word、Excel 和 PowerPoint 共享同一套可检查、可批处理、可被 AI 调用的命令语言。
+          </p>
+          <div className="hero-actions">
+            <button className="button primary" onClick={() => void chooseFiles()}>
+              <FolderOpen size={17} /> 选择文档
+            </button>
+            <button className="button ghost" onClick={() => setView("console")}>
+              打开命令台 <ArrowUpRight size={16} />
+            </button>
+          </div>
+        </div>
+        <div className="hero-diagram" aria-label="OfficeCLI processing diagram">
+          <div className="diagram-orbit orbit-word">W</div>
+          <div className="diagram-orbit orbit-excel">X</div>
+          <div className="diagram-orbit orbit-powerpoint">P</div>
+          <div className="diagram-core"><Code2 size={27} /><span>CLI</span></div>
+          <div className="diagram-caption">OPEN XML / STDIO / JSON</div>
+        </div>
+      </section>
+
+      {statusPhase === "missing" && <DependencyNotice onSettings={openSettings} />}
+
+      <section className="format-grid reveal delay-1">
+        {(Object.keys(FORMAT_META) as OfficeFormat[]).map(format => {
+          const meta = FORMAT_META[format];
+          const Icon = meta.icon;
+          const count = files.filter(path => detectFormat(path) === format).length;
+          return (
+            <button
+              className={`format-card ${meta.className}`}
+              key={format}
+              onClick={() => setView(meta.view)}
+            >
+              <span className="format-number">0{format === "word" ? 1 : format === "excel" ? 2 : 3}</span>
+              <Icon size={28} strokeWidth={1.6} />
+              <span className="format-eyebrow">{meta.eyebrow}</span>
+              <strong>{meta.label}</strong>
+              <span>{meta.description}</span>
+              <span className="format-footer">{count ? `${count} 个已载入` : `支持 ${meta.extension}`} <ChevronRight size={16} /></span>
+            </button>
+          );
+        })}
+      </section>
+
+      <section className="home-bottom reveal delay-2">
+        <DocumentQueue
+          files={files}
+          selectedFile={selectedFile}
+          onSelect={setSelectedFile}
+          onAdd={() => void chooseFiles()}
+          onRemove={path => {
+            const remaining = files.filter(item => item !== path);
+            setFiles(remaining);
+            if (selectedFile === path) setSelectedFile(remaining[0] ?? "");
+          }}
+        />
+        <ActivityList history={history} onOpenConsole={() => setView("console")} />
+      </section>
+    </div>
+  );
+
+  const renderFormatView = (format: OfficeFormat) => {
+    const meta = FORMAT_META[format];
+    const Icon = meta.icon;
+    const formatFiles = files.filter(path => detectFormat(path) === format);
+    const activePath = selectedFormat === format ? selectedFile : formatFiles[0] ?? "";
+
+    return (
+      <div className={`view-stack workbench-view theme-${meta.className}`}>
+        <section className="workbench-heading reveal">
+          <div className="heading-icon"><Icon size={34} /></div>
+          <div>
+            <span className="section-index">{meta.eyebrow}</span>
+            <h1>{meta.label} 工作站</h1>
+            <p>{meta.description}</p>
+          </div>
+          <button className="button format-action" disabled={Boolean(busyLabel)} onClick={() => void createDocument(format)}>
+            <FilePlus2 size={17} /> 新建 {meta.extension}
+          </button>
+        </section>
+
+        <section
+          className="file-stage reveal delay-1"
+          onDragOver={event => event.preventDefault()}
+          onDrop={event => {
+            event.preventDefault();
+            const paths = Array.from(event.dataTransfer.files)
+              .map(file => (file as File & { path?: string }).path ?? "")
+              .filter(Boolean);
+            addFiles(paths);
+          }}
+        >
+          <div className="stage-label"><span>ACTIVE DOCUMENT</span><span>{formatFiles.length} FILES</span></div>
+          {activePath ? (
+            <div className="active-file">
+              <div className="file-mark"><Icon size={24} /></div>
+              <div className="file-copy">
+                <strong>{basename(activePath)}</strong>
+                <span title={activePath}>{activePath}</span>
+              </div>
+              <select
+                aria-label="切换当前文档"
+                value={activePath}
+                onChange={event => setSelectedFile(event.target.value)}
+              >
+                {formatFiles.map(path => <option value={path} key={path}>{basename(path)}</option>)}
+              </select>
+              <button className="icon-button" title="在系统中打开" onClick={() => void window.ztools?.shellOpenPath?.(activePath)}>
+                <ExternalLink size={17} />
+              </button>
+            </div>
+          ) : (
+            <button className="empty-file" onClick={() => void chooseFiles()}>
+              <FolderOpen size={26} />
+              <strong>拖入或选择 {meta.extension} 文件</strong>
+              <span>文件只在本机交给 OfficeCLI 处理</span>
+            </button>
+          )}
+        </section>
+
+        <div className="workbench-columns reveal delay-2">
+          <section className="operation-panel">
+            <div className="panel-title"><span>QUICK OPERATIONS</span><strong>文档操作</strong></div>
+            <div className="operation-grid">
+              {QUICK_ACTIONS.map((action, index) => {
+                const icons = [ListTree, FileText, Gauge, ScanSearch, FileCheck2, Activity];
+                const ActionIcon = icons[index];
+                return (
+                  <button
+                    key={action.id}
+                    disabled={!activePath || Boolean(busyLabel)}
+                    onClick={() => void runQuickAction(action.id, activePath)}
+                  >
+                    <ActionIcon size={19} />
+                    <strong>{action.label}</strong>
+                    <span>{action.description}</span>
+                    <ChevronRight size={15} className="operation-arrow" />
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <section className="recipe-panel">
+            <div className="panel-title"><span>COMMAND RECIPES</span><strong>专业配方</strong></div>
+            <div className="recipe-list">
+              {RECIPES[format].map((recipe, index) => {
+                const command = activePath ? recipe.command(activePath) : [];
+                return (
+                  <button
+                    key={recipe.title}
+                    disabled={!activePath || Boolean(busyLabel)}
+                    onClick={() => void runCommand(command, recipe.title)}
+                  >
+                    <span className="recipe-index">R{index + 1}</span>
+                    <span><strong>{recipe.title}</strong><code>{command.length ? formatCommand(command) : "等待选择文件"}</code></span>
+                    <Play size={15} />
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        </div>
+      </div>
+    );
+  };
+
+  const renderConsole = () => (
+    <div className="view-stack console-view">
+      <section className="console-heading reveal">
+        <div>
+          <span className="section-index">RAW POWER / CONTROLLED PROCESS</span>
+          <h1>Office 命令台</h1>
+          <p>直接使用 OfficeCLI 语法；执行器固定为 OfficeCLI，不经过 shell。</p>
+        </div>
+        <ShieldCheck size={38} />
+      </section>
+
+      <section className="terminal-shell reveal delay-1">
+        <div className="terminal-bar">
+          <span><i className="terminal-dot red" /><i className="terminal-dot amber" /><i className="terminal-dot green" /></span>
+          <span>officecli — safe argv mode</span>
+          <span>{status.version ?? "not connected"}</span>
+        </div>
+        <div className="command-editor">
+          <span className="prompt-mark">›</span>
+          <textarea
+            aria-label="OfficeCLI 命令"
+            spellCheck={false}
+            value={consoleCommand}
+            onChange={event => setConsoleCommand(event.target.value)}
+            onKeyDown={event => {
+              if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
+                event.preventDefault();
+                void runCommand(consoleCommand, "命令台执行");
+              }
+            }}
+          />
+          <button
+            className="run-command"
+            disabled={!consoleCommand.trim() || Boolean(busyLabel)}
+            onClick={() => void runCommand(consoleCommand, "命令台执行")}
+          >
+            {busyLabel ? <LoaderCircle className="spin" size={18} /> : <Play size={18} />}
+            RUN
+          </button>
+        </div>
+        <div className="command-hint">⌘ / Ctrl + Enter 执行 · 允许文档操作、help 与 load_skill · 禁止安装和配置管理命令</div>
+      </section>
+
+      <div className="console-grid reveal delay-2">
+        <section className="examples-panel">
+          <div className="panel-title"><span>STARTING POINTS</span><strong>命令样例</strong></div>
+          {CONSOLE_EXAMPLES.map(example => (
+            <button key={example} onClick={() => setConsoleCommand(example)}>
+              <code>{example}</code><ChevronRight size={15} />
+            </button>
+          ))}
+        </section>
+        <ResultPanel
+          execution={lastExecution}
+          text={resultText}
+          busy={Boolean(busyLabel)}
+          onCopy={() => void copyText(resultText)}
+        />
+      </div>
+    </div>
+  );
+
+  const renderMcp = () => {
+    const configuration = mcpTransport === "ztools"
+      ? ZTOOLS_MCP_CONFIGS[mcpClient]
+      : mcpConfigs?.ok ? mcpConfigs.data.configs?.[mcpClient] : undefined;
+    const canCopyConfiguration = mcpTransport === "ztools"
+      || Boolean(mcpConfigs?.ok && configuration !== undefined);
+    const configurationDisplay = mcpTransport === "ztools"
+      ? configText(configuration)
+      : !mcpConfigs
+        ? "正在读取 OfficeCLI 路径…"
+        : mcpConfigs.ok
+          ? configText(configuration)
+          : `读取失败：${mcpConfigs.error.message}`;
+    const clientLabels: Record<ClientId, string> = {
+      generic: "通用 JSON",
+      codex: "Codex",
+      claude: "Claude",
+      cursor: "Cursor",
+      vscode: "VS Code"
+    };
+    return (
+      <div className="view-stack mcp-view">
+        <section className="mcp-hero reveal">
+          <div>
+            <span className="section-index">MODEL CONTEXT PROTOCOL / STDIO</span>
+            <h1>让 AI 直接操作 Office。</h1>
+            <p>ZTools 网关暴露受控 <code>office_document(command)</code>；高级模式可直连 OfficeCLI stdio。</p>
+          </div>
+          <div className={`mcp-signal ${mcpProbe?.ok ? "online" : ""}`}>
+            <span className="signal-ring"><Sparkles size={28} /></span>
+            <strong>{mcpProbe?.ok ? "HANDSHAKE OK" : "READY TO PROBE"}</strong>
+            <small>{mcpProbe?.ok ? `${mcpProbe.data.serverInfo?.name ?? "officecli"} ${mcpProbe.data.serverInfo?.version ?? ""}` : "stdio / JSON-RPC"}</small>
+          </div>
+        </section>
+
+        <section className="probe-strip reveal delay-1">
+          <div><Activity size={19} /><span><strong>原生 MCP 自检</strong><small>initialize → tools/list</small></span></div>
+          <div className="probe-detail">
+            {mcpProbe?.ok && <><span>协议 {mcpProbe.data.protocolVersion}</span><span>工具 {mcpProbe.data.toolNames?.join(", ")}</span></>}
+            {mcpProbe && !mcpProbe.ok && <span className="error-text">{mcpProbe.error.message}</span>}
+          </div>
+          <button className="button primary" disabled={Boolean(busyLabel) || statusPhase !== "ready"} onClick={() => void probeMcp()}>
+            {busyLabel === "探测 MCP" ? <LoaderCircle className="spin" size={16} /> : <Activity size={16} />}
+            运行握手
+          </button>
+        </section>
+
+        <div className="mcp-grid reveal delay-2">
+          <section className="config-panel">
+            <div className="panel-title"><span>CLIENT CONFIGURATION</span><strong>复制接入配置</strong></div>
+            <div className="transport-switch" aria-label="MCP 传输方式">
+              <button className={mcpTransport === "ztools" ? "active" : ""} onClick={() => setMcpTransport("ztools")}>
+                <ShieldCheck size={14} /><span><strong>ZTools HTTP 网关</strong><small>推荐 · 插件策略保护</small></span>
+              </button>
+              <button className={mcpTransport === "stdio" ? "active" : ""} onClick={() => setMcpTransport("stdio")}>
+                <SquareTerminal size={14} /><span><strong>OfficeCLI stdio</strong><small>高级 · 直接完整能力</small></span>
+              </button>
+            </div>
+            <div className="client-tabs">
+              {(Object.keys(clientLabels) as ClientId[]).map(client => (
+                <button className={mcpClient === client ? "active" : ""} key={client} onClick={() => setMcpClient(client)}>
+                  {clientLabels[client]}
+                </button>
+              ))}
+            </div>
+            <div className="config-code">
+              <div><span>{clientLabels[mcpClient]}</span><button disabled={!canCopyConfiguration} onClick={() => void copyText(configText(configuration))}><Clipboard size={15} /> COPY</button></div>
+              <pre>{configurationDisplay}</pre>
+            </div>
+            <p className="config-note"><ShieldCheck size={15} /> {mcpTransport === "ztools"
+              ? <>先在 ZTools 设置 → MCP 服务中启用服务并替换 API Key；工具名以客户端 <code>tools/list</code> 为准。</>
+              : <>配置直接启动 <code>officecli mcp</code>，会绕过插件侧策略，适合可信本机客户端。</>}
+            </p>
+          </section>
+
+          <section className="registration-panel">
+            <div className="panel-title"><span>{mcpTransport === "ztools" ? "ZTOOLS GATEWAY" : "ONE-CLICK REGISTRATION"}</span><strong>{mcpTransport === "ztools" ? "接入步骤" : "客户端注册"}</strong></div>
+            {mcpTransport === "ztools" ? (
+              <ol className="gateway-steps">
+                <li><span>01</span><div><strong>开启宿主服务</strong><small>打开 ZTools 设置 → MCP 服务，启用 HTTP 端点。</small></div></li>
+                <li><span>02</span><div><strong>复制 API Key</strong><small>将配置中的占位符替换为设置页生成的 Key。</small></div></li>
+                <li><span>03</span><div><strong>刷新 tools/list</strong><small>找到 <code>office_suite_workbench_office_document</code>（实际名称以列表为准）。</small></div></li>
+              </ol>
+            ) : (["claude", "cursor", "vscode", "lms"] as const).map(target => (
+                <div className="client-row" key={target}>
+                  <span className="client-monogram">{target.slice(0, 2).toUpperCase()}</span>
+                  <span><strong>{target === "lms" ? "LM Studio" : target === "vscode" ? "VS Code" : target[0].toUpperCase() + target.slice(1)}</strong><small>由 OfficeCLI 管理配置</small></span>
+                  <button disabled={Boolean(busyLabel)} onClick={() => void changeMcpRegistration(target, "register")}>注册</button>
+                  <button disabled={Boolean(busyLabel)} className="subtle" onClick={() => void changeMcpRegistration(target, "unregister")}>移除</button>
+                </div>
+              ))}
+            <div className="registration-state">
+              <span>{mcpTransport === "ztools" ? "安全提示" : "当前状态"}</span>
+              <pre>{mcpTransport === "ztools"
+                ? "宿主端点使用 Bearer Key。不要把 Key 放入仓库、截图或聊天记录；跨设备访问前请同时检查系统防火墙。"
+                : mcpStatus ? configText(mcpStatus.ok ? mcpStatus.data : mcpStatus.error) : "尚未读取"}</pre>
+            </div>
+          </section>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="app-shell">
+      <header className="topbar">
+        <button className="brand" onClick={() => setView("home")} aria-label="返回总览">
+          <img src="./logo.svg" alt="" />
+          <span><strong>OFFICE / SUITE</strong><small>powered by OfficeCLI</small></span>
+        </button>
+        <div className="topbar-center"><span>LOCAL DOCUMENT OPERATIONS</span><i /><span>MCP READY</span></div>
+        <button className={`runtime-status ${statusPhase}`} onClick={openSettings}>
+          {statusPhase === "checking" && <LoaderCircle className="spin" size={15} />}
+          {statusPhase === "ready" && <Check size={15} />}
+          {statusPhase === "missing" && <Unplug size={15} />}
+          <span>{statusPhase === "ready" ? `OfficeCLI ${status.version ?? "online"}` : statusPhase === "checking" ? "正在探测" : "需要连接"}</span>
+          <Settings2 size={14} />
+        </button>
+      </header>
+
+      <aside className="sidebar">
+        <nav>
+          {NAV_ITEMS.map(item => {
+            const Icon = item.icon;
+            return (
+              <button key={item.id} className={view === item.id ? "active" : ""} onClick={() => setView(item.id)} title={item.label}>
+                <Icon size={19} /><span>{item.label}</span>
+              </button>
+            );
+          })}
+        </nav>
+        <div className="sidebar-footer">
+          <span>{files.length.toString().padStart(2, "0")}</span>
+          <small>DOCS<br />LOADED</small>
+        </div>
+      </aside>
+
+      <main className="main-canvas">
+        {view === "home" && renderHome()}
+        {view === "word" && renderFormatView("word")}
+        {view === "excel" && renderFormatView("excel")}
+        {view === "powerpoint" && renderFormatView("powerpoint")}
+        {view === "console" && renderConsole()}
+        {view === "mcp" && renderMcp()}
+      </main>
+
+      {lastExecution && view !== "console" && (
+        <aside className="result-drawer">
+          <ResultPanel
+            execution={lastExecution}
+            text={resultText}
+            busy={Boolean(busyLabel)}
+            onCopy={() => void copyText(resultText)}
+            onClose={() => setLastExecution(null)}
+          />
+        </aside>
+      )}
+
+      {showSettings && (
+          <dialog
+            ref={settingsDialogRef}
+            className="settings-modal"
+            aria-labelledby="settings-title"
+            onCancel={event => { event.preventDefault(); closeSettings(); }}
+            onClose={() => { setShowSettings(false); restoreSettingsFocus(); }}
+          >
+            <button className="modal-close" onClick={closeSettings} aria-label="关闭"><X size={18} /></button>
+            <span className="section-index">RUNTIME CONNECTION</span>
+            <h2 id="settings-title">OfficeCLI 运行时</h2>
+            <p>插件只使用 PATH、只读环境变量 <code>OFFICECLI_PATH</code> 与官方常见安装目录中发现的 OfficeCLI，不接受页面指定任意可执行文件。</p>
+            <div className="runtime-readout">
+              <span>{statusPhase === "ready" ? <Check size={16} /> : <CircleAlert size={16} />}</span>
+              <div><strong>{statusPhase === "ready" ? "运行时已连接" : "尚未发现 OfficeCLI"}</strong><small>{status.binaryPath ?? "安装后重启 ZTools，或设置 OFFICECLI_PATH"}</small></div>
+            </div>
+            <div className="modal-actions">
+              <button className="button ghost" onClick={() => void window.ztools?.shellOpenExternal?.("https://github.com/iOfficeAI/OfficeCLI")}>
+                安装说明 <ExternalLink size={15} />
+              </button>
+              <button className="button primary" onClick={retryRuntimeDiscovery}>重新探测</button>
+            </div>
+          </dialog>
+      )}
+
+      {busyLabel && <div className="busy-pill"><LoaderCircle className="spin" size={15} /> {busyLabel}</div>}
+      {toast && <div className="toast"><Check size={15} /> {toast}</div>}
+    </div>
+  );
+}
+
+function DependencyNotice({ onSettings }: { onSettings: () => void }) {
+  return (
+    <section className="dependency-notice reveal">
+      <CircleAlert size={22} />
+      <div><strong>还差一个 OfficeCLI 运行时</strong><span>插件不会捆绑或静默安装第三方二进制；安装后即可获得全部文档与 MCP 能力。</span></div>
+      <code>curl -fsSL https://d.officecli.ai/install.sh | bash</code>
+      <button onClick={onSettings}>检查路径 <ChevronRight size={15} /></button>
+    </section>
+  );
+}
+
+function DocumentQueue({
+  files,
+  selectedFile,
+  onSelect,
+  onAdd,
+  onRemove
+}: {
+  files: string[];
+  selectedFile: string;
+  onSelect: (path: string) => void;
+  onAdd: () => void;
+  onRemove: (path: string) => void;
+}) {
+  return (
+    <section className="document-queue">
+      <div className="panel-title"><span>DOCUMENT QUEUE</span><strong>已载入文档</strong><button onClick={onAdd}><FilePlus2 size={15} /> 添加</button></div>
+      {files.length ? (
+        <div className="queue-list">
+          {files.slice(0, 6).map(path => {
+            const format = detectFormat(path)!;
+            const meta = FORMAT_META[format];
+            const Icon = meta.icon;
+            return (
+              <div className={`queue-row ${selectedFile === path ? "selected" : ""}`} key={path}>
+                <button className="queue-select" onClick={() => onSelect(path)}>
+                  <span className={`queue-icon ${meta.className}`}><Icon size={17} /></span>
+                  <span><strong>{basename(path)}</strong><small>{path}</small></span>
+                  <i>{meta.extension}</i>
+                </button>
+                <button className="remove-file" aria-label={`移除 ${basename(path)}`} onClick={() => onRemove(path)}><X size={14} /></button>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <button className="queue-empty" onClick={onAdd}><FolderOpen size={23} /><span><strong>尚未载入文档</strong><small>选择 docx、xlsx 或 pptx 开始</small></span></button>
+      )}
+    </section>
+  );
+}
+
+function ActivityList({ history, onOpenConsole }: { history: HistoryItem[]; onOpenConsole: () => void }) {
+  return (
+    <section className="activity-list">
+      <div className="panel-title"><span>RECENT RUNS</span><strong>最近执行</strong><button onClick={onOpenConsole}>命令台 <ArrowUpRight size={14} /></button></div>
+      {history.length ? history.slice(0, 5).map(item => (
+        <div className="activity-row" key={item.id}>
+          <span className={item.ok ? "success" : "failure"}>{item.ok ? <Check size={13} /> : <X size={13} />}</span>
+          <span><strong>{item.label}</strong><code>{item.command}</code></span>
+          <time><Clock3 size={12} />{new Date(item.at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</time>
+        </div>
+      )) : <div className="activity-empty"><Activity size={22} /><span>执行记录会保存在本机</span></div>}
+    </section>
+  );
+}
+
+function ResultPanel({
+  execution,
+  text,
+  busy,
+  onCopy,
+  onClose
+}: {
+  execution: LastExecution | null;
+  text: string;
+  busy: boolean;
+  onCopy: () => void;
+  onClose?: () => void;
+}) {
+  const ok = execution?.result.ok;
+  return (
+    <section className="result-panel">
+      <div className="result-title">
+        <span className={execution ? (ok ? "success" : "failure") : "idle"}>{busy ? <LoaderCircle className="spin" size={14} /> : ok ? <Check size={14} /> : execution ? <X size={14} /> : <Code2 size={14} />}</span>
+        <span><small>COMMAND OUTPUT</small><strong>{execution?.label ?? "等待执行"}</strong></span>
+        <button onClick={onCopy} title="复制结果"><Clipboard size={15} /></button>
+        {onClose && <button onClick={onClose} title="关闭"><X size={15} /></button>}
+      </div>
+      {execution && <code className="executed-command">$ officecli {execution.command}</code>}
+      <pre>{text}</pre>
+    </section>
+  );
+}

--- a/plugins/office-suite-workbench/src/App.tsx
+++ b/plugins/office-suite-workbench/src/App.tsx
@@ -996,6 +996,22 @@ function ResultPanel({
         {onClose && <button onClick={onClose} title="关闭"><X size={15} /></button>}
       </div>
       {execution && <code className="executed-command">$ officecli {execution.command}</code>}
+      {execution?.result.ok && Boolean(execution.result.data.previewImages?.length) && (
+        <div className="result-previews" aria-label="视觉预览">
+          {execution.result.data.previewImages?.map(preview => (
+            <figure key={preview.path}>
+              <button
+                type="button"
+                title="用系统默认应用打开图片"
+                onClick={() => void window.ztools?.shellOpenPath?.(preview.path)}
+              >
+                <img src={preview.dataUrl} alt={`OfficeCLI 视觉预览：${basename(preview.path)}`} />
+              </button>
+              <figcaption title={preview.path}>{basename(preview.path)}</figcaption>
+            </figure>
+          ))}
+        </div>
+      )}
       <pre>{text}</pre>
     </section>
   );

--- a/plugins/office-suite-workbench/src/lib/ai.ts
+++ b/plugins/office-suite-workbench/src/lib/ai.ts
@@ -1,0 +1,131 @@
+const OFFICE_AI_OPERATIONS = [
+  "add",
+  "batch",
+  "close",
+  "create",
+  "dump",
+  "get",
+  "help",
+  "load_skill",
+  "move",
+  "query",
+  "raw",
+  "refresh",
+  "remove",
+  "save",
+  "set",
+  "swap",
+  "validate",
+  "view"
+] as const;
+
+const OFFICE_AI_OPERATION_SET = new Set<string>(OFFICE_AI_OPERATIONS);
+const FILELESS_OPERATIONS = new Set(["help", "load_skill"]);
+
+export const OFFICE_AI_TOOL = {
+  type: "function" as const,
+  function: {
+    name: "office_document",
+    description: "Run one safe OfficeCLI operation. For reading use operation=view with args=[\"text\"], args=[\"stats\"], args=[\"issues\",\"--json\"], or operation=get. Never use read as an operation. filePath must be absolute; omit it only to use the currently selected document.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        operation: {
+          type: "string",
+          enum: OFFICE_AI_OPERATIONS,
+          description: "An exact OfficeCLI operation name. Use view, not read."
+        },
+        filePath: {
+          type: "string",
+          description: "Absolute .docx, .xlsx, or .pptx path. Omit to use the selected document."
+        },
+        args: {
+          type: "array",
+          items: { type: "string" },
+          description: "Arguments after the document path. Example for reading text: [\"text\"]."
+        }
+      },
+      required: ["operation"]
+    }
+  }
+};
+
+function normalizedArgs(value: unknown): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some(item => typeof item !== "string")) {
+    throw new Error("office_document args must be an array of strings.");
+  }
+  return value.slice();
+}
+
+function isAbsolutePath(value: string): boolean {
+  return value.startsWith("/") || /^[A-Za-z]:[\\/]/u.test(value) || value.startsWith("\\\\");
+}
+
+function normalizeLegacyCommand(value: unknown, selectedFile: string): string | string[] | null {
+  if (value === undefined) return null;
+  if (Array.isArray(value)) {
+    if (!value.length || value.some(item => typeof item !== "string")) {
+      throw new Error("office_document command must contain strings.");
+    }
+    const argv = value as string[];
+    if (isAbsolutePath(argv[0])) return ["view", argv[0], ...(argv.slice(1).length ? argv.slice(1) : ["text"])];
+    if (argv[0].toLowerCase() === "read") {
+      const filePath = argv[1] && isAbsolutePath(argv[1]) ? argv[1] : selectedFile;
+      if (!filePath) throw new Error("A selected document or absolute filePath is required for read.");
+      return ["view", filePath, ...(argv.slice(filePath === argv[1] ? 2 : 1).length
+        ? argv.slice(filePath === argv[1] ? 2 : 1)
+        : ["text"])];
+    }
+    return argv.slice();
+  }
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error("office_document command must be a non-empty string or argv array.");
+  }
+  const command = value.trim();
+  if (isAbsolutePath(command)) return ["view", command, "text"];
+  if (command.toLowerCase() === "read") {
+    if (!selectedFile) throw new Error("A selected document or absolute filePath is required for read.");
+    return ["view", selectedFile, "text"];
+  }
+  return command;
+}
+
+export function normalizeOfficeAiToolInput(
+  input: Record<string, unknown>,
+  selectedFile = ""
+): string | string[] {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("office_document input must be an object.");
+  }
+
+  const legacy = normalizeLegacyCommand(input.command, selectedFile);
+  if (legacy) return legacy;
+
+  const rawOperation = typeof input.operation === "string" ? input.operation.trim() : "";
+  let operation = rawOperation.toLowerCase();
+  let filePath = typeof input.filePath === "string" ? input.filePath.trim() : "";
+  const args = normalizedArgs(input.args);
+
+  if (isAbsolutePath(rawOperation)) {
+    filePath = rawOperation;
+    operation = "view";
+    if (!args.length) args.push("text");
+  }
+  if (operation === "read") {
+    operation = "view";
+    if (!args.length) args.push("text");
+  }
+  if (!OFFICE_AI_OPERATION_SET.has(operation)) {
+    throw new Error(`Unsupported office_document operation: ${operation || "(empty)"}. Use view to read a document.`);
+  }
+  if (FILELESS_OPERATIONS.has(operation)) return [operation, ...args];
+
+  filePath ||= selectedFile;
+  if (!filePath || !isAbsolutePath(filePath)) {
+    throw new Error(`office_document ${operation} requires an absolute filePath or a selected document.`);
+  }
+  if (operation === "view" && !args.length) args.push("text");
+  return [operation, filePath, ...args];
+}

--- a/plugins/office-suite-workbench/src/lib/commands.ts
+++ b/plugins/office-suite-workbench/src/lib/commands.ts
@@ -1,0 +1,101 @@
+import type { OfficeFormat } from "../types";
+
+export type QuickActionId = "outline" | "text" | "stats" | "issues" | "validate" | "screenshot";
+
+export interface QuickAction {
+  id: QuickActionId;
+  label: string;
+  description: string;
+}
+
+export const QUICK_ACTIONS: QuickAction[] = [
+  { id: "outline", label: "结构速览", description: "读取文档层级与关键节点" },
+  { id: "text", label: "提取正文", description: "抽取可检索的纯文本内容" },
+  { id: "stats", label: "内容统计", description: "查看页数、字数、形状和工作表" },
+  { id: "issues", label: "格式体检", description: "定位溢出、格式和结构问题" },
+  { id: "validate", label: "结构校验", description: "按 OpenXML schema 验证文件" },
+  { id: "screenshot", label: "视觉预览", description: "渲染页面或幻灯片检查布局" }
+];
+
+export const RECIPES: Record<OfficeFormat, Array<{ title: string; command: (path: string) => string[] }>> = {
+  word: [
+    { title: "查找所有一级标题", command: path => ["query", path, "paragraph[style=Heading1]", "--json"] },
+    { title: "检查非 Arial 正文字体", command: path => ["query", path, "paragraph[style=Normal] > run[font!=Arial]", "--json"] },
+    { title: "导出带批注的文本", command: path => ["view", path, "annotated"] }
+  ],
+  excel: [
+    { title: "列出含公式单元格", command: path => ["query", path, "cell:has(formula)", "--json"] },
+    { title: "检查空白单元格", command: path => ["query", path, "cell:empty", "--json"] },
+    { title: "读取首个工作表", command: path => ["get", path, "/sheet[1]", "--depth", "2", "--json"] }
+  ],
+  powerpoint: [
+    { title: "检查缺少替代文本的图片", command: path => ["query", path, "picture:no-alt", "--json"] },
+    { title: "列出所有幻灯片", command: path => ["get", path, "/", "--depth", "1", "--json"] },
+    { title: "生成整套联系表", command: path => ["view", path, "screenshot", "--grid", "auto"] }
+  ]
+};
+
+export function detectFormat(filePath: string): OfficeFormat | null {
+  const extension = filePath.trim().toLowerCase().split(".").pop();
+  if (extension === "docx") return "word";
+  if (extension === "xlsx") return "excel";
+  if (extension === "pptx") return "powerpoint";
+  return null;
+}
+
+export function buildQuickCommand(action: QuickActionId, filePath: string): string[] {
+  switch (action) {
+    case "outline":
+      return ["view", filePath, "outline"];
+    case "text":
+      return ["view", filePath, "text", "--max-lines", "240"];
+    case "stats":
+      return ["view", filePath, "stats", "--json"];
+    case "issues":
+      return ["view", filePath, "issues", "--limit", "100", "--json"];
+    case "validate":
+      return ["validate", filePath, "--json"];
+    case "screenshot":
+      return detectFormat(filePath) === "powerpoint"
+        ? ["view", filePath, "screenshot", "--grid", "auto"]
+        : ["view", filePath, "screenshot", "--page", "1"];
+  }
+}
+
+export function formatCommand(argv: string[]): string {
+  return argv.map(quoteArgument).join(" ");
+}
+
+export function quoteArgument(value: string): string {
+  if (/^[A-Za-z0-9_./:@=,+-]+$/.test(value)) return value;
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+export function basename(filePath: string): string {
+  return filePath.split(/[\\/]/).filter(Boolean).pop() ?? filePath;
+}
+
+export function normalizeFilePayload(payload: unknown): string[] {
+  const collected = new Set<string>();
+
+  const visit = (value: unknown, depth: number) => {
+    if (depth > 4 || value == null) return;
+    if (typeof value === "string") {
+      if (detectFormat(value)) collected.add(value);
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach(item => visit(item, depth + 1));
+      return;
+    }
+    if (typeof value !== "object") return;
+
+    const record = value as Record<string, unknown>;
+    for (const key of ["path", "filePath", "payload", "files", "filePaths"]) {
+      if (key in record) visit(record[key], depth + 1);
+    }
+  };
+
+  visit(payload, 0);
+  return [...collected];
+}

--- a/plugins/office-suite-workbench/src/lib/history.ts
+++ b/plugins/office-suite-workbench/src/lib/history.ts
@@ -1,0 +1,29 @@
+export interface HistoryItem {
+  id: string;
+  label: string;
+  command: string;
+  ok: boolean;
+  at: string;
+}
+
+function isHistoryItem(value: unknown): value is HistoryItem {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const item = value as Record<string, unknown>;
+  return typeof item.id === "string"
+    && typeof item.label === "string"
+    && typeof item.command === "string"
+    && typeof item.ok === "boolean"
+    && typeof item.at === "string"
+    && Number.isFinite(Date.parse(item.at));
+}
+
+export function parseStoredHistory(value: string | null): HistoryItem[] {
+  if (!value) return [];
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isHistoryItem).slice(0, 12);
+  } catch {
+    return [];
+  }
+}

--- a/plugins/office-suite-workbench/src/main.tsx
+++ b/plugins/office-suite-workbench/src/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import App from "./App";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/plugins/office-suite-workbench/src/styles.css
+++ b/plugins/office-suite-workbench/src/styles.css
@@ -1,0 +1,1930 @@
+:root {
+  font-family: "Avenir Next", "Noto Sans SC", "PingFang SC", sans-serif;
+  color: #182022;
+  background: #101719;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  --ink: #182022;
+  --muted: #697274;
+  --paper: #f2eee4;
+  --paper-deep: #e7e1d3;
+  --night: #101719;
+  --night-soft: #192224;
+  --line: rgba(24, 32, 34, 0.16);
+  --acid: #f2d33f;
+  --coral: #ed5a35;
+  --word: #2467d6;
+  --excel: #188555;
+  --powerpoint: #e95c2b;
+  --success: #51bd7a;
+  --danger: #ef6a57;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button {
+  color: inherit;
+}
+
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--acid);
+  outline-offset: 2px;
+}
+
+code,
+pre {
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+}
+
+.app-shell {
+  display: grid;
+  grid-template: 62px minmax(0, 1fr) / 88px minmax(0, 1fr);
+  width: 100%;
+  height: 100%;
+  background: var(--night);
+}
+
+.topbar {
+  position: relative;
+  z-index: 20;
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) auto minmax(220px, 1fr);
+  align-items: center;
+  min-width: 0;
+  padding: 0 18px 0 14px;
+  color: #f8f2e5;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  background:
+    linear-gradient(90deg, rgba(242, 211, 63, 0.06), transparent 28%),
+    var(--night);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  width: max-content;
+  padding: 0;
+  color: inherit;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.brand img {
+  width: 39px;
+  height: 39px;
+  margin-right: 11px;
+  border-radius: 9px;
+}
+
+.brand span {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  line-height: 1.1;
+}
+
+.brand strong {
+  font-size: 12px;
+  letter-spacing: 0.14em;
+}
+
+.brand small {
+  margin-top: 5px;
+  color: #8f9b9c;
+  font-size: 9px;
+  letter-spacing: 0.06em;
+}
+
+.topbar-center {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: #728082;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+}
+
+.topbar-center i {
+  width: 42px;
+  height: 1px;
+  background: #3a4547;
+}
+
+.runtime-status {
+  justify-self: end;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  max-width: 250px;
+  min-height: 33px;
+  padding: 0 11px;
+  color: #b7c1c2;
+  border: 1px solid #354144;
+  border-radius: 2px;
+  background: #172022;
+  cursor: pointer;
+}
+
+.runtime-status span {
+  overflow: hidden;
+  font: 10px "JetBrains Mono", "SFMono-Regular", monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.runtime-status.ready {
+  color: #b8e7c8;
+  border-color: rgba(81, 189, 122, 0.38);
+}
+
+.runtime-status.missing {
+  color: #f0ac9f;
+  border-color: rgba(239, 106, 87, 0.4);
+}
+
+.sidebar {
+  position: relative;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 0;
+  color: #d8dfdf;
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  background: #121a1c;
+}
+
+.sidebar::after {
+  position: absolute;
+  top: 0;
+  right: -1px;
+  width: 1px;
+  height: 90px;
+  background: var(--acid);
+  content: "";
+}
+
+.sidebar nav {
+  display: flex;
+  flex-direction: column;
+  padding: 14px 8px;
+  gap: 4px;
+}
+
+.sidebar nav button {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 58px;
+  gap: 6px;
+  padding: 0;
+  color: #778486;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  cursor: pointer;
+  transition: color 160ms ease, background 160ms ease, transform 160ms ease;
+}
+
+.sidebar nav button span {
+  font-size: 9px;
+  letter-spacing: 0.04em;
+}
+
+.sidebar nav button:hover {
+  color: #e8eded;
+  background: rgba(255, 255, 255, 0.05);
+  transform: translateX(2px);
+}
+
+.sidebar nav button.active {
+  color: #101719;
+  background: var(--acid);
+}
+
+.sidebar nav button.active::before {
+  position: absolute;
+  left: -8px;
+  width: 3px;
+  height: 32px;
+  background: var(--acid);
+  content: "";
+}
+
+.sidebar-footer {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  margin: 10px;
+  padding: 12px 4px;
+  border-top: 1px solid #344043;
+}
+
+.sidebar-footer > span {
+  color: var(--acid);
+  font: 27px/1 "Iowan Old Style", "Songti SC", serif;
+}
+
+.sidebar-footer small {
+  color: #667375;
+  font-size: 7px;
+  font-weight: 700;
+  line-height: 1.3;
+  letter-spacing: 0.1em;
+}
+
+.main-canvas {
+  position: relative;
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  background:
+    linear-gradient(rgba(24, 32, 34, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(24, 32, 34, 0.035) 1px, transparent 1px),
+    var(--paper);
+  background-size: 26px 26px;
+}
+
+.view-stack {
+  width: min(1400px, 100%);
+  min-height: 100%;
+  margin: 0 auto;
+  padding: 28px clamp(24px, 4vw, 58px) 54px;
+}
+
+.section-index {
+  color: #727b7c;
+  font: 700 9px/1.4 "JetBrains Mono", "SFMono-Regular", monospace;
+  letter-spacing: 0.16em;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  gap: 8px;
+  padding: 0 17px;
+  border: 1px solid transparent;
+  border-radius: 3px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-2px);
+}
+
+.button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.button.primary {
+  color: #11191b;
+  background: var(--acid);
+  box-shadow: 4px 4px 0 #182022;
+}
+
+.button.primary:hover:not(:disabled) {
+  box-shadow: 6px 6px 0 #182022;
+}
+
+.button.ghost {
+  color: var(--ink);
+  border-color: rgba(24, 32, 34, 0.34);
+  background: transparent;
+}
+
+.hero-panel {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+  min-height: 300px;
+  overflow: hidden;
+  color: #f2eee4;
+  border: 1px solid #263234;
+  background:
+    radial-gradient(circle at 70% 15%, rgba(242, 211, 63, 0.1), transparent 27%),
+    #152022;
+  box-shadow: 12px 12px 0 rgba(24, 32, 34, 0.12);
+}
+
+.hero-panel::after {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 5px;
+  background: linear-gradient(90deg, var(--word) 0 33.33%, var(--excel) 33.33% 66.66%, var(--powerpoint) 66.66%);
+  content: "";
+}
+
+.hero-copy {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 42px clamp(34px, 5vw, 74px);
+}
+
+.hero-copy .section-index {
+  color: #849193;
+}
+
+.hero-copy h1 {
+  max-width: 720px;
+  margin: 16px 0 13px;
+  font: 500 clamp(38px, 5vw, 68px)/0.98 "Iowan Old Style", "Songti SC", serif;
+  letter-spacing: -0.045em;
+}
+
+.hero-copy h1 em {
+  color: var(--acid);
+  font-style: italic;
+}
+
+.hero-copy p {
+  max-width: 620px;
+  margin: 0;
+  color: #aeb9ba;
+  font-size: 13px;
+  line-height: 1.75;
+}
+
+.hero-actions {
+  display: flex;
+  margin-top: 26px;
+  gap: 12px;
+}
+
+.hero-actions .button.ghost {
+  color: #dbe2e1;
+  border-color: #435052;
+}
+
+.hero-diagram {
+  position: relative;
+  min-height: 300px;
+  overflow: hidden;
+  border-left: 1px solid #334143;
+  background:
+    repeating-linear-gradient(0deg, transparent 0 25px, rgba(255, 255, 255, 0.045) 25px 26px),
+    repeating-linear-gradient(90deg, transparent 0 25px, rgba(255, 255, 255, 0.045) 25px 26px);
+}
+
+.diagram-core,
+.diagram-orbit {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}
+
+.diagram-core {
+  top: 50%;
+  left: 50%;
+  flex-direction: column;
+  width: 94px;
+  height: 94px;
+  color: #11191b;
+  background: var(--acid);
+  box-shadow: 0 0 0 14px rgba(242, 211, 63, 0.08), 0 0 0 38px rgba(242, 211, 63, 0.04);
+  transform: translate(-50%, -50%);
+}
+
+.diagram-core span {
+  margin-top: 4px;
+  font: 800 9px "JetBrains Mono", monospace;
+  letter-spacing: 0.14em;
+}
+
+.diagram-orbit {
+  width: 45px;
+  height: 45px;
+  color: white;
+  font: 700 16px "Iowan Old Style", serif;
+  box-shadow: 0 7px 18px rgba(0, 0, 0, 0.25);
+  animation: orbit-float 5s ease-in-out infinite;
+}
+
+.orbit-word {
+  top: 21%;
+  left: 18%;
+  background: var(--word);
+}
+
+.orbit-excel {
+  right: 18%;
+  bottom: 18%;
+  background: var(--excel);
+  animation-delay: -1.7s;
+}
+
+.orbit-powerpoint {
+  top: 17%;
+  right: 18%;
+  background: var(--powerpoint);
+  animation-delay: -3.2s;
+}
+
+.diagram-caption {
+  position: absolute;
+  right: 16px;
+  bottom: 17px;
+  color: #657375;
+  font: 700 8px "JetBrains Mono", monospace;
+  letter-spacing: 0.1em;
+}
+
+@keyframes orbit-float {
+  0%, 100% { transform: translateY(0) rotate(-2deg); }
+  50% { transform: translateY(-8px) rotate(3deg); }
+}
+
+.dependency-notice {
+  display: grid;
+  grid-template-columns: auto minmax(230px, 1fr) minmax(240px, auto) auto;
+  align-items: center;
+  gap: 16px;
+  margin-top: 22px;
+  padding: 15px 18px;
+  color: #411f17;
+  border: 1px solid rgba(146, 56, 32, 0.32);
+  background: #f2c3ad;
+}
+
+.dependency-notice > div {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.dependency-notice strong {
+  font-size: 12px;
+}
+
+.dependency-notice span {
+  color: #724638;
+  font-size: 10px;
+}
+
+.dependency-notice code {
+  overflow: hidden;
+  padding: 8px 11px;
+  color: #f3ebe1;
+  background: #45251e;
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dependency-notice button {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  font-size: 11px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.format-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.format-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto auto 1fr auto;
+  min-height: 240px;
+  overflow: hidden;
+  padding: 25px;
+  text-align: left;
+  border: 1px solid var(--line);
+  background: rgba(255, 253, 248, 0.62);
+  cursor: pointer;
+  transition: color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
+}
+
+.format-card::before {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 6px;
+  height: 100%;
+  background: var(--format-color);
+  content: "";
+  transition: width 180ms ease;
+}
+
+.format-card.word { --format-color: var(--word); }
+.format-card.excel { --format-color: var(--excel); }
+.format-card.powerpoint { --format-color: var(--powerpoint); }
+
+.format-card:hover {
+  color: white;
+  background: var(--format-color);
+  box-shadow: 9px 9px 0 rgba(24, 32, 34, 0.16);
+  transform: translate(-3px, -3px);
+}
+
+.format-card:hover::before {
+  width: 100%;
+  opacity: 0.18;
+}
+
+.format-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.format-number {
+  justify-self: end;
+  grid-column: 2;
+  color: var(--format-color);
+  font: 600 28px "Iowan Old Style", serif;
+}
+
+.format-card:hover .format-number,
+.format-card:hover .format-eyebrow,
+.format-card:hover > span,
+.format-card:hover .format-footer {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.format-card > svg {
+  grid-column: 1;
+  grid-row: 1 / 3;
+  color: var(--format-color);
+}
+
+.format-card:hover > svg {
+  color: white;
+}
+
+.format-eyebrow {
+  grid-column: 1 / -1;
+  margin-top: 35px;
+  color: var(--format-color);
+  font: 700 8px "JetBrains Mono", monospace;
+  letter-spacing: 0.14em;
+}
+
+.format-card strong {
+  grid-column: 1 / -1;
+  margin: 7px 0 8px;
+  font: 500 32px "Iowan Old Style", "Songti SC", serif;
+  letter-spacing: -0.025em;
+}
+
+.format-card > span:not(.format-number, .format-eyebrow, .format-footer) {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.6;
+}
+
+.format-footer {
+  display: flex;
+  grid-column: 1 / -1;
+  align-items: center;
+  justify-content: space-between;
+  align-self: end;
+  margin-top: 20px;
+  padding-top: 12px;
+  color: #555f61;
+  border-top: 1px solid currentColor;
+  font: 700 9px "JetBrains Mono", monospace;
+  text-transform: uppercase;
+}
+
+.home-bottom {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(340px, 0.85fr);
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.document-queue,
+.activity-list,
+.operation-panel,
+.recipe-panel,
+.examples-panel,
+.result-panel,
+.config-panel,
+.registration-panel {
+  min-width: 0;
+  border: 1px solid var(--line);
+  background: rgba(255, 253, 248, 0.76);
+}
+
+.panel-title {
+  display: flex;
+  align-items: center;
+  min-height: 58px;
+  gap: 10px;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.panel-title > span {
+  color: #788183;
+  font: 700 8px "JetBrains Mono", monospace;
+  letter-spacing: 0.13em;
+}
+
+.panel-title > strong {
+  margin-right: auto;
+  font: 500 17px "Iowan Old Style", "Songti SC", serif;
+}
+
+.panel-title > button {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0;
+  color: #596365;
+  border: 0;
+  background: none;
+  font-size: 10px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.queue-list {
+  padding: 4px 14px 14px;
+}
+
+.queue-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  width: 100%;
+  min-height: 58px;
+  border-bottom: 1px solid rgba(24, 32, 34, 0.1);
+  background: transparent;
+}
+
+.queue-row:hover,
+.queue-row.selected {
+  background: rgba(24, 32, 34, 0.045);
+}
+
+.queue-select {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  min-width: 0;
+  min-height: 57px;
+  gap: 10px;
+  padding: 7px 4px;
+  text-align: left;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+}
+
+.queue-icon {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  color: white;
+}
+
+.queue-icon.word { background: var(--word); }
+.queue-icon.excel { background: var(--excel); }
+.queue-icon.powerpoint { background: var(--powerpoint); }
+
+.queue-select > span:nth-child(2) {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.queue-list strong {
+  overflow: hidden;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queue-list small {
+  overflow: hidden;
+  color: #899092;
+  font: 8px "JetBrains Mono", monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.queue-list i {
+  color: #7d8687;
+  font: normal 8px "JetBrains Mono", monospace;
+}
+
+.remove-file {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  margin-right: 4px;
+  color: #8a9293;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  cursor: pointer;
+}
+
+.remove-file:hover {
+  color: white;
+  background: var(--danger);
+}
+
+.queue-empty,
+.activity-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 142px;
+  gap: 12px;
+  color: #747e7f;
+  border: 0;
+  background: transparent;
+}
+
+.queue-empty {
+  width: 100%;
+  cursor: pointer;
+}
+
+.queue-empty > span {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+}
+
+.queue-empty strong {
+  color: var(--ink);
+  font-size: 11px;
+}
+
+.queue-empty small,
+.activity-empty span {
+  font-size: 9px;
+}
+
+.activity-list {
+  padding-bottom: 10px;
+}
+
+.activity-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 50px;
+  gap: 9px;
+  margin: 0 14px;
+  border-bottom: 1px solid rgba(24, 32, 34, 0.1);
+}
+
+.activity-row > span:first-child,
+.result-title > span:first-child {
+  display: grid;
+  place-items: center;
+  width: 23px;
+  height: 23px;
+  color: white;
+  border-radius: 50%;
+}
+
+.activity-row .success,
+.result-title .success { background: var(--excel); }
+.activity-row .failure,
+.result-title .failure { background: var(--danger); }
+.result-title .idle { background: #6f797b; }
+
+.activity-row > span:nth-child(2) {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.activity-row strong {
+  font-size: 10px;
+}
+
+.activity-row code {
+  overflow: hidden;
+  color: #7f898a;
+  font-size: 8px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-row time {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  color: #8c9495;
+  font: 8px "JetBrains Mono", monospace;
+}
+
+.workbench-view {
+  --theme-color: var(--word);
+}
+
+.workbench-view.theme-excel { --theme-color: var(--excel); }
+.workbench-view.theme-powerpoint { --theme-color: var(--powerpoint); }
+
+.workbench-heading {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 135px;
+  gap: 20px;
+  padding: 24px 30px;
+  color: white;
+  background: var(--theme-color);
+  box-shadow: 10px 10px 0 rgba(24, 32, 34, 0.12);
+}
+
+.heading-icon {
+  display: grid;
+  place-items: center;
+  width: 64px;
+  height: 64px;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.workbench-heading .section-index {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.workbench-heading h1 {
+  margin: 6px 0 3px;
+  font: 500 35px "Iowan Old Style", "Songti SC", serif;
+}
+
+.workbench-heading p {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 11px;
+}
+
+.format-action {
+  color: var(--theme-color);
+  background: white;
+}
+
+.file-stage {
+  margin-top: 24px;
+  padding: 17px 19px 19px;
+  border: 1px solid var(--line);
+  background: rgba(255, 253, 248, 0.76);
+}
+
+.stage-label {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 11px;
+  color: #7a8384;
+  font: 700 8px "JetBrains Mono", monospace;
+  letter-spacing: 0.13em;
+}
+
+.active-file {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) minmax(150px, 220px) auto;
+  align-items: center;
+  min-height: 66px;
+  gap: 12px;
+  padding: 10px 12px;
+  color: white;
+  background: #172022;
+}
+
+.file-mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  color: white;
+  background: var(--theme-color);
+}
+
+.file-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.file-copy strong {
+  overflow: hidden;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-copy span {
+  overflow: hidden;
+  color: #859294;
+  font: 8px "JetBrains Mono", monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.active-file select {
+  min-width: 0;
+  height: 34px;
+  padding: 0 9px;
+  color: #d9e0e0;
+  border: 1px solid #3d494b;
+  border-radius: 2px;
+  background: #202a2c;
+  font-size: 9px;
+}
+
+.icon-button {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  color: #d6dddd;
+  border: 1px solid #3d494b;
+  background: transparent;
+  cursor: pointer;
+}
+
+.empty-file {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 102px;
+  gap: 4px;
+  color: #6d7778;
+  border: 1px dashed rgba(24, 32, 34, 0.3);
+  background: rgba(24, 32, 34, 0.025);
+  cursor: pointer;
+}
+
+.empty-file strong {
+  margin-top: 5px;
+  color: var(--ink);
+  font-size: 11px;
+}
+
+.empty-file span {
+  font-size: 9px;
+}
+
+.workbench-columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(310px, 0.85fr);
+  gap: 16px;
+  margin-top: 18px;
+}
+
+.operation-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding: 12px;
+  gap: 8px;
+}
+
+.operation-grid button {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-rows: auto auto;
+  min-height: 89px;
+  gap: 4px 10px;
+  padding: 16px;
+  text-align: left;
+  border: 1px solid rgba(24, 32, 34, 0.13);
+  background: #f6f2e9;
+  cursor: pointer;
+  transition: border-color 160ms ease, transform 160ms ease, background 160ms ease;
+}
+
+.operation-grid button:hover:not(:disabled) {
+  border-color: var(--theme-color);
+  background: white;
+  transform: translateY(-2px);
+}
+
+.operation-grid button:disabled,
+.recipe-list button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.operation-grid button > svg:first-child {
+  grid-row: 1 / -1;
+  color: var(--theme-color);
+}
+
+.operation-grid strong {
+  font-size: 11px;
+}
+
+.operation-grid span {
+  grid-column: 2 / 4;
+  color: #7d8586;
+  font-size: 9px;
+  line-height: 1.4;
+}
+
+.operation-arrow {
+  color: #969d9e;
+}
+
+.recipe-list {
+  padding: 10px 15px 16px;
+}
+
+.recipe-list button {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  width: 100%;
+  min-height: 76px;
+  gap: 10px;
+  padding: 11px 3px;
+  text-align: left;
+  border: 0;
+  border-bottom: 1px solid rgba(24, 32, 34, 0.11);
+  background: transparent;
+  cursor: pointer;
+}
+
+.recipe-list button:hover:not(:disabled) {
+  color: var(--theme-color);
+}
+
+.recipe-index {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  color: white;
+  background: var(--theme-color);
+  font: 700 8px "JetBrains Mono", monospace;
+}
+
+.recipe-list button > span:nth-child(2) {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.recipe-list strong {
+  color: var(--ink);
+  font-size: 10px;
+}
+
+.recipe-list code {
+  overflow: hidden;
+  color: #849092;
+  font-size: 7.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.console-heading,
+.mcp-hero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 8px 4px 25px;
+  border-bottom: 1px solid rgba(24, 32, 34, 0.24);
+}
+
+.console-heading h1,
+.mcp-hero h1 {
+  margin: 8px 0 4px;
+  font: 500 clamp(34px, 4vw, 52px) "Iowan Old Style", "Songti SC", serif;
+  letter-spacing: -0.035em;
+}
+
+.console-heading p,
+.mcp-hero p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.console-heading > svg {
+  color: var(--excel);
+}
+
+.terminal-shell {
+  overflow: hidden;
+  margin-top: 23px;
+  color: #e7eeed;
+  border: 1px solid #344143;
+  background: #11191b;
+  box-shadow: 10px 10px 0 rgba(24, 32, 34, 0.13);
+}
+
+.terminal-bar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 14px;
+  color: #728083;
+  border-bottom: 1px solid #303d3f;
+  background: #182224;
+  font: 8px "JetBrains Mono", monospace;
+  letter-spacing: 0.07em;
+}
+
+.terminal-bar > span:first-child {
+  display: flex;
+  gap: 6px;
+}
+
+.terminal-bar > span:last-child {
+  justify-self: end;
+}
+
+.terminal-dot {
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.terminal-dot.red { background: #ef6a57; }
+.terminal-dot.amber { background: #e5b84c; }
+.terminal-dot.green { background: #51bd7a; }
+
+.command-editor {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 12px;
+  min-height: 132px;
+  padding: 23px;
+}
+
+.prompt-mark {
+  color: var(--acid);
+  font: 700 24px/1 "JetBrains Mono", monospace;
+}
+
+.command-editor textarea {
+  width: 100%;
+  min-height: 88px;
+  resize: vertical;
+  color: #e8efee;
+  border: 0;
+  background: transparent;
+  font: 13px/1.7 "JetBrains Mono", "SFMono-Regular", monospace;
+}
+
+.run-command {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 84px;
+  height: 38px;
+  gap: 8px;
+  color: #121a1c;
+  border: 0;
+  background: var(--acid);
+  font: 800 9px "JetBrains Mono", monospace;
+  cursor: pointer;
+}
+
+.run-command:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.command-hint {
+  padding: 10px 23px;
+  color: #657375;
+  border-top: 1px solid #283537;
+  background: #141d1f;
+  font: 8px "JetBrains Mono", monospace;
+}
+
+.console-grid {
+  display: grid;
+  grid-template-columns: minmax(290px, 0.72fr) minmax(0, 1.28fr);
+  gap: 16px;
+  margin-top: 22px;
+}
+
+.examples-panel > button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: calc(100% - 28px);
+  min-height: 45px;
+  margin: 0 14px;
+  padding: 0 5px;
+  color: #566163;
+  border: 0;
+  border-bottom: 1px solid rgba(24, 32, 34, 0.1);
+  background: transparent;
+  cursor: pointer;
+}
+
+.examples-panel > button:hover {
+  color: var(--ink);
+  transform: translateX(3px);
+}
+
+.examples-panel code {
+  overflow: hidden;
+  font-size: 8px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.result-panel {
+  display: flex;
+  min-height: 280px;
+  flex-direction: column;
+  overflow: hidden;
+  color: #dfe7e6;
+  border-color: #293638;
+  background: #121a1c;
+}
+
+.result-title {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  min-height: 58px;
+  gap: 9px;
+  padding: 0 14px;
+  border-bottom: 1px solid #2a3739;
+}
+
+.result-title > span:nth-child(2) {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.result-title small {
+  color: #627174;
+  font: 7px "JetBrains Mono", monospace;
+  letter-spacing: 0.12em;
+}
+
+.result-title strong {
+  font-size: 10px;
+}
+
+.result-title button {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  color: #819092;
+  border: 1px solid #354244;
+  background: transparent;
+  cursor: pointer;
+}
+
+.executed-command {
+  display: block;
+  overflow: hidden;
+  padding: 11px 16px;
+  color: #91a09f;
+  border-bottom: 1px solid #263335;
+  background: #172123;
+  font-size: 8px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.result-panel pre {
+  flex: 1;
+  max-height: 340px;
+  margin: 0;
+  overflow: auto;
+  padding: 18px;
+  color: #b8c5c4;
+  font-size: 9px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.result-drawer {
+  position: fixed;
+  z-index: 35;
+  right: 20px;
+  bottom: 20px;
+  width: min(560px, calc(100vw - 128px));
+  max-height: min(430px, calc(100vh - 110px));
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.36);
+  animation: drawer-in 220ms ease both;
+}
+
+.result-drawer .result-panel {
+  min-height: 250px;
+  max-height: inherit;
+}
+
+@keyframes drawer-in {
+  from { opacity: 0; transform: translateY(18px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.mcp-hero {
+  align-items: center;
+}
+
+.mcp-hero p code {
+  color: #243435;
+  font-size: 10px;
+}
+
+.mcp-signal {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 180px;
+  padding: 20px;
+  color: #748082;
+  border: 1px solid rgba(24, 32, 34, 0.18);
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.signal-ring {
+  display: grid;
+  place-items: center;
+  width: 58px;
+  height: 58px;
+  margin-bottom: 9px;
+  color: #586466;
+  border: 1px solid #929b9c;
+  border-radius: 50%;
+  box-shadow: 0 0 0 7px rgba(24, 32, 34, 0.045), 0 0 0 14px rgba(24, 32, 34, 0.025);
+}
+
+.mcp-signal.online .signal-ring {
+  color: white;
+  border-color: var(--excel);
+  background: var(--excel);
+  box-shadow: 0 0 0 7px rgba(24, 133, 85, 0.14), 0 0 0 14px rgba(24, 133, 85, 0.06);
+}
+
+.mcp-signal strong {
+  margin-top: 7px;
+  color: var(--ink);
+  font: 800 8px "JetBrains Mono", monospace;
+  letter-spacing: 0.11em;
+}
+
+.mcp-signal small {
+  margin-top: 4px;
+  font: 8px "JetBrains Mono", monospace;
+}
+
+.probe-strip {
+  display: grid;
+  grid-template-columns: minmax(220px, auto) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 18px;
+  margin-top: 22px;
+  padding: 14px 16px;
+  color: white;
+  background: #172123;
+}
+
+.probe-strip > div:first-child {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.probe-strip > div:first-child > span {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.probe-strip strong {
+  font-size: 10px;
+}
+
+.probe-strip small {
+  color: #748285;
+  font: 8px "JetBrains Mono", monospace;
+}
+
+.probe-detail {
+  display: flex;
+  min-width: 0;
+  gap: 16px;
+  color: #93a09f;
+  font: 8px "JetBrains Mono", monospace;
+}
+
+.probe-detail span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.error-text { color: #f19c8f !important; }
+
+.mcp-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(330px, 0.85fr);
+  gap: 16px;
+  margin-top: 18px;
+}
+
+.client-tabs {
+  display: flex;
+  overflow: auto;
+  padding: 12px 14px 0;
+  gap: 4px;
+}
+
+.transport-switch {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+  padding: 12px 14px 0;
+}
+
+.transport-switch > button {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  min-height: 52px;
+  gap: 8px;
+  padding: 8px 10px;
+  text-align: left;
+  color: #737e7f;
+  border: 1px solid rgba(24, 32, 34, 0.16);
+  background: rgba(24, 32, 34, 0.025);
+  cursor: pointer;
+}
+
+.transport-switch > button.active {
+  color: white;
+  border-color: #172123;
+  background: #172123;
+}
+
+.transport-switch button > span {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.transport-switch strong {
+  font-size: 9px;
+}
+
+.transport-switch small {
+  color: #839092;
+  font-size: 7.5px;
+}
+
+.client-tabs button {
+  flex: 0 0 auto;
+  min-height: 29px;
+  padding: 0 10px;
+  color: #758082;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  font-size: 9px;
+  cursor: pointer;
+}
+
+.client-tabs button.active {
+  color: var(--ink);
+  border-bottom-color: var(--acid);
+  font-weight: 800;
+}
+
+.config-code {
+  margin: 10px 14px;
+  color: #b9c5c4;
+  background: #11191b;
+}
+
+.config-code > div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 37px;
+  padding: 0 12px;
+  color: #6d7b7d;
+  border-bottom: 1px solid #2d393b;
+  font: 8px "JetBrains Mono", monospace;
+  letter-spacing: 0.08em;
+}
+
+.config-code button {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  color: #9faaaa;
+  border: 0;
+  background: transparent;
+  font: 8px "JetBrains Mono", monospace;
+  cursor: pointer;
+}
+
+.config-code pre {
+  min-height: 220px;
+  max-height: 330px;
+  margin: 0;
+  overflow: auto;
+  padding: 17px;
+  font-size: 9px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.config-note {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 12px 16px 17px;
+  color: #747f80;
+  font-size: 8px;
+}
+
+.client-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  min-height: 66px;
+  gap: 9px;
+  margin: 0 14px;
+  border-bottom: 1px solid rgba(24, 32, 34, 0.1);
+}
+
+.gateway-steps {
+  margin: 0;
+  padding: 4px 14px 0;
+  list-style: none;
+}
+
+.gateway-steps li {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  min-height: 70px;
+  gap: 12px;
+  border-bottom: 1px solid rgba(24, 32, 34, 0.1);
+}
+
+.gateway-steps li > span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  color: var(--ink);
+  background: var(--acid);
+  font: 800 8px "JetBrains Mono", monospace;
+}
+
+.gateway-steps li > div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.gateway-steps strong {
+  font-size: 10px;
+}
+
+.gateway-steps small {
+  color: #7c8687;
+  font-size: 8px;
+  line-height: 1.45;
+}
+
+.gateway-steps code {
+  font-size: 7px;
+}
+
+.client-monogram {
+  display: grid;
+  place-items: center;
+  width: 31px;
+  height: 31px;
+  color: white;
+  background: var(--ink);
+  font: 700 8px "JetBrains Mono", monospace;
+}
+
+.client-row > span:nth-child(2) {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.client-row strong {
+  font-size: 10px;
+}
+
+.client-row small {
+  color: #8a9394;
+  font-size: 8px;
+}
+
+.client-row button {
+  min-height: 28px;
+  padding: 0 8px;
+  color: white;
+  border: 1px solid var(--ink);
+  background: var(--ink);
+  font-size: 8px;
+  cursor: pointer;
+}
+
+.client-row button.subtle {
+  color: #727d7e;
+  border-color: rgba(24, 32, 34, 0.2);
+  background: transparent;
+}
+
+.client-row button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.registration-state {
+  margin: 14px;
+  padding: 11px;
+  color: #a7b3b2;
+  background: #162022;
+}
+
+.registration-state > span {
+  color: #728082;
+  font: 700 7px "JetBrains Mono", monospace;
+  letter-spacing: 0.11em;
+}
+
+.registration-state pre {
+  max-height: 110px;
+  margin: 7px 0 0;
+  overflow: auto;
+  font-size: 7.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.settings-modal::backdrop {
+  background: rgba(6, 10, 11, 0.72);
+  backdrop-filter: blur(8px);
+}
+
+.settings-modal {
+  position: relative;
+  width: min(540px, calc(100% - 48px));
+  max-height: calc(100% - 48px);
+  margin: auto;
+  padding: 32px;
+  overflow: auto;
+  color: var(--ink);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  background:
+    linear-gradient(rgba(24, 32, 34, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(24, 32, 34, 0.04) 1px, transparent 1px),
+    var(--paper);
+  background-size: 20px 20px;
+  box-shadow: 14px 14px 0 var(--acid);
+  animation: modal-in 180ms ease both;
+}
+
+@keyframes modal-in {
+  from { opacity: 0; transform: scale(0.96) translateY(8px); }
+  to { opacity: 1; transform: scale(1) translateY(0); }
+}
+
+.modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  display: grid;
+  place-items: center;
+  width: 31px;
+  height: 31px;
+  border: 1px solid var(--line);
+  background: transparent;
+  cursor: pointer;
+}
+
+.settings-modal h2 {
+  margin: 8px 0;
+  font: 500 31px "Iowan Old Style", "Songti SC", serif;
+}
+
+.settings-modal > p {
+  margin: 0 0 22px;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.65;
+}
+
+.runtime-readout {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  margin-top: 15px;
+  padding: 12px;
+  color: #dce6e4;
+  background: var(--night-soft);
+}
+
+.runtime-readout > span {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  color: var(--night);
+  background: var(--acid);
+}
+
+.runtime-readout > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.runtime-readout strong {
+  font-size: 10px;
+}
+
+.runtime-readout small {
+  overflow: hidden;
+  color: #839092;
+  font: 8px "JetBrains Mono", monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 24px;
+}
+
+.busy-pill,
+.toast {
+  position: fixed;
+  z-index: 110;
+  right: 22px;
+  bottom: 21px;
+  display: flex;
+  align-items: center;
+  min-height: 38px;
+  gap: 8px;
+  padding: 0 14px;
+  color: white;
+  background: #172123;
+  box-shadow: 5px 5px 0 var(--acid);
+  font-size: 10px;
+}
+
+.toast {
+  color: #132019;
+  background: #9ed7b3;
+  box-shadow: 5px 5px 0 #193724;
+  animation: toast-in 180ms ease both;
+}
+
+@keyframes toast-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.spin {
+  animation: spin 900ms linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.reveal {
+  animation: reveal 420ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.delay-1 { animation-delay: 70ms; }
+.delay-2 { animation-delay: 140ms; }
+
+@keyframes reveal {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 1050px) {
+  .topbar-center { display: none; }
+  .topbar { grid-template-columns: 1fr auto; }
+  .hero-panel { grid-template-columns: 1fr 280px; }
+  .format-grid { grid-template-columns: 1fr; }
+  .format-card { min-height: 190px; }
+  .home-bottom,
+  .workbench-columns,
+  .mcp-grid { grid-template-columns: 1fr; }
+  .console-grid { grid-template-columns: minmax(250px, 0.65fr) minmax(0, 1.35fr); }
+}
+
+@media (max-width: 760px) {
+  .app-shell { grid-template: 58px minmax(0, 1fr) / 62px minmax(0, 1fr); }
+  .topbar { padding-inline: 10px; }
+  .brand img { width: 34px; height: 34px; }
+  .brand strong { font-size: 10px; }
+  .brand small { display: none; }
+  .runtime-status span { display: none; }
+  .sidebar nav { padding-inline: 5px; }
+  .sidebar nav button { height: 51px; }
+  .sidebar nav button span { display: none; }
+  .sidebar-footer { display: none; }
+  .view-stack { padding: 20px 16px 40px; }
+  .hero-panel { grid-template-columns: 1fr; }
+  .hero-copy { padding: 34px 28px; }
+  .hero-diagram { display: none; }
+  .dependency-notice { grid-template-columns: auto 1fr; }
+  .dependency-notice code { grid-column: 1 / -1; }
+  .dependency-notice button { justify-self: end; }
+  .workbench-heading { grid-template-columns: auto 1fr; }
+  .workbench-heading .format-action { grid-column: 1 / -1; }
+  .active-file { grid-template-columns: auto minmax(0, 1fr) auto; }
+  .active-file select { grid-column: 1 / -1; grid-row: 2; }
+  .operation-grid { grid-template-columns: 1fr; }
+  .console-grid { grid-template-columns: 1fr; }
+  .probe-strip { grid-template-columns: 1fr; }
+  .mcp-hero { align-items: flex-start; gap: 20px; }
+  .mcp-signal { min-width: 150px; }
+  .result-drawer { right: 12px; bottom: 12px; width: calc(100vw - 86px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}

--- a/plugins/office-suite-workbench/src/styles.css
+++ b/plugins/office-suite-workbench/src/styles.css
@@ -1349,8 +1349,54 @@ pre {
   white-space: nowrap;
 }
 
+.result-previews {
+  display: grid;
+  max-height: 280px;
+  overflow: auto;
+  padding: 14px;
+  border-bottom: 1px solid #263335;
+  background:
+    linear-gradient(45deg, rgba(255, 255, 255, 0.025) 25%, transparent 25%) 0 0 / 16px 16px,
+    linear-gradient(-45deg, rgba(255, 255, 255, 0.025) 25%, transparent 25%) 0 0 / 16px 16px,
+    #0d1416;
+}
+
+.result-previews figure {
+  min-width: 0;
+  margin: 0;
+}
+
+.result-previews button {
+  display: grid;
+  width: 100%;
+  min-height: 120px;
+  place-items: center;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid #354244;
+  background: #f5f3ed;
+  cursor: zoom-in;
+}
+
+.result-previews img {
+  display: block;
+  max-width: 100%;
+  max-height: 230px;
+  object-fit: contain;
+}
+
+.result-previews figcaption {
+  overflow: hidden;
+  margin-top: 8px;
+  color: #91a09f;
+  font: 8px "JetBrains Mono", monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .result-panel pre {
   flex: 1;
+  min-height: 72px;
   max-height: 340px;
   margin: 0;
   overflow: auto;

--- a/plugins/office-suite-workbench/src/styles.css
+++ b/plugins/office-suite-workbench/src/styles.css
@@ -1429,6 +1429,417 @@ pre {
   to { opacity: 1; transform: translateY(0); }
 }
 
+.ai-view {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+}
+
+.ai-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 360px);
+  align-items: end;
+  gap: 28px;
+  padding: 26px 30px;
+  color: #f4efe2;
+  background:
+    radial-gradient(circle at 78% 24%, rgba(242, 211, 63, 0.2), transparent 28%),
+    #172123;
+}
+
+.ai-hero h1 {
+  margin: 10px 0 7px;
+  font: 42px/1.04 "Iowan Old Style", "Songti SC", serif;
+  letter-spacing: -0.035em;
+}
+
+.ai-hero p {
+  max-width: 660px;
+  margin: 0;
+  color: #9eabaa;
+  font-size: 11px;
+  line-height: 1.7;
+}
+
+.ai-model-picker {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 7px 12px;
+  padding: 13px 14px;
+  border: 1px solid #3a4749;
+  background: rgba(8, 14, 16, 0.54);
+}
+
+.ai-model-picker > span {
+  color: #788688;
+  font: 8px "JetBrains Mono", monospace;
+  letter-spacing: 0.1em;
+}
+
+.ai-model-picker select {
+  min-width: 0;
+  height: 34px;
+  padding: 0 28px 0 10px;
+  color: #f2eee4;
+  border: 1px solid #465456;
+  background: #11191b;
+  font-size: 10px;
+}
+
+.ai-model-picker small {
+  grid-column: 1 / -1;
+  overflow: hidden;
+  color: #758284;
+  font-size: 8px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ai-workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(290px, 0.5fr);
+  min-height: 560px;
+  flex: 1;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.ai-chat-panel,
+.ai-context-panel {
+  min-width: 0;
+  border: 1px solid rgba(24, 32, 34, 0.17);
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.ai-chat-panel {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.ai-chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 49px;
+  padding: 0 15px;
+  border-bottom: 1px solid rgba(24, 32, 34, 0.13);
+}
+
+.ai-chat-header > span {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 10px;
+}
+
+.ai-chat-header button {
+  color: #758082;
+  border: 0;
+  background: transparent;
+  font-size: 9px;
+  cursor: pointer;
+}
+
+.ai-chat-header button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.ai-transcript {
+  min-height: 300px;
+  flex: 1;
+  overflow: auto;
+  padding: 18px;
+}
+
+.ai-empty-state {
+  display: flex;
+  min-height: 280px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.ai-empty-state > span {
+  display: grid;
+  place-items: center;
+  width: 58px;
+  height: 58px;
+  margin-bottom: 15px;
+  color: #172123;
+  background: var(--acid);
+  box-shadow: 6px 6px 0 #172123;
+}
+
+.ai-empty-state strong { font-size: 12px; }
+
+.ai-empty-state p {
+  max-width: 420px;
+  margin: 8px 0 0;
+  color: #7b8586;
+  font-size: 9px;
+  line-height: 1.6;
+}
+
+.ai-message {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.ai-message > span {
+  display: grid;
+  place-items: center;
+  width: 31px;
+  height: 31px;
+  color: #172123;
+  background: #d6d1c5;
+  font: 800 7px "JetBrains Mono", monospace;
+}
+
+.ai-message.assistant > span { background: var(--acid); }
+
+.ai-message > div {
+  min-width: 0;
+  padding: 11px 13px;
+  border: 1px solid rgba(24, 32, 34, 0.12);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.ai-message p {
+  margin: 0;
+  font-size: 10px;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.ai-message details {
+  margin-bottom: 8px;
+  color: #7a8586;
+  font-size: 8px;
+}
+
+.ai-message details p {
+  margin-top: 7px;
+  font-size: 8px;
+}
+
+.ai-error {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0 14px 9px;
+  padding: 8px 10px;
+  color: #8e3023;
+  background: rgba(239, 106, 87, 0.12);
+  font-size: 9px;
+}
+
+.ai-composer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 9px;
+  margin: 0 14px;
+  padding: 10px;
+  border: 1px solid rgba(24, 32, 34, 0.25);
+  background: white;
+}
+
+.ai-composer textarea {
+  min-height: 72px;
+  max-height: 160px;
+  resize: vertical;
+  padding: 4px;
+  color: var(--ink);
+  border: 0;
+  outline: 0;
+  background: transparent;
+  font-size: 10px;
+  line-height: 1.55;
+}
+
+.ai-send {
+  display: flex;
+  align-items: center;
+  min-height: 34px;
+  gap: 6px;
+  padding: 0 12px;
+  color: #11191b;
+  border: 0;
+  background: var(--acid);
+  font-size: 9px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.ai-send.stop {
+  color: white;
+  background: var(--danger);
+}
+
+.ai-send:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.ai-composer-hint {
+  padding: 7px 15px 12px;
+  color: #899293;
+  font: 7.5px "JetBrains Mono", monospace;
+}
+
+.ai-context-panel {
+  align-self: start;
+  padding-bottom: 14px;
+}
+
+.ai-context-file {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  margin: 4px 14px 12px;
+  padding: 12px;
+  color: white;
+  background: #172123;
+}
+
+.ai-context-file > span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  color: #172123;
+  background: var(--acid);
+}
+
+.ai-context-file > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ai-context-file strong { font-size: 9px; }
+
+.ai-context-file small {
+  overflow: hidden;
+  color: #788688;
+  font: 7px "JetBrains Mono", monospace;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ai-context-file button {
+  color: #b5c1c1;
+  border: 0;
+  background: transparent;
+  font-size: 8px;
+  cursor: pointer;
+}
+
+.ai-write-toggle {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  margin: 0 14px 12px;
+  padding: 12px;
+  color: #687274;
+  border: 1px solid rgba(24, 32, 34, 0.16);
+  background: rgba(255, 255, 255, 0.44);
+  cursor: pointer;
+}
+
+.ai-write-toggle input {
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  accent-color: var(--excel);
+  cursor: pointer;
+}
+
+.ai-write-toggle > span {
+  display: grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  color: #7c8788;
+  border: 1px solid #aab1b1;
+}
+
+.ai-write-toggle.enabled {
+  color: #315c41;
+  border-color: rgba(24, 133, 85, 0.45);
+  background: rgba(24, 133, 85, 0.08);
+}
+
+.ai-write-toggle.enabled > span { color: white; border-color: var(--excel); background: var(--excel); }
+
+.ai-write-inline {
+  margin: 0 14px 9px;
+  color: #5f4b16;
+  border: 2px solid #d0ad1c;
+  background: rgba(242, 211, 63, 0.2);
+  box-shadow: 3px 3px 0 rgba(24, 32, 34, 0.18);
+}
+
+.ai-write-inline > span {
+  color: #172123;
+  border-color: #b79516;
+  background: var(--acid);
+}
+
+.ai-write-inline.enabled {
+  border-width: 2px;
+  box-shadow: 3px 3px 0 rgba(24, 133, 85, 0.22);
+}
+
+.ai-write-toggle > div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ai-write-toggle strong { color: var(--ink); font-size: 9px; }
+.ai-write-toggle small { font-size: 7.5px; line-height: 1.45; }
+
+.ai-capability-list {
+  margin: 0 14px;
+  border-top: 1px solid rgba(24, 32, 34, 0.12);
+}
+
+.ai-capability-list > div {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  min-height: 52px;
+  gap: 9px;
+  border-bottom: 1px solid rgba(24, 32, 34, 0.1);
+}
+
+.ai-capability-list > div > svg { color: var(--excel); }
+
+.ai-capability-list span {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.ai-capability-list strong { font-size: 9px; }
+.ai-capability-list small { color: #808a8b; font-size: 7.5px; }
+
+.ai-privacy-note {
+  margin: 12px 14px 0;
+  color: #7d8788;
+  font-size: 7.5px;
+  line-height: 1.55;
+}
+
 .mcp-hero {
   align-items: center;
 }
@@ -1932,7 +2343,9 @@ pre {
   .format-card { min-height: 190px; }
   .home-bottom,
   .workbench-columns,
+  .ai-workspace,
   .mcp-grid { grid-template-columns: 1fr; }
+  .ai-context-panel { align-self: stretch; }
   .console-grid { grid-template-columns: minmax(250px, 0.65fr) minmax(0, 1.35fr); }
 }
 
@@ -1960,6 +2373,8 @@ pre {
   .active-file select { grid-column: 1 / -1; grid-row: 2; }
   .operation-grid { grid-template-columns: 1fr; }
   .console-grid { grid-template-columns: 1fr; }
+  .ai-hero { grid-template-columns: 1fr; align-items: start; }
+  .ai-hero h1 { font-size: 34px; }
   .probe-strip { grid-template-columns: 1fr; }
   .mcp-hero { align-items: flex-start; gap: 20px; }
   .mcp-signal { min-width: 150px; }

--- a/plugins/office-suite-workbench/src/types.ts
+++ b/plugins/office-suite-workbench/src/types.ts
@@ -1,4 +1,4 @@
-export type ViewId = "home" | "word" | "excel" | "powerpoint" | "console" | "mcp";
+export type ViewId = "home" | "ai" | "word" | "excel" | "powerpoint" | "console" | "mcp";
 export type OfficeFormat = "word" | "excel" | "powerpoint";
 
 export interface ApiError {
@@ -52,6 +52,10 @@ export interface OfficeSuiteApi {
     command: string | string[],
     options?: { timeoutMs?: number }
   ): Promise<ApiResult<OfficeCliRunOutput>>;
+  runForAi(
+    command: string | string[],
+    options: { allowWrite: boolean }
+  ): Promise<ApiResult<OfficeCliRunOutput>>;
   getMcpStatus(): Promise<ApiResult<unknown>>;
   registerMcp(
     target: "lms" | "claude" | "cursor" | "vscode"
@@ -63,6 +67,42 @@ export interface OfficeSuiteApi {
   getMcpConfigs(): Promise<ApiResult<McpConfigurations>>;
 }
 
+export interface ZToolsAiModel {
+  id: string;
+  label: string;
+  description?: string;
+  icon?: string;
+  cost?: number;
+}
+
+export interface ZToolsAiMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content?: string;
+  reasoning_content?: string;
+}
+
+export interface ZToolsAiRequest extends PromiseLike<void> {
+  abort(): void;
+  catch<TResult = never>(
+    onRejected?: ((reason: unknown) => TResult | PromiseLike<TResult>) | null
+  ): Promise<void | TResult>;
+  finally(onFinally?: (() => void) | null): Promise<void>;
+}
+
+export interface ZToolsAiOptions {
+  model?: string;
+  messages: ZToolsAiMessage[];
+  tools?: Array<{
+    type: "function";
+    function: {
+      name: string;
+      description: string;
+      parameters: Record<string, unknown>;
+      required?: string[];
+    };
+  }>;
+}
+
 export interface ZToolsApi {
   onPluginEnter?(callback: (payload: unknown) => void): void;
   showOpenDialog?(options: Record<string, unknown>): Promise<unknown> | unknown;
@@ -70,11 +110,17 @@ export interface ZToolsApi {
   copyText?(text: string): void;
   shellOpenExternal?(url: string): Promise<unknown> | unknown;
   shellOpenPath?(path: string): Promise<unknown> | unknown;
+  allAiModels?(): Promise<ZToolsAiModel[]>;
+  ai?(
+    options: ZToolsAiOptions,
+    onChunk?: (chunk: ZToolsAiMessage) => void
+  ): ZToolsAiRequest;
 }
 
 declare global {
   interface Window {
     officeSuite?: OfficeSuiteApi;
     ztools?: ZToolsApi;
+    office_document?: (input: Record<string, unknown>) => Promise<unknown>;
   }
 }

--- a/plugins/office-suite-workbench/src/types.ts
+++ b/plugins/office-suite-workbench/src/types.ts
@@ -1,0 +1,72 @@
+export type ViewId = "home" | "word" | "excel" | "powerpoint" | "console" | "mcp";
+export type OfficeFormat = "word" | "excel" | "powerpoint";
+
+export interface ApiError {
+  code: string;
+  message: string;
+  details?: unknown;
+}
+
+export type ApiResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: ApiError };
+
+export interface OfficeCliStatus {
+  installed: boolean;
+  binaryPath?: string;
+  version?: string;
+}
+
+export interface OfficeCliRunOutput {
+  command?: string;
+  args?: string[];
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  json?: unknown;
+  durationMs?: number;
+}
+
+export interface McpProbe {
+  serverInfo?: { name?: string; version?: string };
+  protocolVersion?: string;
+  toolNames?: string[];
+}
+
+export interface McpConfigurations {
+  binaryPath?: string;
+  configs: Record<string, unknown>;
+}
+
+export interface OfficeSuiteApi {
+  getStatus(): Promise<ApiResult<OfficeCliStatus>>;
+  run(
+    command: string | string[],
+    options?: { timeoutMs?: number }
+  ): Promise<ApiResult<OfficeCliRunOutput>>;
+  getMcpStatus(): Promise<ApiResult<unknown>>;
+  registerMcp(
+    target: "lms" | "claude" | "cursor" | "vscode"
+  ): Promise<ApiResult<unknown>>;
+  unregisterMcp(
+    target: "lms" | "claude" | "cursor" | "vscode"
+  ): Promise<ApiResult<unknown>>;
+  probeMcp(): Promise<ApiResult<McpProbe>>;
+  getMcpConfigs(): Promise<ApiResult<McpConfigurations>>;
+}
+
+export interface ZToolsApi {
+  onPluginEnter?(callback: (payload: unknown) => void): void;
+  showOpenDialog?(options: Record<string, unknown>): Promise<unknown> | unknown;
+  showSaveDialog?(options: Record<string, unknown>): Promise<unknown> | unknown;
+  copyText?(text: string): void;
+  shellOpenExternal?(url: string): Promise<unknown> | unknown;
+  shellOpenPath?(path: string): Promise<unknown> | unknown;
+}
+
+declare global {
+  interface Window {
+    officeSuite?: OfficeSuiteApi;
+    ztools?: ZToolsApi;
+  }
+}

--- a/plugins/office-suite-workbench/src/types.ts
+++ b/plugins/office-suite-workbench/src/types.ts
@@ -25,6 +25,14 @@ export interface OfficeCliRunOutput {
   stderr: string;
   json?: unknown;
   durationMs?: number;
+  previewImages?: OfficeCliPreviewImage[];
+}
+
+export interface OfficeCliPreviewImage {
+  path: string;
+  mimeType: "image/png" | "image/jpeg" | "image/gif" | "image/webp";
+  size: number;
+  dataUrl: string;
 }
 
 export interface McpProbe {

--- a/plugins/office-suite-workbench/tests/integration/officecli.integration.test.cjs
+++ b/plugins/office-suite-workbench/tests/integration/officecli.integration.test.cjs
@@ -1,0 +1,93 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const test = require('node:test')
+
+const { createOfficeCliRunner } = require('../../preload/officecli-runner.cjs')
+const { registerOfficeDocumentTool } = require('../../preload/services.cjs')
+
+const runner = createOfficeCliRunner()
+
+async function requireRuntime(t) {
+  const status = await runner.getStatus()
+  if (!status.ok || !status.data.installed) {
+    t.skip('OfficeCLI is not installed on this machine')
+    return false
+  }
+  return true
+}
+
+async function expectRun(command) {
+  const result = await runner.run(command, { timeoutMs: 120_000 })
+  assert.equal(result.ok, true, result.ok ? undefined : JSON.stringify(result.error))
+  return result.data
+}
+
+test('creates and validates Word, Excel and PowerPoint golden smoke files', async (t) => {
+  if (!(await requireRuntime(t))) return
+
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'ztools-office-suite-'))
+  const docx = path.join(directory, 'Word 金样.docx')
+  const xlsx = path.join(directory, 'Excel 金样.xlsx')
+  const pptx = path.join(directory, 'PowerPoint 金样.pptx')
+
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }))
+
+  await expectRun(['create', docx])
+  await expectRun(['add', docx, '/body', '--type', 'paragraph', '--prop', 'text=ZTools Office Suite'])
+  const wordText = await expectRun(['view', docx, 'text'])
+  assert.match(wordText.stdout, /ZTools Office Suite/u)
+  await expectRun(['validate', docx, '--json'])
+
+  await expectRun(['create', xlsx])
+  await expectRun(['set', xlsx, '/Sheet1/A1', '--prop', 'value=21'])
+  await expectRun(['set', xlsx, '/Sheet1/B1', '--prop', 'formula=A1*2'])
+  const excelCell = await expectRun(['get', xlsx, '/Sheet1/B1', '--json'])
+  assert.match(excelCell.stdout, /A1\*2/u)
+  await expectRun(['query', xlsx, 'cell:has(formula)', '--json'])
+  await expectRun(['get', xlsx, '/sheet[1]', '--depth', '2', '--json'])
+  await expectRun(['validate', xlsx, '--json'])
+
+  await expectRun(['create', pptx])
+  await expectRun(['add', pptx, '/', '--type', 'slide', '--prop', 'title=ZTools Office Suite'])
+  const deckOutline = await expectRun(['view', pptx, 'outline'])
+  assert.match(deckOutline.stdout, /ZTools Office Suite/u)
+  await expectRun(['get', pptx, '/', '--depth', '1', '--json'])
+  await expectRun(['query', pptx, 'picture:no-alt', '--json'])
+  await expectRun(['validate', pptx, '--json'])
+})
+
+test('completes the OfficeCLI native MCP initialize and tools/list handshake', async (t) => {
+  if (!(await requireRuntime(t))) return
+  const result = await runner.probeMcp({ timeoutMs: 15_000 })
+  assert.equal(result.ok, true, result.ok ? undefined : JSON.stringify(result.error))
+  assert.equal(result.data.serverInfo.name, 'officecli')
+  assert.deepEqual(result.data.toolNames, ['officecli'])
+})
+
+test('executes the ZTools office_document handler through the real guarded runner', async (t) => {
+  if (!(await requireRuntime(t))) return
+  let registeredName = null
+  let registeredHandler = null
+  const target = {
+    ztools: {
+      registerTool(name, handler) {
+        registeredName = name
+        registeredHandler = handler
+      }
+    }
+  }
+
+  assert.equal(registerOfficeDocumentTool(target, runner), true)
+  assert.equal(registeredName, 'office_document')
+  const response = await registeredHandler({ command: ['help', 'docx', 'paragraph'] })
+  assert.equal(response.ok, true)
+  assert.match(response.stdout, /paragraph/iu)
+  await assert.rejects(
+    registeredHandler({ command: ['get', 'relative.docx', '/'] }),
+    (error) => error.code === 'MCP_ABSOLUTE_PATH_REQUIRED'
+  )
+})

--- a/plugins/office-suite-workbench/tests/preload/command-parser.test.cjs
+++ b/plugins/office-suite-workbench/tests/preload/command-parser.test.cjs
@@ -1,0 +1,89 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  DOCUMENT_COMMANDS,
+  parseCommand,
+  tokenizeCommand
+} = require('../../preload/command-parser.cjs')
+
+test('tokenizeCommand supports quotes and backslash escaping without a shell', () => {
+  assert.deepEqual(
+    tokenizeCommand('officecli set "Quarterly Report.docx" \'/body/p[1]\' --prop "text=Hello world" --prop note=A\\ B --prop "text=Line\\nNext"'),
+    [
+      'officecli',
+      'set',
+      'Quarterly Report.docx',
+      '/body/p[1]',
+      '--prop',
+      'text=Hello world',
+      '--prop',
+      'note=A B',
+      '--prop',
+      'text=Line\\nNext'
+    ]
+  )
+})
+
+test('parseCommand accepts string and argv forms and strips an optional binary prefix', () => {
+  const fromString = parseCommand('officecli get "Quarterly Report.docx" \'/body/p[1]\' --json')
+  assert.equal(fromString.command, 'get')
+  assert.deepEqual(fromString.args, ['Quarterly Report.docx', '/body/p[1]', '--json'])
+
+  const fromArgv = parseCommand(['C:\\Tools\\officecli.exe', 'VIEW', 'deck.pptx', 'outline'])
+  assert.equal(fromArgv.command, 'view')
+  assert.deepEqual(fromArgv.argv, ['view', 'deck.pptx', 'outline'])
+
+  const windowsPath = parseCommand('get C:\\Users\\Harris\\report.docx /body')
+  assert.deepEqual(windowsPath.args, ['C:\\Users\\Harris\\report.docx', '/body'])
+
+  const uncPath = parseCommand('get \\\\server\\share\\report.docx /body')
+  assert.deepEqual(uncPath.args, ['\\\\server\\share\\report.docx', '/body'])
+
+  const uncArgv = parseCommand(['get', '\\\\server\\share\\report.docx', '/body'])
+  assert.deepEqual(uncArgv.args, ['\\\\server\\share\\report.docx', '/body'])
+
+  assert.deepEqual(parseCommand(['get', '/tmp/report.docx']).args, ['/tmp/report.docx'])
+  assert.deepEqual(parseCommand(['raw', '/tmp/report.docx']).args, ['/tmp/report.docx'])
+})
+
+test('document operation allowlist covers supported read and write operations', () => {
+  for (const command of ['create', 'view', 'get', 'query', 'set', 'add', 'remove', 'batch', 'validate', 'merge', 'load_skill']) {
+    assert.equal(DOCUMENT_COMMANDS.includes(command), true)
+  }
+})
+
+test('management and process-control commands are rejected before execution', () => {
+  for (const command of [
+    'install',
+    'skills',
+    'plugins',
+    'mcp',
+    'config',
+    'update',
+    'watch',
+    '__resident-serve__'
+  ]) {
+    assert.throws(
+      () => parseCommand(`officecli ${command} example`),
+      (error) => error.code === 'COMMAND_BLOCKED',
+      command
+    )
+  }
+})
+
+test('unknown commands and incomplete document commands are rejected', () => {
+  assert.throws(() => parseCommand('bash -c whoami'), (error) => error.code === 'COMMAND_NOT_ALLOWED')
+  assert.throws(() => parseCommand('set report.docx'), (error) => error.code === 'MISSING_ARGUMENTS')
+  assert.throws(() => parseCommand('create --json'), (error) => error.code === 'MISSING_DOCUMENT_PATH')
+  assert.throws(() => parseCommand('officecli'), (error) => error.code === 'EMPTY_COMMAND')
+})
+
+test('malformed quoting, escaping, and argv values fail strictly', () => {
+  assert.throws(() => tokenizeCommand('get "broken.docx /'), (error) => error.code === 'UNTERMINATED_QUOTE')
+  assert.throws(() => tokenizeCommand('get report.docx /\\'), (error) => error.code === 'DANGLING_ESCAPE')
+  assert.throws(() => parseCommand(['get', 'report.docx', 1]), (error) => error.code === 'INVALID_ARGUMENT_TYPE')
+  assert.throws(() => parseCommand(['get', 'report.docx', '']), (error) => error.code === 'EMPTY_ARGUMENT')
+})

--- a/plugins/office-suite-workbench/tests/preload/officecli-runner.test.cjs
+++ b/plugins/office-suite-workbench/tests/preload/officecli-runner.test.cjs
@@ -1,0 +1,338 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+const { EventEmitter } = require('node:events')
+const { PassThrough } = require('node:stream')
+
+const {
+  createMcpConfigs,
+  createOfficeCliRunner
+} = require('../../preload/officecli-runner.cjs')
+
+async function executableFixture(t) {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'office-suite-runner-'))
+  const binaryPath = path.join(directory, process.platform === 'win32' ? 'officecli.exe' : 'officecli')
+  await fs.writeFile(binaryPath, process.platform === 'win32' ? '' : '#!/bin/sh\nexit 0\n')
+  if (process.platform !== 'win32') await fs.chmod(binaryPath, 0o755)
+  t.after(() => fs.rm(directory, { recursive: true, force: true }))
+  return { binaryPath, directory }
+}
+
+function fakeSpawn(responder) {
+  const calls = []
+  const spawn = (binaryPath, args, options) => {
+    const child = new EventEmitter()
+    child.stdin = new PassThrough()
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.killed = false
+    child.kill = (signal) => {
+      child.killed = true
+      child.killSignal = signal
+      return true
+    }
+
+    const call = { binaryPath, args: args.slice(), options, input: '', child }
+    calls.push(call)
+    child.stdin.setEncoding('utf8')
+    child.stdin.on('data', (chunk) => { call.input += chunk })
+    child.stdin.on('finish', () => {
+      setImmediate(() => responder({ call, child, complete: ({ stdout = '', stderr = '', exitCode = 0 } = {}) => {
+        if (stdout) child.stdout.write(stdout)
+        if (stderr) child.stderr.write(stderr)
+        child.stdout.end()
+        child.stderr.end()
+        setImmediate(() => child.emit('close', exitCode, null))
+      } }))
+    })
+    return child
+  }
+  return { calls, spawn }
+}
+
+function fakeMcpSpawn() {
+  const calls = []
+  const spawn = (binaryPath, args, options) => {
+    const child = new EventEmitter()
+    child.stdin = new PassThrough()
+    child.stdout = new PassThrough()
+    child.stderr = new PassThrough()
+    child.kill = () => true
+    const call = { binaryPath, args: args.slice(), options, messages: [] }
+    calls.push(call)
+    let buffer = ''
+
+    child.stdin.setEncoding('utf8')
+    child.stdin.on('data', (chunk) => {
+      buffer += chunk
+      let newlineIndex
+      while ((newlineIndex = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newlineIndex)
+        buffer = buffer.slice(newlineIndex + 1)
+        if (!line.trim()) continue
+        const request = JSON.parse(line)
+        call.messages.push(request)
+        if (request.method === 'initialize') {
+          setImmediate(() => child.stdout.write(`${JSON.stringify({
+            jsonrpc: '2.0',
+            id: request.id,
+            result: {
+              protocolVersion: '2024-11-05',
+              serverInfo: { name: 'officecli', version: '1.2.3' },
+              capabilities: { tools: { listChanged: false } }
+            }
+          })}\n`))
+        }
+        if (request.method === 'tools/list') {
+          setImmediate(() => child.stdout.write(`${JSON.stringify({
+            jsonrpc: '2.0',
+            id: request.id,
+            result: { tools: [{ name: 'officecli' }] }
+          })}\n`))
+        }
+      }
+    })
+    child.stdin.on('finish', () => {
+      setImmediate(() => {
+        child.stdout.end()
+        child.stderr.end()
+        child.emit('close', 0, null)
+      })
+    })
+    return child
+  }
+  return { calls, spawn }
+}
+
+test('runner discovers OfficeCLI from a supplied PATH and reports version', async (t) => {
+  const fixture = await executableFixture(t)
+  const fake = fakeSpawn(({ complete }) => complete({ stdout: 'officecli 1.2.3\n' }))
+  const runner = createOfficeCliRunner({
+    spawn: fake.spawn,
+    env: { PATH: '' },
+    homeDir: fixture.directory,
+    commonPaths: []
+  })
+
+  const result = await runner.getStatus({ pathEnv: fixture.directory })
+  assert.deepEqual(result, {
+    ok: true,
+    data: { installed: true, binaryPath: fixture.binaryPath, version: '1.2.3' }
+  })
+  assert.equal(fake.calls[0].options.shell, false)
+  assert.deepEqual(fake.calls[0].args, ['--version'])
+})
+
+test('runner honors the read-only OFFICECLI_PATH environment override', async (t) => {
+  const fixture = await executableFixture(t)
+  const fake = fakeSpawn(({ complete }) => complete({ stdout: '1.2.4\n' }))
+  const runner = createOfficeCliRunner({
+    spawn: fake.spawn,
+    env: { PATH: '', OFFICECLI_PATH: fixture.binaryPath },
+    commonPaths: []
+  })
+
+  const result = await runner.getStatus()
+  assert.equal(result.ok, true)
+  assert.equal(result.data.binaryPath, fixture.binaryPath)
+  assert.equal(result.data.version, '1.2.4')
+})
+
+test('win32 discovery includes the official LOCALAPPDATA OfficeCLI install directory', async (t) => {
+  const localAppData = await fs.mkdtemp(path.join(os.tmpdir(), 'office-suite-win-localappdata-'))
+  const installDirectory = path.join(localAppData, 'OfficeCLI')
+  const binaryPath = path.join(installDirectory, 'officecli.exe')
+  await fs.mkdir(installDirectory, { recursive: true })
+  await fs.writeFile(binaryPath, '')
+  t.after(() => fs.rm(localAppData, { recursive: true, force: true }))
+
+  const fake = fakeSpawn(({ complete }) => complete({ stdout: '1.2.5\n' }))
+  const runner = createOfficeCliRunner({
+    spawn: fake.spawn,
+    platform: 'win32',
+    env: { Path: '', LOCALAPPDATA: localAppData },
+    homeDir: localAppData,
+    commonPaths: []
+  })
+
+  const result = await runner.getStatus()
+  assert.equal(result.ok, true)
+  assert.equal(result.data.binaryPath, binaryPath)
+  assert.equal(result.data.version, '1.2.5')
+})
+
+test('document runner injects argv without a shell and returns parsed JSON', async (t) => {
+  const fixture = await executableFixture(t)
+  const fake = fakeSpawn(({ complete }) => complete({ stdout: '{"success":true,"data":{"text":"Hello"}}\n' }))
+  const runner = createOfficeCliRunner({ spawn: fake.spawn, env: { PATH: '' }, commonPaths: [] })
+
+  const result = await runner.run('officecli get "Report Q4.docx" /body --json', {
+    binaryPath: fixture.binaryPath,
+    env: { OFFICE_TEST_FLAG: 'yes' }
+  })
+
+  assert.equal(result.ok, true)
+  assert.equal(result.data.command, 'get')
+  assert.deepEqual(result.data.args, ['Report Q4.docx', '/body', '--json'])
+  assert.deepEqual(result.data.json, { success: true, data: { text: 'Hello' } })
+  assert.deepEqual(fake.calls[0].args, ['get', 'Report Q4.docx', '/body', '--json'])
+  assert.equal(fake.calls[0].options.shell, false)
+  assert.equal(fake.calls[0].options.env.OFFICE_TEST_FLAG, 'yes')
+  assert.equal(fake.calls[0].options.env.OFFICECLI_SKIP_UPDATE, '1')
+  assert.equal(fake.calls[0].options.env.OFFICECLI_NO_AUTO_RESIDENT, '1')
+})
+
+test('document runner preserves UTF-8 characters split across stdout chunks', async (t) => {
+  const fixture = await executableFixture(t)
+  const fake = fakeSpawn(({ child, complete }) => {
+    const output = Buffer.from('{"text":"中文"}\n', 'utf8')
+    const split = output.indexOf(Buffer.from('中')) + 1
+    child.stdout.write(output.subarray(0, split))
+    child.stdout.write(output.subarray(split))
+    complete()
+  })
+  const runner = createOfficeCliRunner({ spawn: fake.spawn, env: { PATH: '' }, commonPaths: [] })
+
+  const result = await runner.run(['get', '/tmp/report.docx'], { binaryPath: fixture.binaryPath })
+  assert.equal(result.ok, true)
+  assert.deepEqual(result.data.json, { text: '中文' })
+})
+
+test('dangerous commands and unsupported MCP targets never reach spawn', async (t) => {
+  const fixture = await executableFixture(t)
+  const fake = fakeSpawn(({ complete }) => complete())
+  const runner = createOfficeCliRunner({ spawn: fake.spawn, env: { PATH: '' }, commonPaths: [] })
+
+  const blocked = await runner.run('officecli mcp claude', { binaryPath: fixture.binaryPath })
+  assert.equal(blocked.ok, false)
+  assert.equal(blocked.error.code, 'COMMAND_BLOCKED')
+
+  const target = await runner.registerMcp('codex', { binaryPath: fixture.binaryPath })
+  assert.equal(target.ok, false)
+  assert.equal(target.error.code, 'INVALID_MCP_TARGET')
+  assert.equal(fake.calls.length, 0)
+})
+
+test('MCP status, register, and unregister use fixed OfficeCLI argv', async (t) => {
+  const fixture = await executableFixture(t)
+  const fake = fakeSpawn(({ call, complete }) => {
+    if (call.args.join(' ') === 'mcp list') {
+      complete({ stdout: 'officecli MCP registration status:\n  ✓ LM Studio       registered\n  ✗ Claude Code     not registered\n  ✓ Cursor          registered\n  ✗ VS Code         not registered\n' })
+      return
+    }
+    complete({ stdout: 'ok\n' })
+  })
+  const runner = createOfficeCliRunner({ spawn: fake.spawn, env: { PATH: '' }, commonPaths: [] })
+  const options = { binaryPath: fixture.binaryPath }
+
+  const status = await runner.getMcpStatus(options)
+  assert.equal(status.ok, true)
+  assert.deepEqual(status.data.targets, { lms: true, claude: false, cursor: true, vscode: false })
+
+  assert.equal((await runner.registerMcp('cursor', options)).ok, true)
+  assert.equal((await runner.unregisterMcp('vscode', options)).ok, true)
+  assert.deepEqual(fake.calls.map((call) => call.args), [
+    ['mcp', 'list'],
+    ['mcp', 'cursor'],
+    ['mcp', 'uninstall', 'vscode']
+  ])
+})
+
+test('native MCP probe performs initialize and tools/list over stdio', async (t) => {
+  const fixture = await executableFixture(t)
+  const fake = fakeMcpSpawn()
+  const runner = createOfficeCliRunner({ spawn: fake.spawn, env: { PATH: '' }, commonPaths: [] })
+
+  const result = await runner.probeMcp({ binaryPath: fixture.binaryPath })
+  assert.deepEqual(result, {
+    ok: true,
+    data: {
+      serverInfo: { name: 'officecli', version: '1.2.3' },
+      protocolVersion: '2024-11-05',
+      toolNames: ['officecli']
+    }
+  })
+  assert.deepEqual(fake.calls[0].args, ['mcp'])
+  assert.equal(fake.calls[0].options.shell, false)
+  assert.deepEqual(fake.calls[0].messages.map((message) => message.method), [
+    'initialize',
+    'notifications/initialized',
+    'tools/list'
+  ])
+})
+
+test('MCP config generator returns generic/client JSON and Codex TOML', async (t) => {
+  const fixture = await executableFixture(t)
+  const runner = createOfficeCliRunner({ env: { PATH: '' }, commonPaths: [] })
+  const result = await runner.getMcpConfigs({ binaryPath: fixture.binaryPath })
+
+  assert.equal(result.ok, true)
+  assert.deepEqual(result.data.configs.generic, { command: fixture.binaryPath, args: ['mcp'] })
+  assert.deepEqual(result.data.configs.claude.mcpServers.officecli, result.data.configs.generic)
+  assert.deepEqual(result.data.configs.cursor.mcpServers.officecli, result.data.configs.generic)
+  assert.deepEqual(result.data.configs.vscode.servers.officecli, {
+    type: 'stdio',
+    ...result.data.configs.generic
+  })
+  assert.match(result.data.configs.codex, /^\[mcp_servers\.officecli\]/u)
+  assert.match(result.data.configs.codex, /args = \["mcp"\]/u)
+
+  const windows = createMcpConfigs('C:\\Program Files\\OfficeCLI\\officecli.exe')
+  assert.match(windows.codex, /C:\\\\Program Files/u)
+})
+
+test('non-zero exits and output limits resolve to serializable errors', async (t) => {
+  const fixture = await executableFixture(t)
+  const failedSpawn = fakeSpawn(({ complete }) => complete({ stderr: 'document is invalid\n', exitCode: 2 }))
+  const failedRunner = createOfficeCliRunner({ spawn: failedSpawn.spawn, env: { PATH: '' }, commonPaths: [] })
+  const failed = await failedRunner.run('validate report.docx', { binaryPath: fixture.binaryPath })
+  assert.equal(failed.ok, false)
+  assert.equal(failed.error.code, 'OFFICECLI_EXIT')
+  assert.equal(failed.error.details.exitCode, 2)
+  assert.doesNotThrow(() => JSON.stringify(failed))
+
+  const largeSpawn = fakeSpawn(({ complete }) => complete({ stdout: 'x'.repeat(64) }))
+  const limitedRunner = createOfficeCliRunner({ spawn: largeSpawn.spawn, env: { PATH: '' }, commonPaths: [] })
+  const limited = await limitedRunner.run('get report.docx /', {
+    binaryPath: fixture.binaryPath,
+    maxOutputBytes: 16
+  })
+  assert.equal(limited.ok, false)
+  assert.equal(limited.error.code, 'OUTPUT_LIMIT_EXCEEDED')
+})
+
+test('timeout and output-limit failures wait for child close before resolving', async (t) => {
+  const fixture = await executableFixture(t)
+
+  const timeoutSpawn = fakeSpawn(() => undefined)
+  const timeoutRunner = createOfficeCliRunner({ spawn: timeoutSpawn.spawn, env: { PATH: '' }, commonPaths: [] })
+  let timeoutSettled = false
+  const timeoutPromise = timeoutRunner
+    .run(['get', '/tmp/report.docx'], { binaryPath: fixture.binaryPath, timeoutMs: 10 })
+    .then((result) => { timeoutSettled = true; return result })
+  await new Promise((resolve) => setTimeout(resolve, 30))
+  assert.equal(timeoutSettled, false)
+  assert.equal(timeoutSpawn.calls[0].child.killSignal, 'SIGTERM')
+  timeoutSpawn.calls[0].child.emit('close', null, 'SIGTERM')
+  const timeout = await timeoutPromise
+  assert.equal(timeout.ok, false)
+  assert.equal(timeout.error.code, 'OFFICECLI_TIMEOUT')
+
+  const outputSpawn = fakeSpawn(({ child }) => child.stdout.write('x'.repeat(64)))
+  const outputRunner = createOfficeCliRunner({ spawn: outputSpawn.spawn, env: { PATH: '' }, commonPaths: [] })
+  let outputSettled = false
+  const outputPromise = outputRunner
+    .run(['get', '/tmp/report.docx'], { binaryPath: fixture.binaryPath, maxOutputBytes: 16 })
+    .then((result) => { outputSettled = true; return result })
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  assert.equal(outputSettled, false)
+  assert.equal(outputSpawn.calls[0].child.killSignal, 'SIGTERM')
+  outputSpawn.calls[0].child.emit('close', null, 'SIGTERM')
+  const output = await outputPromise
+  assert.equal(output.ok, false)
+  assert.equal(output.error.code, 'OUTPUT_LIMIT_EXCEEDED')
+})

--- a/plugins/office-suite-workbench/tests/preload/services.test.cjs
+++ b/plugins/office-suite-workbench/tests/preload/services.test.cjs
@@ -1,0 +1,255 @@
+'use strict'
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+
+const {
+  MCP_TOOL_TIMEOUT_MS,
+  attachOfficeSuite
+} = require('../../preload/services.cjs')
+
+function runnerMock() {
+  const calls = []
+  const method = (name) => async (...args) => {
+    calls.push({ name, args })
+    return { ok: true, data: { name, args } }
+  }
+  return {
+    calls,
+    runner: {
+      getStatus: method('getStatus'),
+      run: method('run'),
+      getMcpStatus: method('getMcpStatus'),
+      registerMcp: method('registerMcp'),
+      unregisterMcp: method('unregisterMcp'),
+      probeMcp: method('probeMcp'),
+      getMcpConfigs: method('getMcpConfigs')
+    }
+  }
+}
+
+test('attachOfficeSuite exposes only the fixed narrow UI methods', () => {
+  const mock = runnerMock()
+  const target = {}
+  attachOfficeSuite(target, mock.runner)
+  assert.deepEqual(Object.keys(target.officeSuite).sort(), [
+    'getMcpConfigs',
+    'getMcpStatus',
+    'getStatus',
+    'probeMcp',
+    'registerMcp',
+    'run',
+    'unregisterMcp'
+  ])
+})
+
+test('renderer bridge rejects hidden runner options before invocation', async () => {
+  const mock = runnerMock()
+  const target = {}
+  attachOfficeSuite(target, mock.runner)
+
+  const blocked = await target.officeSuite.run('help', {
+    env: { PATH: '/tmp/untrusted' },
+    pathEnv: '/tmp/untrusted'
+  })
+  assert.equal(blocked.ok, false)
+  assert.equal(blocked.error.code, 'OPTION_BLOCKED')
+  assert.equal(mock.calls.length, 0)
+
+  const binaryOverride = await target.officeSuite.getStatus({ binaryPath: '/tmp/not-officecli' })
+  assert.equal(binaryOverride.ok, false)
+  assert.equal(binaryOverride.error.code, 'OPTION_BLOCKED')
+  assert.equal(mock.calls.length, 0)
+
+  const allowed = await target.officeSuite.run('help', {
+    timeoutMs: 5_000
+  })
+  assert.equal(allowed.ok, true)
+  assert.deepEqual(mock.calls[0].args, [
+    'help',
+    { timeoutMs: 5_000 }
+  ])
+})
+
+test('native office_document tool registers once and reuses the same runner', async () => {
+  const mock = runnerMock()
+  const registrations = []
+  const target = {
+    ztools: {
+      registerTool(name, handler) {
+        registrations.push({ name, handler })
+      }
+    }
+  }
+
+  attachOfficeSuite(target, mock.runner)
+  attachOfficeSuite(target, mock.runner)
+  assert.equal(registrations.length, 1)
+  assert.equal(registrations[0].name, 'office_document')
+
+  const result = await registrations[0].handler({ command: ['get', '/tmp/report.docx', '/body'] })
+  assert.equal(result.ok, true)
+  assert.equal(result.name, 'run')
+  assert.equal('data' in result, false)
+  assert.equal(mock.calls.length, 1)
+  assert.equal(mock.calls[0].name, 'run')
+  assert.deepEqual(mock.calls[0].args, [
+    ['get', '/tmp/report.docx', '/body'],
+    {
+      timeoutMs: MCP_TOOL_TIMEOUT_MS,
+      env: { OFFICECLI_NO_AUTO_RESIDENT: '1' }
+    }
+  ])
+
+  const replacement = runnerMock()
+  attachOfficeSuite(target, replacement.runner)
+  await registrations[0].handler({ command: ['get', '/tmp/replacement.docx', '/body'] })
+  assert.equal(replacement.calls.length, 1)
+  assert.equal(mock.calls.length, 1)
+})
+
+test('native office_document tool accepts only command and resolves errors', async () => {
+  const mock = runnerMock()
+  let handler
+  const target = {
+    ztools: {
+      registerTool(_name, registeredHandler) {
+        handler = registeredHandler
+      }
+    }
+  }
+  attachOfficeSuite(target, mock.runner)
+
+  await assert.rejects(
+    handler({ command: 'get /tmp/report.docx /body', binaryPath: '/tmp/officecli' }),
+    (error) => error.code === 'INVALID_TOOL_INPUT'
+  )
+  assert.equal(mock.calls.length, 0)
+
+  await assert.rejects(handler({}), (error) => error.code === 'INVALID_TOOL_INPUT')
+})
+
+test('native office_document management commands remain rejected by the shared runner contract', async () => {
+  const mock = runnerMock()
+  mock.runner.run = async (command) => {
+    const { parseCommand } = require('../../preload/command-parser.cjs')
+    try {
+      parseCommand(command)
+      return { ok: true, data: {} }
+    } catch (error) {
+      return { ok: false, error: { code: error.code, message: error.message } }
+    }
+  }
+  let handler
+  const target = { ztools: { registerTool: (_name, value) => { handler = value } } }
+  attachOfficeSuite(target, mock.runner)
+
+  await assert.rejects(handler({ command: 'officecli mcp claude' }), (error) => error.code === 'COMMAND_BLOCKED')
+})
+
+test('native office_document enforces external-only path and high-risk command policy', async () => {
+  const mock = runnerMock()
+  let handler
+  const target = { ztools: { registerTool: (_name, value) => { handler = value } } }
+  attachOfficeSuite(target, mock.runner)
+
+  for (const command of [
+    ['raw-set', '/tmp/report.docx', 'document'],
+    ['add-part', '/tmp/report.docx', '/body'],
+    ['import', '/tmp/report.xlsx', '/Sheet1', '/etc/passwd'],
+    ['merge', '/tmp/template.docx', '/tmp/output.docx', '--data', '/etc/secrets.json'],
+    ['open', '/tmp/report.docx']
+  ]) {
+    await assert.rejects(handler({ command }), (error) => error.code === 'MCP_COMMAND_BLOCKED')
+  }
+  await assert.rejects(
+    handler({ command: ['get', 'relative.docx', '/body'] }),
+    (error) => error.code === 'MCP_ABSOLUTE_PATH_REQUIRED'
+  )
+  await assert.rejects(
+    handler({ command: ['batch', '/tmp/report.docx', '--input', '/tmp/commands.json'] }),
+    (error) => error.code === 'MCP_BATCH_INPUT_BLOCKED'
+  )
+  await assert.rejects(
+    handler({ command: ['batch', '/tmp/report.docx', '--commands', '[{"command":"raw-set","path":"document"}]'] }),
+    (error) => error.code === 'MCP_COMMAND_BLOCKED'
+  )
+  for (const command of [
+    ['add', '/tmp/report.pptx', '/slide[1]', '--type', 'ole', '--prop', 'src=/etc/hosts'],
+    ['set', '/tmp/report.pptx', '/slide[1]/picture[1]', '--prop=path:https://internal.example/image.png'],
+    ['add', '/tmp/report.pptx', '/slide[1]', '--type', 'media', '--prop:poster=/tmp/poster.png'],
+    ['set', '/tmp/report.pptx', '/slide[1]', '--prop', 'background=image:/etc/hosts'],
+    ['set', '/tmp/report.pptx', '/slide[1]/shape[1]', '--prop', 'fill=url(http://127.0.0.1/private)']
+  ]) {
+    await assert.rejects(
+      handler({ command }),
+      (error) => error.code === 'MCP_EXTERNAL_RESOURCE_BLOCKED'
+    )
+  }
+  for (const operations of [
+    [{ command: 'add', parent: '/slide[1]', type: 'ole', props: { src: '/etc/hosts' } }],
+    [{ command: 'set', path: '/slide[1]', properties: { background: 'image:/etc/hosts' } }],
+    [{ command: 'add', parent: '/slide[1]', type: 'picture', Props: { image: '/tmp/private.png' } }],
+    [{ command: 'add', parent: '/slide[1]', props: { text: 'Safe' }, Props: { src: '/etc/hosts' } }]
+  ]) {
+    await assert.rejects(
+      handler({ command: ['batch', '/tmp/report.pptx', '--commands', JSON.stringify(operations)] }),
+      (error) => error.code === 'MCP_EXTERNAL_RESOURCE_BLOCKED'
+    )
+  }
+  await assert.rejects(
+    handler({ command: ['batch', '/tmp/report.pptx'] }),
+    (error) => error.code === 'MCP_BATCH_INPUT_BLOCKED'
+  )
+  await assert.rejects(
+    handler({
+      command: [
+        'batch',
+        '/tmp/report.pptx',
+        '--commands',
+        '[{"command":"add","Command":"raw-set","parent":"/slide[1]"}]'
+      ]
+    }),
+    (error) => error.code === 'MCP_BATCH_UNSAFE'
+  )
+  for (const command of [
+    ['dump', '/tmp/report.docx', '--out', '/tmp/overwrite.txt'],
+    ['view', '/tmp/report.docx', 'html', '-o=/tmp/overwrite.html'],
+    ['get', '/tmp/report.docx', '/body', '--save', '/tmp/payload.bin'],
+    ['view', '/tmp/report.docx', 'html', '--browser']
+  ]) {
+    await assert.rejects(handler({ command }), (error) => error.code === 'MCP_OUTPUT_PATH_BLOCKED')
+  }
+  await assert.rejects(
+    handler({ command: ['batch', '/tmp/report.docx', '--commands', '[{"command":"view","path":"/","out":"/tmp/x"}]'] }),
+    (error) => error.code === 'MCP_OUTPUT_PATH_BLOCKED'
+  )
+  assert.equal(mock.calls.length, 0)
+
+  const safe = await handler({
+    command: [
+      'batch',
+      '/tmp/report.pptx',
+      '--commands',
+      '[{"command":"add","parent":"/slide[1]","type":"shape","props":{"text":"Safe"}}]'
+    ]
+  })
+  assert.equal(safe.ok, true)
+  assert.equal(mock.calls.length, 1)
+})
+
+test('native office_document throws runner failures as MCP errors', async () => {
+  const mock = runnerMock()
+  mock.runner.run = async () => ({
+    ok: false,
+    error: { code: 'OFFICECLI_EXIT', message: 'document failed', details: { exitCode: 2 } }
+  })
+  let handler
+  const target = { ztools: { registerTool: (_name, value) => { handler = value } } }
+  attachOfficeSuite(target, mock.runner)
+
+  await assert.rejects(
+    handler({ command: ['validate', '/tmp/report.docx'] }),
+    (error) => error.code === 'OFFICECLI_EXIT' && error.details.exitCode === 2
+  )
+})

--- a/plugins/office-suite-workbench/tests/preload/services.test.cjs
+++ b/plugins/office-suite-workbench/tests/preload/services.test.cjs
@@ -7,6 +7,7 @@ const os = require('node:os')
 const path = require('node:path')
 
 const {
+  AI_TOOL_TIMEOUT_MS,
   MCP_TOOL_TIMEOUT_MS,
   attachOfficeSuite
 } = require('../../preload/services.cjs')
@@ -42,8 +43,50 @@ test('attachOfficeSuite exposes only the fixed narrow UI methods', () => {
     'probeMcp',
     'registerMcp',
     'run',
+    'runForAi',
     'unregisterMcp'
   ])
+})
+
+test('native AI bridge enforces per-turn write approval without weakening MCP policy', async () => {
+  const mock = runnerMock()
+  const target = {}
+  attachOfficeSuite(target, mock.runner)
+
+  const read = await target.officeSuite.runForAi(
+    ['get', '/tmp/report.docx', '/body'],
+    { allowWrite: false }
+  )
+  assert.equal(read.ok, true)
+  assert.deepEqual(mock.calls[0], {
+    name: 'run',
+    args: [
+      ['get', '/tmp/report.docx', '/body'],
+      {
+        timeoutMs: AI_TOOL_TIMEOUT_MS,
+        env: { OFFICECLI_NO_AUTO_RESIDENT: '1' }
+      }
+    ]
+  })
+
+  const blockedWrite = await target.officeSuite.runForAi(
+    ['set', '/tmp/report.docx', '/body/p[1]', '--prop', 'bold=true'],
+    { allowWrite: false }
+  )
+  assert.equal(blockedWrite.ok, false)
+  assert.equal(blockedWrite.error.code, 'AI_WRITE_APPROVAL_REQUIRED')
+  assert.equal(mock.calls.length, 1)
+
+  const allowedWrite = await target.officeSuite.runForAi(
+    ['set', '/tmp/report.docx', '/body/p[1]', '--prop', 'bold=true'],
+    { allowWrite: true }
+  )
+  assert.equal(allowedWrite.ok, true)
+  assert.equal(mock.calls.length, 2)
+
+  const invalidOptions = await target.officeSuite.runForAi('help', { allowWrite: true, env: {} })
+  assert.equal(invalidOptions.ok, false)
+  assert.equal(invalidOptions.error.code, 'INVALID_OPTIONS')
 })
 
 test('renderer bridge rejects hidden runner options before invocation', async () => {

--- a/plugins/office-suite-workbench/tests/preload/services.test.cjs
+++ b/plugins/office-suite-workbench/tests/preload/services.test.cjs
@@ -2,6 +2,9 @@
 
 const test = require('node:test')
 const assert = require('node:assert/strict')
+const fs = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
 
 const {
   MCP_TOOL_TIMEOUT_MS,
@@ -69,6 +72,34 @@ test('renderer bridge rejects hidden runner options before invocation', async ()
     'help',
     { timeoutMs: 5_000 }
   ])
+})
+
+test('renderer bridge embeds standalone OfficeCLI image paths as safe previews', async (t) => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), 'office-suite-preview-'))
+  const imagePath = path.join(directory, 'page 1.png')
+  const textPath = path.join(directory, 'not-an-image.png')
+  await fs.writeFile(imagePath, Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB', 'base64'))
+  await fs.writeFile(textPath, 'not really an image')
+  t.after(() => fs.rm(directory, { recursive: true, force: true }))
+
+  const mock = runnerMock()
+  mock.runner.run = async () => ({
+    ok: true,
+    data: {
+      exitCode: 0,
+      stdout: `${imagePath}\n${imagePath}\n${textPath}\ncreated at ${imagePath}\n`,
+      stderr: ''
+    }
+  })
+  const target = {}
+  attachOfficeSuite(target, mock.runner)
+
+  const result = await target.officeSuite.run(['view', '/tmp/report.docx', 'screenshot'])
+  assert.equal(result.ok, true)
+  assert.equal(result.data.previewImages.length, 1)
+  assert.equal(result.data.previewImages[0].path, await fs.realpath(imagePath))
+  assert.equal(result.data.previewImages[0].mimeType, 'image/png')
+  assert.match(result.data.previewImages[0].dataUrl, /^data:image\/png;base64,/u)
 })
 
 test('native office_document tool registers once and reuses the same runner', async () => {

--- a/plugins/office-suite-workbench/tests/ui_visual_test.py
+++ b/plugins/office-suite-workbench/tests/ui_visual_test.py
@@ -36,6 +36,7 @@ window.officeSuite = {
       }
     };
   },
+  async runForAi(command) { return this.run(command); },
   async getMcpStatus() {
     return { ok: true, data: { raw: 'Claude registered\nCursor not registered', targets: { claude: true, cursor: false } } };
   },
@@ -69,8 +70,27 @@ window.ztools = {
   async showSaveDialog() { return '/tmp/Untitled.docx'; },
   copyText(text) { window.__copiedText = text; },
   async shellOpenExternal() {},
-  async shellOpenPath() {}
-
+  async shellOpenPath() {},
+  async allAiModels() {
+    return [
+      { id: 'deepseek-chat', label: 'DeepSeek Chat', description: 'ZTools configured model' },
+      { id: 'qwen-plus', label: 'Qwen Plus', description: 'Backup model' }
+    ];
+  },
+  ai(options, onChunk) {
+    window.__lastAiOptions = options;
+    const request = Promise.resolve().then(async () => {
+      const toolResult = await window.office_document({
+        operation: 'get',
+        filePath: '/tmp/Annual Report.docx',
+        args: ['/body']
+      });
+      window.__lastAiToolResult = toolResult;
+      onChunk({ role: 'assistant', content: '已通过 ZTools AI 检查当前文档。' });
+    });
+    request.abort = () => { window.__aiAborted = true; };
+    return request;
+  }
 };
 """
 
@@ -131,6 +151,26 @@ def main() -> None:
         assert "Executive summary" in page.locator(".result-drawer pre").inner_text()
         assert page.locator(".result-drawer .result-previews img").is_visible()
         page.locator('.result-drawer button[title="关闭"]').click()
+
+        page.get_by_title("AI 助手").click()
+        page.get_by_role("heading", name="使用你已经配置的 AI。").wait_for()
+        assert page.get_by_role("combobox", name="ZTools AI 模型").input_value() == "deepseek-chat"
+        page.evaluate("window.ztools.showOpenDialog = async () => ['/tmp/Replacement.docx']")
+        page.get_by_role("button", name="更换").click()
+        page.get_by_role("heading", name="使用你已经配置的 AI。").wait_for()
+        page.get_by_text("Replacement.docx", exact=True).wait_for()
+        write_toggle = page.locator(".ai-write-inline input[type='checkbox']")
+        write_toggle.check()
+        assert write_toggle.is_checked()
+        ai_prompt = page.get_by_role("textbox", name="向 Office AI 提问")
+        ai_prompt.fill("检查当前文档")
+        page.get_by_role("button", name="发送").click()
+        page.get_by_text("已通过 ZTools AI 检查当前文档。").wait_for()
+        assert page.evaluate("window.__lastAiOptions.model") == "deepseek-chat"
+        assert page.evaluate("window.__lastAiOptions.tools[0].function.name") == "office_document"
+        assert page.evaluate("window.__lastAiOptions.tools[0].function.parameters.properties.operation.enum.includes('view')") is True
+        assert page.evaluate("window.__lastAiToolResult.ok") is True
+        assert write_toggle.is_checked() is False
 
         page.get_by_title("MCP 接入").click()
         page.get_by_role("heading", name="让 AI 直接操作 Office。").wait_for()

--- a/plugins/office-suite-workbench/tests/ui_visual_test.py
+++ b/plugins/office-suite-workbench/tests/ui_visual_test.py
@@ -1,0 +1,171 @@
+import json
+import os
+import re
+from pathlib import Path
+
+from playwright.sync_api import sync_playwright
+
+
+BASE_URL = "http://127.0.0.1:5188"
+OUTPUT_DIR = Path(os.environ.get("OFFICE_SUITE_VISUAL_OUTPUT", "/tmp/office-suite-visuals"))
+
+
+MOCK_BRIDGE = r"""
+window.officeSuite = {
+  async getStatus() {
+    return { ok: true, data: { installed: true, binaryPath: '/opt/homebrew/bin/officecli', version: '1.0.141' } };
+  },
+  async run(command) {
+    const args = Array.isArray(command) ? command : [command];
+    return {
+      ok: true,
+      data: {
+        command: args[0],
+        args: args.slice(1),
+        exitCode: 0,
+        stdout: JSON.stringify({ success: true, data: { Results: [{ path: '/body/p[1]', text: 'Executive summary' }] } }, null, 2),
+        stderr: '',
+        json: { success: true, data: { Results: [{ path: '/body/p[1]', text: 'Executive summary' }] } },
+        durationMs: 84
+      }
+    };
+  },
+  async getMcpStatus() {
+    return { ok: true, data: { raw: 'Claude registered\nCursor not registered', targets: { claude: true, cursor: false } } };
+  },
+  async registerMcp(target) { return { ok: true, data: { target, stdout: 'registered', stderr: '' } }; },
+  async unregisterMcp(target) { return { ok: true, data: { target, stdout: 'removed', stderr: '' } }; },
+  async probeMcp() {
+    return { ok: true, data: { serverInfo: { name: 'officecli', version: '1.0.141' }, protocolVersion: '2024-11-05', toolNames: ['officecli'] } };
+  },
+  async getMcpConfigs() {
+    const entry = { command: '/opt/homebrew/bin/officecli', args: ['mcp'] };
+    return {
+      ok: true,
+      data: {
+        binaryPath: entry.command,
+        configs: {
+          generic: entry,
+          codex: '[mcp_servers.officecli]\ncommand = "/opt/homebrew/bin/officecli"\nargs = ["mcp"]',
+          claude: { mcpServers: { officecli: entry } },
+          cursor: { mcpServers: { officecli: entry } },
+          vscode: { servers: { officecli: { type: 'stdio', ...entry } } }
+        }
+      }
+    };
+  }
+};
+window.ztools = {
+  onPluginEnter(callback) { window.__pluginEnter = callback; },
+  async showOpenDialog() {
+    return ['/tmp/Annual Report.docx', '/tmp/Budget 2026.xlsx', '/tmp/Launch Deck.pptx'];
+  },
+  async showSaveDialog() { return '/tmp/Untitled.docx'; },
+  copyText(text) { window.__copiedText = text; },
+  async shellOpenExternal() {},
+  async shellOpenPath() {}
+};
+"""
+
+
+def main() -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    console_errors = []
+    page_errors = []
+
+    with sync_playwright() as playwright:
+        chrome_candidates = [
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+        ]
+        executable = next((candidate for candidate in chrome_candidates if Path(candidate).is_file()), None)
+        launch_options = {"headless": True}
+        if executable:
+            launch_options["executable_path"] = executable
+        browser = playwright.chromium.launch(**launch_options)
+        context = browser.new_context(viewport={"width": 1280, "height": 780}, device_scale_factor=1)
+        context.add_init_script(MOCK_BRIDGE)
+        context.add_init_script("localStorage.setItem('office-suite.history', '[null]')")
+        page = context.new_page()
+        page.on("console", lambda message: console_errors.append(message.text) if message.type == "error" else None)
+        page.on("pageerror", lambda error: page_errors.append(str(error)))
+
+        page.goto(BASE_URL)
+        page.wait_for_load_state("networkidle")
+        page.get_by_role("heading", name="一个工作台， 三种文档世界。").wait_for()
+        page.screenshot(path=str(OUTPUT_DIR / "office-suite-home.png"), full_page=True)
+
+        runtime_button = page.get_by_role("button", name=re.compile(r"OfficeCLI 1\.0\.141"))
+        runtime_button.focus()
+        runtime_button.click()
+        dialog = page.get_by_role("dialog", name="OfficeCLI 运行时")
+        dialog.wait_for()
+        assert page.evaluate("document.activeElement?.closest('dialog') !== null")
+        page.keyboard.press("Escape")
+        dialog.wait_for(state="hidden")
+        assert runtime_button.evaluate("element => document.activeElement === element")
+
+        page.get_by_role("button", name="选择文档").click()
+        page.get_by_role("heading", name="Word 工作站").wait_for()
+        assert page.get_by_text("Annual Report.docx").count() >= 1
+        page.get_by_title("总览").click()
+        remove_button = page.get_by_role("button", name="移除 Launch Deck.pptx")
+        remove_button.focus()
+        page.keyboard.press("Enter")
+        assert page.get_by_role("button", name="移除 Launch Deck.pptx").count() == 0
+        page.get_by_title("Word").click()
+        page.get_by_role("heading", name="Word 工作站").wait_for()
+        page.wait_for_timeout(600)
+        page.screenshot(path=str(OUTPUT_DIR / "office-suite-word.png"), full_page=True)
+
+        page.get_by_role("button", name="结构速览 读取文档层级与关键节点").click()
+        page.get_by_text("COMMAND OUTPUT").wait_for()
+        assert "Executive summary" in page.locator(".result-drawer pre").inner_text()
+        page.locator('.result-drawer button[title="关闭"]').click()
+
+        page.get_by_title("MCP 接入").click()
+        page.get_by_role("heading", name="让 AI 直接操作 Office。").wait_for()
+        page.get_by_role("button", name="运行握手").click()
+        page.get_by_text("HANDSHAKE OK").wait_for()
+        page.wait_for_timeout(600)
+        page.screenshot(path=str(OUTPUT_DIR / "office-suite-mcp.png"), full_page=True)
+
+        page.get_by_role("button", name="OfficeCLI stdio 高级 · 直接完整能力").click()
+        page.get_by_role("button", name="Codex", exact=True).click()
+        assert "mcp_servers.officecli" in page.locator(".config-code pre").inner_text()
+
+        page.get_by_title("总览").click()
+        page.evaluate("""window.officeSuite.getMcpConfigs = async () => ({
+          ok: false,
+          error: { code: 'OFFICECLI_NOT_FOUND', message: 'runtime unavailable' }
+        })""")
+        page.get_by_title("MCP 接入").click()
+        page.get_by_role("button", name="OfficeCLI stdio 高级 · 直接完整能力").click()
+        page.get_by_text("读取失败：runtime unavailable").wait_for()
+        assert page.locator(".config-code button").is_disabled()
+
+        page.get_by_title("命令台").click()
+        command_input = page.get_by_role("textbox", name="OfficeCLI 命令")
+        command_input.focus()
+        outline = command_input.evaluate("element => getComputedStyle(element).outlineStyle")
+        assert outline != "none"
+
+        browser.close()
+
+    summary = {
+        "screenshots": [
+            str(OUTPUT_DIR / "office-suite-home.png"),
+            str(OUTPUT_DIR / "office-suite-word.png"),
+            str(OUTPUT_DIR / "office-suite-mcp.png"),
+        ],
+        "console_errors": console_errors,
+        "page_errors": page_errors,
+    }
+    print(json.dumps(summary, ensure_ascii=False, indent=2))
+    if console_errors or page_errors:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/office-suite-workbench/tests/ui_visual_test.py
+++ b/plugins/office-suite-workbench/tests/ui_visual_test.py
@@ -26,7 +26,13 @@ window.officeSuite = {
         stdout: JSON.stringify({ success: true, data: { Results: [{ path: '/body/p[1]', text: 'Executive summary' }] } }, null, 2),
         stderr: '',
         json: { success: true, data: { Results: [{ path: '/body/p[1]', text: 'Executive summary' }] } },
-        durationMs: 84
+        durationMs: 84,
+        previewImages: [{
+          path: '/tmp/officecli-preview.png',
+          mimeType: 'image/png',
+          size: 68,
+          dataUrl: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+        }]
       }
     };
   },
@@ -64,6 +70,7 @@ window.ztools = {
   copyText(text) { window.__copiedText = text; },
   async shellOpenExternal() {},
   async shellOpenPath() {}
+
 };
 """
 
@@ -122,6 +129,7 @@ def main() -> None:
         page.get_by_role("button", name="结构速览 读取文档层级与关键节点").click()
         page.get_by_text("COMMAND OUTPUT").wait_for()
         assert "Executive summary" in page.locator(".result-drawer pre").inner_text()
+        assert page.locator(".result-drawer .result-previews img").is_visible()
         page.locator('.result-drawer button[title="关闭"]').click()
 
         page.get_by_title("MCP 接入").click()

--- a/plugins/office-suite-workbench/tests/unit/ai.test.ts
+++ b/plugins/office-suite-workbench/tests/unit/ai.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeOfficeAiToolInput } from "../../src/lib/ai";
+
+const documentPath = "/Users/harris/Downloads/1111.docx";
+
+describe("normalizeOfficeAiToolInput", () => {
+  it("builds structured OfficeCLI argv and uses the selected document", () => {
+    expect(normalizeOfficeAiToolInput({ operation: "view", args: ["stats", "--json"] }, documentPath))
+      .toEqual(["view", documentPath, "stats", "--json"]);
+    expect(normalizeOfficeAiToolInput({ operation: "set", args: ["/body/p[1]", "--prop", "bold=true"] }, documentPath))
+      .toEqual(["set", documentPath, "/body/p[1]", "--prop", "bold=true"]);
+  });
+
+  it("repairs the path-first and read inputs observed from native AI", () => {
+    expect(normalizeOfficeAiToolInput({ operation: documentPath }))
+      .toEqual(["view", documentPath, "text"]);
+    expect(normalizeOfficeAiToolInput({ operation: "read", filePath: documentPath }))
+      .toEqual(["view", documentPath, "text"]);
+    expect(normalizeOfficeAiToolInput({ command: documentPath }))
+      .toEqual(["view", documentPath, "text"]);
+    expect(normalizeOfficeAiToolInput({ command: "read" }, documentPath))
+      .toEqual(["view", documentPath, "text"]);
+  });
+
+  it("rejects ambiguous operations and invalid argument shapes", () => {
+    expect(() => normalizeOfficeAiToolInput({ operation: "summarize" }, documentPath))
+      .toThrow(/Unsupported office_document operation/u);
+    expect(() => normalizeOfficeAiToolInput({ operation: "view", args: "text" }, documentPath))
+      .toThrow(/array of strings/u);
+  });
+});

--- a/plugins/office-suite-workbench/tests/unit/commands.test.ts
+++ b/plugins/office-suite-workbench/tests/unit/commands.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildQuickCommand,
+  detectFormat,
+  formatCommand,
+  normalizeFilePayload,
+  quoteArgument
+} from "../../src/lib/commands";
+
+describe("Office command builders", () => {
+  it("detects the three supported OpenXML formats case-insensitively", () => {
+    expect(detectFormat("report.DOCX")).toBe("word");
+    expect(detectFormat("book.xlsx")).toBe("excel");
+    expect(detectFormat("deck.pptx")).toBe("powerpoint");
+    expect(detectFormat("legacy.doc")).toBeNull();
+  });
+
+  it("uses argv arrays so paths with spaces remain one argument", () => {
+    expect(buildQuickCommand("issues", "/tmp/Q4 report.docx")).toEqual([
+      "view",
+      "/tmp/Q4 report.docx",
+      "issues",
+      "--limit",
+      "100",
+      "--json"
+    ]);
+  });
+
+  it("quotes display commands without changing their meaning", () => {
+    expect(quoteArgument("/tmp/Q4 report.docx")).toBe('"/tmp/Q4 report.docx"');
+    expect(formatCommand(["get", "/tmp/Q4 report.docx", "/body/p[1]"])).toBe(
+      'get "/tmp/Q4 report.docx" "/body/p[1]"'
+    );
+  });
+
+  it("normalizes file launch payloads from common ZTools shapes", () => {
+    expect(
+      normalizeFilePayload({ payload: [{ path: "/tmp/a.docx" }, { filePath: "/tmp/b.xlsx" }] })
+    ).toEqual(["/tmp/a.docx", "/tmp/b.xlsx"]);
+  });
+});

--- a/plugins/office-suite-workbench/tests/unit/history.test.ts
+++ b/plugins/office-suite-workbench/tests/unit/history.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { parseStoredHistory } from "../../src/lib/history";
+
+describe("stored Office history", () => {
+  it("keeps valid history records and enforces the storage limit", () => {
+    const records = Array.from({ length: 15 }, (_, index) => ({
+      id: String(index),
+      label: `Run ${index}`,
+      command: "help",
+      ok: true,
+      at: "2026-07-24T00:00:00.000Z"
+    }));
+
+    expect(parseStoredHistory(JSON.stringify(records))).toHaveLength(12);
+  });
+
+  it("filters corrupt and legacy records instead of crashing the UI", () => {
+    const valid = {
+      id: "valid",
+      label: "Validate",
+      command: "validate /tmp/report.docx",
+      ok: true,
+      at: "2026-07-24T00:00:00.000Z"
+    };
+
+    expect(parseStoredHistory(JSON.stringify([null, {}, { ...valid, ok: "yes" }, valid]))).toEqual([valid]);
+    expect(parseStoredHistory("not-json")).toEqual([]);
+    expect(parseStoredHistory(JSON.stringify({ records: [valid] }))).toEqual([]);
+  });
+});

--- a/plugins/office-suite-workbench/tsconfig.json
+++ b/plugins/office-suite-workbench/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client", "vitest/globals"]
+  },
+  "include": ["src", "tests/unit", "vite.config.ts"]
+}

--- a/plugins/office-suite-workbench/vite.config.ts
+++ b/plugins/office-suite-workbench/vite.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  base: "./",
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+    sourcemap: false
+  },
+  server: {
+    host: "127.0.0.1",
+    port: 5188
+  }
+});


### PR DESCRIPTION
## Summary

- Add an OfficeCLI-powered workbench for Word, Excel, and PowerPoint documents.
- Reuse ZTools-configured AI providers with structured Office tool calls and single-turn write authorization.
- Expose the protected `office_document` tool through ZTools MCP for external AI clients.
- Render verified local image output directly in the command result panel.

## Verification

- `npm run build`
- 9 unit tests passed
- 26 preload and security-policy tests passed
- TypeScript and production bundle verification passed
- Browser visual regression passed with no console or page errors

## Notes

- OfficeCLI remains an external runtime dependency and is not bundled with the plugin.
- The PR is opened as a draft for maintainer review.