### PR TITLE
Update plugin PDF处理 v1.0.1

### DIFF
--- a/plugins/pdf-process/package-lock.json
+++ b/plugins/pdf-process/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pdf-process",
-  "version": "0.9.9",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pdf-process",
-      "version": "0.9.9",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "dependencies": {
         "jpeg-js": "^0.4.4",

--- a/plugins/pdf-process/package.json
+++ b/plugins/pdf-process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-process",
-  "version": "0.9.9",
+  "version": "1.0.1",
   "description": "",
   "type": "module",
   "scripts": {

--- a/plugins/pdf-process/public/plugin.json
+++ b/plugins/pdf-process/public/plugin.json
@@ -5,7 +5,7 @@
   "description": "PDF 压缩、合并、拆分、水印、格式转换等工具",
   "author": "Taitres",
   "homepage": "https://github.com/Taitres/pdf-process",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.html",
   "preload": "preload/services.js",
   "logo": "logo.png",


### PR DESCRIPTION
## 插件信息

- **名称**: PDF处理
- **插件ID**: pdf-process
- **版本**: 1.0.1
- **描述**: PDF 压缩、合并、拆分、水印、格式转换等工具
- **作者**: Taitres
- **类型**: 更新

## 本次变更

- Initial commit
- chore: add pdf-lib dependency
- feat: configure all PDF features in plugin.json
- feat: add TypeScript types for PDF services
- feat: add Sidebar component
- feat: add FileUpload component
- feat: add Settings component
- feat: add feature routing in App.tsx
- feat: add PDF processing services to preload
- feat: add PDF compress feature
- feat: add PDF merge feature
- feat: add PDF split feature
- feat: add PDF watermark feature
- feat: add extract images feature
- feat: add PDF to image feature
- feat: add PDF to Word feature (mock)
- feat: add PDF to PPT feature (mock)
- feat: add PDF to Excel feature (mock)
- feat: add PDF edit feature (placeholder)
- chore: final build and cleanup
- fix: 13 bugs - services APIs, React types, settings JSON, watermark centering
- fix: use getPathForFile for all FileUpload features, embed CJK font for Chinese watermarks
- fix: Chinese watermark with subset font, extractImages stream decode, compression quality slider, pdfToImage via system ImageMagick
- chore: archive audit-and-repair
- chore: fix archive metadata paths
- fix: ensure output directory exists for compressPdf, mergePdfs, addWatermark
- tweak: remove extractImages, fix splitPdf ranges, fix addWatermark syntax
- chore: add .worktrees to gitignore
- 1
- chore: remove accidentally tracked .worktrees and Windows residue
- chore: gitignore .worktrees, .comet, %SystemDrive% to prevent future accidental tracking
- docs: update ZTools developer documentation
- tweak: 优化前端和操作逻辑，统一 UI 组件与交互
- docs: design doc for pure local PDF→Word/PPT/Excel conversion
- fix: pdfcpu watermark 改为正确位置参数语法，CJK 字体自动检测 feat: 每个操作隔离到独立任务文件夹（useTaskFolder hook）
- chore: archive local-pdf-to-word-mammoth change (branch deleted)
- fix: pdfcpu 字体名映射 + 每次操作生成独立任务文件夹
- fix: 自动安装完整 CJK 字体到 pdfcpu，修复水印不可见
- docs: design doc for portable LibreOffice local PDF-to-Office conversion
- docs: implementation plan for portable LibreOffice PDF-to-Office conversion
- feat: update Services/SettingsData types for portable LO and remove cloud API fields
- feat: add useLibreOffice hook for portable LO lifecycle
- fix: add source fallback, unmount safety, useCallback wrappers to useLibreOffice
- feat: add LONotInstalledBanner component for LO missing prompt
- feat: add PdfToWord component with LO detection
- feat: add PdfToPpt component with LO detection
- feat: add PdfToExcel component with LO detection
- feat: wire up PdfToWord/Ppt/Excel routes and onOpenSettings prop in App
- feat: replace cloud API UI with LibreOffice management in Settings
- test: update mock services and rewrite Settings tests for LO management UI
- feat: implement downloadFile/cancelDownload/uninstallLibreOffice in services.js for portable LO
- fix: update LO portable URL to 26.2.4 paf.exe, handle paf extraction via 7z/silent
- fix: paf.exe extraction - use 7z with fallback, recursive soffice search, correct file extension
- fix: setCustomPath now calls installLibreOffice, support directory paths for pre-extracted LO
- fix: strip trailing slashes from path, call 7z directly via Node, better error logging per step
- feat: bundle 7zr.exe in bin/, use as primary extraction method before 7z/Expand-Archive/silent
- fix: replace 7zr.exe with 7za.exe (NSIS support) to extract paf.exe archives
- fix: suppress LO first-run wizard — add SAL_USE_VCLPLUGIN=svp, pre-create profile, --nofirststartwizard, capture stdout
- feat(ai): add DocumentSchema normalize and fixtures
- fix(ai): drop out-of-scope convert scripts from Task 1 package.json
- feat(ai): write Word via docx from DocumentSchema
- feat(ai): write Excel and PPT from DocumentSchema via Node
- feat(ai): extract per-page PDF text with pdfjs in preload
- feat(ai): OpenAI and Anthropic compatible JSON completion client
- feat(ai): wire convertPdfAi orchestration into preload services
- feat(ai): settings UI for OpenAI/Anthropic conversion config
- feat(ai): local/AI mode toggle on PDF convert pages
- docs: document AI convert mode and setup
- test: exclude preload AI tests from jsdom suite (use test:ai)
- fix(build): restore publicDir so vite copies public/ into dist
- fix(ai): lazy-load convert stack, cancel toast, unique sheets, batch test
- refactor(convert): drop convert.exe; PDF to Office is AI-only
- fix(ai): set pdfjs workerSrc for Electron preload (asar-safe)
- fix(ai): cMap via fs factory + vision fallback for scan PDFs
- feat: remove PDF edit; local convert fallback without API
- v0.9
- v0.9.5
- v0.9.6
- v0.9.7
- v0.9.8
- v0.9.9
- fix(0.9.9): path-added files get preview, selection, and drop-to-add
- v1.0.0
- fix(0.9.9): import files from ZTools super panel onPluginEnter
- v1.0.0 preview
- v1.0.0 review
- Add preload dependency installation hooks
- fix: install preload deps in ci
- chore: bump plugin version to 1.0.1

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/pdf-process/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
