### PR TITLE
fix: repair goose notes CI build

### DIFF
--- a/plugins/goose-notes/README.md
+++ b/plugins/goose-notes/README.md
@@ -12,6 +12,9 @@
 主插件产物位于 `dist/`。同一构建还会生成尚未发布的速记候选产物
 `dist-quicknote-ztools/`，用于后续独立窗口真机验证。
 
+上游通过自己的 `.gitignore` 排除了 `scripts/`。构建所需的 `utools-build.js`
+因此保存在 `compat/upstream-scripts/`，构建前会自动恢复到上游期望的位置。
+
 ## 同步上游
 
 ```bash

--- a/plugins/goose-notes/build-plugin.sh
+++ b/plugins/goose-notes/build-plugin.sh
@@ -3,6 +3,16 @@ set -euo pipefail
 
 PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 UPSTREAM_DIR="${PLUGIN_DIR}/upstream"
+UPSTREAM_BUILD_SCRIPT="${UPSTREAM_DIR}/scripts/utools-build.js"
+COMPAT_BUILD_SCRIPT="${PLUGIN_DIR}/compat/upstream-scripts/utools-build.js"
+
+if [ ! -f "${COMPAT_BUILD_SCRIPT}" ]; then
+  echo "缺少受控的上游构建脚本: ${COMPAT_BUILD_SCRIPT}" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "${UPSTREAM_BUILD_SCRIPT}")"
+cp "${COMPAT_BUILD_SCRIPT}" "${UPSTREAM_BUILD_SCRIPT}"
 
 if command -v bun >/dev/null 2>&1; then
   BUN_COMMAND=(bun)

--- a/plugins/goose-notes/compat/upstream-scripts/utools-build.js
+++ b/plugins/goose-notes/compat/upstream-scripts/utools-build.js
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const distDir = path.resolve('dist');
+const rootDir = path.resolve('.');
+
+if (!fs.existsSync(distDir)) {
+  console.error('dist 目录不存在');
+  process.exit(1);
+}
+
+const removeMapFiles = (dir) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      removeMapFiles(full);
+    } else if (entry.name.endsWith('.map')) {
+      fs.unlinkSync(full);
+    }
+  }
+};
+
+try {
+  const preloadSrc = path.join(rootDir, 'preload/preload.cjs');
+  if (fs.existsSync(preloadSrc)) {
+    fs.copyFileSync(preloadSrc, path.join(distDir, 'preload.js'));
+  }
+
+  const preloadHelperSrc = path.join(rootDir, 'preload/mcp-tools.cjs');
+  if (fs.existsSync(preloadHelperSrc)) {
+    fs.copyFileSync(preloadHelperSrc, path.join(distDir, 'mcp-tools.cjs'));
+  }
+
+  const webFetchHelperSrc = path.join(rootDir, 'preload/web-fetch.cjs');
+  if (fs.existsSync(webFetchHelperSrc)) {
+    fs.copyFileSync(webFetchHelperSrc, path.join(distDir, 'web-fetch.cjs'));
+  }
+
+  fs.writeFileSync(path.join(distDir, 'package.json'), JSON.stringify({ type: 'commonjs' }));
+
+  const logoSrc = path.join(rootDir, 'public/logo.png');
+  if (fs.existsSync(logoSrc)) {
+    fs.copyFileSync(logoSrc, path.join(distDir, 'logo.png'));
+  }
+
+  const pluginConfigPath = path.join(rootDir, 'plugin.json');
+  if (fs.existsSync(pluginConfigPath)) {
+    const pluginConfig = JSON.parse(fs.readFileSync(pluginConfigPath, 'utf-8'));
+    pluginConfig.main = 'index.html';
+    pluginConfig.preload = 'preload.js';
+    fs.writeFileSync(path.join(distDir, 'plugin.json'), JSON.stringify(pluginConfig, null, 2));
+  } else {
+    console.error('未找到 plugin.json');
+    process.exit(1);
+  }
+
+  if (process.env.GOOSE_DEBUG === '1') {
+    console.log('[utools-build] GOOSE_DEBUG=1：保留 sourcemap (.map) 文件');
+  } else {
+    removeMapFiles(distDir);
+  }
+} catch (e) {
+  console.error(e);
+  process.exit(1);
+}
+
+const distQuicknoteDir = path.resolve('dist-quicknote');
+
+try {
+  if (!fs.existsSync(distQuicknoteDir)) {
+    console.error('dist-quicknote 目录不存在——请先执行 quicknote 构建：GOOSE_BUILD_TARGET=quicknote vite build');
+    process.exit(1);
+  }
+
+  const preloadQnSrc = path.join(rootDir, 'preload/preload-quicknote.cjs');
+  if (fs.existsSync(preloadQnSrc)) {
+    fs.copyFileSync(preloadQnSrc, path.join(distQuicknoteDir, 'preload-quicknote.js'));
+  } else {
+    console.error('未找到 preload/preload-quicknote.cjs');
+    process.exit(1);
+  }
+
+  const qnPluginSrc = path.join(rootDir, 'quicknote-plugin.json');
+  if (fs.existsSync(qnPluginSrc)) {
+    const qnPluginConfig = JSON.parse(fs.readFileSync(qnPluginSrc, 'utf-8'));
+    qnPluginConfig.preload = 'preload-quicknote.js';
+    fs.writeFileSync(path.join(distQuicknoteDir, 'plugin.json'), JSON.stringify(qnPluginConfig, null, 2));
+  } else {
+    console.error('未找到 quicknote-plugin.json');
+    process.exit(1);
+  }
+
+  const qnLogo = path.join(distQuicknoteDir, 'logo.png');
+  if (!fs.existsSync(qnLogo)) {
+    const publicLogo = path.join(rootDir, 'public/logo.png');
+    if (fs.existsSync(publicLogo)) {
+      fs.copyFileSync(publicLogo, qnLogo);
+    }
+  }
+
+  fs.writeFileSync(path.join(distQuicknoteDir, 'package.json'), JSON.stringify({ type: 'commonjs' }));
+
+  if (process.env.GOOSE_DEBUG === '1') {
+    console.log('[utools-build] GOOSE_DEBUG=1：dist-quicknote 保留 sourcemap (.map) 文件');
+  } else {
+    removeMapFiles(distQuicknoteDir);
+  }
+
+  console.log('[utools-build] dist-quicknote/ 产出完成');
+} catch (e) {
+  console.error(e);
+  process.exit(1);
+}

--- a/plugins/goose-notes/scripts/sync-upstream.mjs
+++ b/plugins/goose-notes/scripts/sync-upstream.mjs
@@ -3,6 +3,7 @@ import { execFileSync } from 'node:child_process'
 import {
   cpSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -18,6 +19,12 @@ const pluginDir = resolve(scriptDir, '..')
 const upstreamDir = join(pluginDir, 'upstream')
 const lockPath = join(pluginDir, 'upstream.lock.json')
 const metaPath = join(pluginDir, 'compat', 'plugin-meta.json')
+const compatBuildScriptPath = join(
+  pluginDir,
+  'compat',
+  'upstream-scripts',
+  'utools-build.js'
+)
 const pluginManifestPath = join(pluginDir, 'plugin.json')
 const repository = 'https://github.com/eachann1024/goose-notes.git'
 
@@ -63,9 +70,19 @@ try {
     encoding: 'utf8'
   }).trim()
 
-  if (previousLock?.sha === sha && existsSync(upstreamDir) && !force) {
+  if (
+    previousLock?.sha === sha &&
+    existsSync(upstreamDir) &&
+    existsSync(compatBuildScriptPath) &&
+    !force
+  ) {
     console.log(`goose-notes 已是目标版本: ${sha}`)
     process.exit(0)
+  }
+
+  const checkoutBuildScriptPath = join(checkoutDir, 'scripts', 'utools-build.js')
+  if (!existsSync(checkoutBuildScriptPath)) {
+    throw new Error(`上游缺少构建脚本: ${checkoutBuildScriptPath}`)
   }
 
   const nextVersion = requestedVersion || (previousLock ? bumpPatch(meta.version) : meta.version)
@@ -79,6 +96,9 @@ try {
       return !['.git', 'node_modules', 'dist', 'dist-quicknote', 'output'].includes(name)
     }
   })
+
+  mkdirSync(dirname(compatBuildScriptPath), { recursive: true })
+  cpSync(checkoutBuildScriptPath, compatBuildScriptPath)
 
   const upstreamManifest = readJson(join(upstreamDir, 'plugin.json'))
   const upstreamPackage = readJson(join(upstreamDir, 'package.json'))

--- a/plugins/goose-notes/scripts/verify-dist.mjs
+++ b/plugins/goose-notes/scripts/verify-dist.mjs
@@ -8,6 +8,12 @@ const pluginDir = resolve(scriptDir, '..')
 const upstreamDir = join(pluginDir, 'upstream')
 const mainDist = join(pluginDir, 'dist')
 const quicknoteDist = join(pluginDir, 'dist-quicknote-ztools')
+const compatBuildScript = join(
+  pluginDir,
+  'compat',
+  'upstream-scripts',
+  'utools-build.js'
+)
 const contract = JSON.parse(
   readFileSync(join(pluginDir, 'compat', 'api-contract.json'), 'utf8')
 )
@@ -15,6 +21,8 @@ const contract = JSON.parse(
 const assert = (condition, message) => {
   if (!condition) throw new Error(message)
 }
+
+assert(existsSync(compatBuildScript), `缺少受控的上游构建脚本: ${compatBuildScript}`)
 
 const walk = (directory) => readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
   const path = join(directory, entry.name)

--- a/scripts/detect-changes.js
+++ b/scripts/detect-changes.js
@@ -87,7 +87,17 @@ function detectChangedPlugins() {
       }
     });
 
-    return Array.from(changedPlugins);
+    const existingPlugins = Array.from(changedPlugins).filter(name => {
+      const pluginPath = join(PLUGINS_DIR, name);
+      return existsSync(pluginPath) && statSync(pluginPath).isDirectory();
+    });
+    const deletedPlugins = Array.from(changedPlugins).filter(name => !existingPlugins.includes(name));
+
+    if (deletedPlugins.length > 0) {
+      console.log(`忽略已删除的插件目录: ${deletedPlugins.join(', ')}`);
+    }
+
+    return existingPlugins;
   } catch (error) {
     console.log('无法检测git变动，可能是首次提交，构建所有插件');
     return getAllPlugins();


### PR DESCRIPTION
修复 goose-notes 在线构建失败：\n\n- 将被上游 .gitignore 排除的 utools-build.js 保存为受控兼容文件，并在构建前恢复\n- 同步上游时同步刷新该受控构建脚本\n- 变更检测忽略已经删除的插件目录，避免继续构建 goose-note\n\n本地已通过干净 clone 构建、兼容契约检查和仓库级 ZIP 打包。