### PR TITLE
Update plugin ZTools 提供商 v1.0.5

### DIFF
--- a/plugins/f-provider/README.md
+++ b/plugins/f-provider/README.md
@@ -4,9 +4,9 @@
 
 <img src="./public/logo.png" alt="Logo" width="120">
 
-**一个 ZTools 提供商插件，把本地 OCR 与多家翻译封装为可复用的「OCR / 翻译提供商」**
+**一个 ZTools 提供商插件，把离线 OCR 与多家翻译封装为可复用的「OCR / 翻译提供商」**
 
-_微信 OCR 离线识别 · 百度 / 谷歌 / 有道 / 微软翻译 · 代码命名翻译_
+_微信 OCR 离线识别 · LaTeX 公式识别 · 百度 / 谷歌 / 有道 / 微软翻译 · 代码命名翻译_
 
 [![License](https://img.shields.io/badge/license-MIT-green)](./LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue)](#-平台与限制)
@@ -18,15 +18,17 @@ _微信 OCR 离线识别 · 百度 / 谷歌 / 有道 / 微软翻译 · 代码命
 
 ## ✨ 特性
 
-- 🔍 **离线 OCR** - 复用本机微信内置 OCR 引擎，无需联网即可识别图片文字，带坐标逐行结果
+- 🔍 **离线 OCR** - 调用微信 OCR 引擎（Windows 子进程 / macOS 动态库），离线识别图片文字，带坐标逐行结果。运行时文件随插件下载
+- 📐 **公式识别** - 基于 onnxruntime-node + pix2tex ONNX 模型，离线把图片中的数学公式识别为 LaTeX（Mac/Win 双端）
 - 🌐 **多家翻译** - 百度 / 谷歌 / 有道 / 微软四种翻译提供商，统一接口、可设默认、凭据隔离
 - 🧩 **Provider 抽象** - 以「提供商」形式注册进 ZTools，主程序与任意插件均可复用
 - ⌨️ **代码翻译** - 把中文（或任意文本）翻译为英文，并生成 8 种代码命名风格候选，纯键盘操作
 - 📸 **截图识别** - 进入即自动截屏框选区域，识别出文字并可视化悬浮在原图上，可点选复制
-- 🖼️ **图片识别** - 拖入 / 选择图片即识别，canvas 绘图 + 透明文字层，支持全屏缩放拖动
+- 🖼️ **图片识别** - 拖入 / 选择图片即识别，文字模式用 canvas 绘图 + 透明文字层，公式模式用 KaTeX 渲染；支持全屏缩放拖动
 - 🔁 **自动翻译** - 原文变化 1s 自动重译，支持语言互换、自动推断目标语言
+- 📜 **历史记录** - OCR / 翻译结果按条目落盘到 `ztools.dbStorage`，管理页「历史记录」tab 可回看复制
 - 🔒 **凭据安全** - 敏感凭据按插件命名空间隔离存入 `ztools.dbStorage`
-- 🌍 **跨平台** - 翻译部分全平台可用，OCR 部分依赖 Windows 原生运行时
+- 🌍 **跨平台** - 翻译全平台可用；微信 OCR 与 LaTeX 公式识别覆盖 Windows + macOS（Linux 仅翻译）
 
 ## 📸 预览
 
@@ -55,7 +57,7 @@ _微信 OCR 离线识别 · 百度 / 谷歌 / 有道 / 微软翻译 · 代码命
 
 ## 🚀 快速开始
 
-> `npm install` 只安装前端依赖；native 的依赖在 `build:native` 时自动安装，**不会**联网下载专有文件，也不会编译原生模块。
+> `npm install` 只安装前端依赖；native 的依赖在 `build:native` 时自动安装。OCR 专有运行时（`wco_data` / `wechat-ocr-mac`）与 LaTeX 模型分别在 build 时从 NuGet / GitHub Release 拉取，**不**读取本机已装的微信，也不会随仓库分发。
 
 ### 安装依赖
 
@@ -67,20 +69,21 @@ npm install        # 仅装前端依赖；native 的依赖会在 build 时自动
 
 ```bash
 npm run build      # 前端打包：vue-tsc + vite build，产物在 dist/
-npm run build:native  # 构建 native 模块（Windows 原生 OCR 运行时）
+npm run build:native  # 编译 native 模块（wechat_ocr.node，Win/Mac 分别在对应 CI 上构建）
+npm run fetch:latex  # 拉取 LaTeX OCR 模型到 dist/latex/models/
 ```
 
-native 部分由 GitHub Actions 在打 tag 时自动构建并发布。
+native 与 LaTeX 引擎的 per-platform zip 由 GitHub Actions 在打 `v*` tag 时自动构建并发布到 Release（`native-win.zip` / `native-mac.zip` / `latex-ort-{win,mac}.zip` / `latex-models.zip`）。插件首次使用时由前端下载这些 Release 资产到 `<userData>/f-provider`，不走本机微信。
 
 ### 使用
 
-1. 安装插件后，OCR 引擎会在首次调用时自动拉起（仅 Windows）
+1. 安装插件后，OCR / LaTeX 引擎会在首次调用时提示下载对应平台的 Release 资产（Windows / macOS）
 2. 在「设置 → 提供商」中启用 / 设为默认 OCR 与翻译提供商
 3. 主搜索框输入 `ZTools 提供商` 进入管理页，配置翻译凭据
 
 ## 🔌 作为 Provider 接入
 
-本插件在 `plugin.json` 声明了 5 个 provider：`ocr` 与 `baidu` / `google` / `youdao` / `microsoft`（均为 `translation` 类型），并在 preload 中调用 `ztools.registerProvider(<key>, handler)` 注册实现。
+本插件在 `plugin.json` 声明了 6 个 provider：2 个 `ocr` 类型（`ocr` = 微信 OCR、`latex-ocr` = 公式识别）与 4 个 `translation` 类型（`baidu` / `google` / `youdao` / `microsoft`），并在 preload 中调用 `ztools.registerProvider(<key>, handler)` 注册实现。
 
 - 安装后，「设置 → 提供商」的「OCR」「翻译」tab 会分别列出这些 provider，可启用 / 设为默认
 - 任何插件都可通过消费方 API 复用：
@@ -96,7 +99,7 @@ const { text, detectedFrom } = await ztools.translate('hello', { from: 'en', to:
 await ztools.providers.invokeProvider('baidu', { text: 'hello', from: 'en', to: 'zh-CN' })
 ```
 
-**OCR 契约**：输入 `{ image, lang? }`（`image` 为本地路径 / `data:` URI / `http(s)` URL），输出 `{ text, blocks?, confidence? }`。
+**OCR 契约**：输入 `{ image, lang? }`（`image` 为本地路径 / `data:` URI / `http(s)` URL），输出 `{ text, blocks?, confidence? }`。微信 OCR 返回逐行 `blocks`；`latex-ocr` 把整段公式作为单元素 `blocks` 返回，`text` 为 LaTeX 源码。
 
 **翻译契约**（对齐宿主 `TranslationInput/Output`）：输入 `{ text, from?, to? }`（`from`/`to` 为语言码字符串，缺省视为自动检测 / 默认目标），输出 `{ text, detectedFrom? }`。语言码使用中性字符串：`auto` / `zh-CN` / `zh-TW` / `yue` / `en` / `ja` / `ko` / `fr` / `es` / `ru` / `de` / `it` / `tr` / `pt-PT` / `pt-BR` / `vi` / `id` / `th` / `ms` / `ar` / `hi` / `mn-Cyrl` / `mn-Mong` / `km` / `nb` / `nn` / `fa` / `sv` / `pl` / `nl` / `uk` / `uz`，各 provider 内部再映射到自家 API 的语种代码。
 
@@ -107,54 +110,74 @@ await ztools.providers.invokeProvider('baidu', { text: 'hello', from: 'en', to: 
 | 百度 | ✅ | AppID / AppKey |
 | 有道 | ✅ | AppKey / AppSecret |
 | 微软 | ✅ | 鉴权方案（Edge Token 或 Signature） |
-| 谷歌 | ❌ | 免费反代端点，无需凭据 |
+| 谷歌 | ❌ | 官方 `translate.googleapis.com` 端点（`client=gtx`），无需凭据；国内需走系统代理 |
 
-凭据在「ZTools 提供商管理」入口（feature `code: manage`）侧边栏的「翻译设置」子页填写并保存。敏感字段统一存入 `ztools.dbStorage`（按插件命名空间隔离），键名 `translate.<provider>`。
+凭据在「ZTools 提供商管理」入口（feature `code: manage`）侧边栏的「设置」子页填写并保存。敏感字段统一存入 `ztools.dbStorage`（按插件命名空间隔离），键名 `translate.<provider>`。
 
 ## 🧩 功能详解
 
-本插件提供**三个 feature**：
+本插件提供**五个 feature**：
 
 ### `code: manage` — 管理页
 
 通过不同类型 cmd 承载多种入口，全部进入同一管理页，根据进入方式自动切到对应 tab：
 
 - **关键词进入**（`text` 型 cmd `ZTools 提供商`）：可被搜索（支持拼音），默认打开「设置」tab
-- **图片进入**（`img` / `files` 匹配型 cmd）：拖入或选择图片文件后，自动切到「识别」tab，展示原图预览并用该图片跑 OCR，展示带坐标的逐行结果。仅 Windows
-- **文本翻译进入**（`regex` 型 cmd `翻译`，`match: ^[\s\S]*$`）：在主搜索框输入任意文本即可命中，进入后自动切到「翻译」tab，预填该文本并触发一次翻译
+- **图片进入**（`img` / `files` 匹配型 cmd `识别图片文字`）：拖入或选择图片文件后，自动切到「OCR 识别」tab 的**文字**模式，展示原图预览并用该图片跑微信 OCR，展示带坐标的逐行结果
+- **文本翻译进入**（`over` 型 cmd `翻译`，`minLength: 1`）：在主搜索框输入任意文本即可命中，进入后自动切到「翻译」tab，预填该文本并触发一次翻译
 
-管理页侧边栏子页（无分组，平铺）：
+管理页底部悬浮导航（无分组，平铺）：
 
-- **设置** - OCR 引擎 + 翻译服务卡片网格（凭据 / 鉴权方案）
-- **识别** - 选图 / 拖拽 / 粘贴识别，画布绘制原图 + 透明文字层可点选复制；超级面板选图会先转 data URI 展示原图
+- **设置** - 微信 OCR 引擎 + LaTeX 引擎 + 翻译服务卡片网格（凭据 / 鉴权方案 / 引擎下载）
+- **OCR 识别** - 同一页顶部切「文字 / 公式」两种模式，保留同一张图片与各自结果互不干扰
+  - 文字模式：选图 / 拖拽 / 粘贴识别，画布绘制原图 + 透明文字层可点选复制；超级面板选图会先转 data URI 展示原图
+  - 公式模式：`<img>` 预览原图 + 右侧 KaTeX 渲染 + LaTeX 源码 + 三种复制形式（源码 / 渲染文本 / 图片）
 - **翻译** - 单 provider 实用翻译器，原文/译文左右结构、原文可编辑、顶部「自动翻译」开关——开启后原文变化 1s 自动重译，支持语言互换、自动推断目标语言
-- **批量测试** - 四 provider 并发对比，供验证凭据
+- **历史记录** - OCR 与翻译的结果条目按时间倒序列出，点击复用 / 复制；落盘到 `ztools.dbStorage`，切 tab 保留
 
-> OCR 子页在非 Windows 下打开会显示「引擎未就绪」并引导下载；翻译相关子页全平台可用。
+> 引擎未就绪时，「OCR 识别」页会渲染下载卡片（可下载自救），下载就绪后自动补一次当前模式的识别；翻译相关子页全平台可用。
 
 ### `code: code-translate` — 代码翻译
 
 把选中的中文文本（或任意文本）翻译为英文，再按多种代码命名风格生成候选列表，纯键盘操作：
 
-- **进入**（`regex` 型 cmd `代码翻译`，`match: ^[\s\S]*$`）：主搜索框输入任意文本即可命中
+- **进入**（`over` 型 cmd `代码翻译`，`minLength: 1`）：主搜索框输入任意文本即可命中
 - **流程** - 含中文的文本经 translation provider（默认 microsoft → google → baidu → youdao 降级）翻译到英文（`auto` → `en`）；纯 ASCII 文本跳过翻译直接转换
 - **候选风格（8 种）** - camelCase、PascalCase、snake_case、CONSTANT_CASE、kebab-case、camel_Snake（混合下划线+驼峰）、Pascal_Snake、flatcase（全小写无分隔）、UPPERFLAT（全大写无分隔）
 - **键盘** - `↑` / `↓`（或 `Tab` / `Shift+Tab`）环形切换候选、`Enter` 确认、`Esc` 取消；也支持鼠标 hover/click
 - **确认动作** - `Enter` 调 `ztools.hideMainWindowPasteText` 把结果粘贴回原光标位置并退出；粘贴失败时回退到复制 + Toast 提示
 - **兜底** - provider 翻译失败时用原文做风格转换，保证候选列表非空
 
-### `code: screen-ocr` — 截图识别
+### `code: screen-ocr` — 截图识别文字
 
-进入即自动调起系统截屏，框选区域后自动跑微信 OCR，可视化与「识别」页完全一致（canvas 绘图 + 透明文字层悬浮 + 全屏缩放/拖动 + 结果列表）：
+进入即自动调起系统截屏，框选区域后自动跑微信 OCR，结果留在主窗口内「OCR 识别」页展示（不再弹独立窗口）：
 
-- **进入**（`text` 型 cmd `截图识别文字`）：可被搜索（支持拼音）。仅 Windows（`platform: ["win32"]`）
+- **进入**（`text` 型 cmd `截图识别文字`）：可被搜索（支持拼音）。平台 `["win32", "darwin"]`
 - **流程** - 进入即自动触发 `ztools.screenCapture` → 用户框选屏幕区域 → 截图回调返回 base64 → 自动调 `ocrImageDetail` 识别 → canvas 绘制截图 + 透明文字层（按坐标悬浮，鼠标 hover 预览 / 点击复制）+ 结果列表双向高亮。顶部「重新截图」可反复截
 - **可视化**（复用 `OcrImageViewer`）- 图上文字鼠标悬浮弹出预览、点击复制；右下角「⛶」全屏预览，支持滚轮缩放（以鼠标为锚点）、拖动、按钮缩放/复位
 - **取消** - 截屏时按 `Esc` 取消（不报错，回到待截图态）；非截屏态按 `Esc` 退出插件
 - **复制** - 点击单行复制该行；「复制全部」复制全部识别文字
 - **引擎未就绪** - 渲染 native 引擎下载卡片（允许下载自救），下载就绪后自动补一次截屏
 
-> 💡 **关于 cmd 类型**：`text` 型 cmd（label 即搜索关键字）是唯一能进入 ZTools 主搜索列表的 cmd 类型；`img`/`files`/`regex`/`over`/`window` 仅在对应场景匹配时出现。因此若需要让插件「能被搜到且能打开」，至少要有一个 feature 携带 `text` 型 cmd。
+### `code: latex-recognize` — 公式识别
+
+把图片中的数学公式离线识别为 LaTeX，基于 onnxruntime-node + pix2tex ONNX 导出模型：
+
+- **进入**：
+  - `text` 型 cmd `公式识别`：可被搜索（支持拼音），进入「OCR 识别」tab 的**公式**模式
+  - `img` / `files` 型 cmd `识别图片公式`：拖入或选择图片后自动切到公式模式并识别
+- **流程** - `latexOcr.recognize(imagePath)` 返回 `{ latex }`；右侧用 KaTeX 渲染预览 + 源码 + 三种复制形式
+- **引擎未就绪** - 渲染 LaTeX 引擎下载卡片（`latex-ort-{win,mac}.zip` + `latex-models.zip`），支持镜像竞速、加速点选择与取消；下载就绪后自动补识别当前图片
+
+### `code: screen-latex` — 截图识别公式
+
+进入即自动截屏，框选区域后跑 LaTeX 公式识别，结果留在主窗口内「OCR 识别」页的公式模式展示：
+
+- **进入**（`text` 型 cmd `截图识别公式`）：可被搜索（支持拼音）。平台 `["win32", "darwin"]`
+- 流程与「截图识别文字」对齐，把 `ocrImageDetail` 换成 `latexOcr.recognize`，可视化层用 `<img>` + KaTeX 预览（不使用 canvas 文字层）
+- 引擎未就绪时同样走 LaTeX 下载卡片，下载就绪后自动补一次截屏
+
+> 💡 **关于 cmd 类型**：`text` 型 cmd（label 即搜索关键字）是唯一能进入 ZTools 主搜索列表的 cmd 类型；`img`/`files`/`over`/`window` 仅在对应场景匹配时出现。因此若需要让插件「能被搜到且能打开」，至少要有一个 feature 携带 `text` 型 cmd。
 
 ## 🛠️ 技术栈
 
@@ -162,40 +185,46 @@ await ztools.providers.invokeProvider('baidu', { text: 'hello', from: 'en', to: 
 - **UI**: ztools-ui（与宿主一致的组件库）
 - **Provider 注册**: ZTools `ztools.registerProvider` API
 - **原生模块**: C++ (Node-API / node-addon-api)
-  - 微信 OCR 运行时（mmmojo IPC 桥接）
+  - 微信 OCR 运行时（mmmojo IPC 桥接，Windows 走 `WeChatOCR.exe` 子进程，macOS 直接加载打包的 `libwxocr.dylib`）
   - 手写 protobuf 编解码
   - 任务队列 + 回调
+- **LaTeX 公式识别**: onnxruntime-node + pix2tex ONNX 导出模型（RapidAI/RapidLaTeXOCR），跨平台
 - **翻译**: 移植自 [STranslate](https://github.com/ZGGSONG/STranslate) 的纯 Node.js 实现
 
 ## 📁 项目结构
 
 ```
 f-provider/
-├── native/                      # 原生模块工程
+├── native/                      # 原生模块工程（wechat_ocr.node）
 │   ├── binding.gyp              # node-gyp 构建配置
 │   ├── package.json             # node-addon-api 依赖
 │   ├── index.js                 # .node 加载入口（require）
 │   ├── scripts/
-│   │   └── fetch-wco-data.cjs   # build 时自动获取 OCR 运行时数据
+│   │   ├── fetch-wco-data.cjs   #   build 时从 NuGet 拉取 Windows 微信 OCR 运行时（wco_data/）
+│   │   ├── fetch-mac-vendor.cjs #   build 时从 npm 包拉取 macOS 微信 OCR 运行时（wechat-ocr-mac/）
+│   │   └── fetch-latex-models.cjs#   build 时从 GitHub Release 拉取 LaTeX 公式识别模型
 │   ├── src/                     # C++ 源
 │   │   ├── addon.cc             #   N-API 绑定（init/ocr/dispose）
 │   │   ├── mmmojo.{h,cc}        #   IPC 桥接库动态加载封装
 │   │   ├── ocr_manager.{h,cc}   #   任务队列 + 回调
 │   │   ├── pb.{h,cc}            #   手写 protobuf 编解码
 │   │   └── ocr_protobuf.proto   #   消息定义（文档用）
-│   └── wco_data/                # OCR 运行时（git-ignored，build 时自动获取）
+│   ├── wco_data/                # Windows OCR 运行时（git-ignored，build 时自动获取）
+│   └── wechat-ocr-mac/          # macOS OCR 运行时（git-ignored，build 时自动获取）
 ├── public/
-│   ├── plugin.json              # 声明 providers.{ocr,baidu,google,youdao,microsoft} + 三个 feature
-│   ├── preload/services.js      # registerProvider(...) + 归一化输入
+│   ├── plugin.json              # 声明 providers.{ocr,latex-ocr,baidu,google,youdao,microsoft} + 五个 feature
+│   ├── preload/services.js      # registerProvider(...) + 归一化输入 + 引擎下载/校验
 │   └── logo.png
 ├── src/                         # Vue 前端（交互式 feature，全部基于 ztools-ui）
 │   ├── App.vue                  #   按 action.code 分流
 │   ├── main.ts                  #   注册 ztools-ui + 同步宿主主题
-│   ├── components/              #   SettingLayout / EngineStatusCard / OcrImageViewer / GlobalFeedback
-│   ├── composables/             #   useNativeEngine / useCaseConvert
-│   ├── views/                   #   Settings / RecognizeTest / Translate / TranslateTest / CodeTranslate / ScreenOcr
-│   └── Manage/index.vue         #   manage feature 容器
-├── scripts/copy-native.mjs      # 构建后把 native 资源拷进 dist/
+│   ├── components/              #   SettingLayout / EngineStatusCard / OcrImageViewer / HistoryView / ProviderLogo / GlobalFeedback
+│   ├── composables/             #   useNativeEngine / useLatexEngine / useCaseConvert / useHistory / useSegmentIndicator
+│   ├── views/                   #   Settings / Recognize（文字+公式合并）/ Translate / CodeTranslate
+│   └── Manage/index.vue         #   manage feature 容器（底部悬浮导航）
+├── scripts/
+│   ├── copy-native.mjs          # 构建后把 native 资源拷进 dist/ 并打 per-platform zip
+│   └── copy-latex.mjs           # 构建后把 LaTeX 引擎拷进 dist/ 并打 zip
 └── package.json
 ```
 
@@ -203,14 +232,17 @@ f-provider/
 
 | 功能 | Windows | macOS | Linux |
 | --- | :---: | :---: | :---: |
-| OCR（微信引擎） | ✅ | ❌ | ❌ |
-| 截图识别 | ✅ | ❌ | ❌ |
+| 微信 OCR（文字识别） | ✅ | ✅ | ❌ |
+| 截图识别文字 | ✅ | ✅ | ❌ |
+| LaTeX 公式识别 | ✅ | ✅ | ❌ |
+| 截图识别公式 | ✅ | ✅ | ❌ |
 | 翻译（百度/谷歌/有道/微软） | ✅ | ✅ | ✅ |
-| 翻译设置 / 批量测试 | ✅ | ✅ | ✅ |
+| 历史记录 / 设置 / 代码翻译 | ✅ | ✅ | ✅ |
 
-- **OCR** 仅 **Windows x64**（依赖原生运行时）。`plugin.json` 中 `screen-ocr` feature 已用 `platform: ["win32"]` 标注；`manage` feature 不限制平台，非 Windows 下可打开但「识别」子页会显示引擎未就绪
-- **翻译** provider 为纯 Node.js 实现，跨平台无原生依赖，其设置 / 测试子页随 `manage` feature 全平台可访问
-- OCR 首次调用时拉起引擎子进程；长时间不再使用时 preload 会按需 `dispose` 释放
+- **微信 OCR** 覆盖 Windows x64 与 macOS（Apple Silicon 原生编译的 `.node`，`libwxocr.dylib` 为 universal）。运行时文件随插件 GitHub Release 下载，**不读取本机已装的微信**。`screen-ocr` / `screen-latex` feature 用 `platform: ["win32", "darwin"]` 标注；`manage` feature 不限制平台，Linux 下可打开但「OCR 识别」页会显示引擎未就绪
+- **LaTeX 公式识别** 基于 onnxruntime-node，Win/Mac 各有 per-platform 的 ORT 二进制 + 共享模型 zip，同样走 Release 资产下载
+- **翻译** provider 为纯 Node.js 实现，跨平台无原生依赖；谷歌走 `translate.googleapis.com` 官方端点，国内需系统代理
+- 微信 OCR 首次调用时拉起引擎（Windows 子进程 / macOS 动态库），长时间不再使用时 preload 会按需 `dispose` 释放
 
 ## 🐛 问题反馈
 
@@ -225,7 +257,9 @@ f-provider/
 
 ## 💝 致谢
 
-- [STranslate](https://github.com/ZGGSONG/STranslate) - 翻译实现移植来源
+- [STranslate](https://github.com/ZGGSONG/STranslate) - 翻译实现移植来源 & 微信 OCR 运行时获取方式参考
+- [RapidAI/RapidLaTeXOCR](https://github.com/RapidAI/RapidLaTeXOCR) - LaTeX 公式识别 ONNX 模型来源
+- [LaTeX-OCR](https://github.com/lukas-blecher/LaTeX-OCR) - pix2tex 模型本体（MIT）
 - [ZTools](https://github.com/ZToolsCenter/ZTools) - Provider 抽象与契约
 - [Vue.js](https://vuejs.org/) - 渐进式 JavaScript 框架
 - [Vite](https://vite.dev/) - 下一代前端构建工具

--- a/plugins/f-provider/package-lock.json
+++ b/plugins/f-provider/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wechat-ocr-provider",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wechat-ocr-provider",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "katex": "^0.16.11",
         "vue": "^3.5.13",
@@ -17,6 +17,7 @@
         "@vitejs/plugin-vue": "^5.2.1",
         "@ztools-center/ztools-api-types": "^1.0.1",
         "onnxruntime-node": "^1.20.1",
+        "sass": "^1.102.0",
         "typescript": "^5.3.0",
         "vite": "^6.0.11",
         "vue-tsc": "^2.0.0"
@@ -515,6 +516,312 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+      "integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.6.0",
+        "@parcel/watcher-darwin-arm64": "2.6.0",
+        "@parcel/watcher-darwin-x64": "2.6.0",
+        "@parcel/watcher-freebsd-x64": "2.6.0",
+        "@parcel/watcher-linux-arm-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm-musl": "2.6.0",
+        "@parcel/watcher-linux-arm64-glibc": "2.6.0",
+        "@parcel/watcher-linux-arm64-musl": "2.6.0",
+        "@parcel/watcher-linux-x64-glibc": "2.6.0",
+        "@parcel/watcher-linux-x64-musl": "2.6.0",
+        "@parcel/watcher-win32-arm64": "2.6.0",
+        "@parcel/watcher-win32-x64": "2.6.0"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+      "integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+      "integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+      "integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+      "integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+      "integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+      "integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+      "integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+      "integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+      "integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+      "integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+      "integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+      "integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
@@ -1141,6 +1448,22 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/commander": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -1197,6 +1520,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/entities": {
@@ -1394,6 +1728,38 @@
         "he": "bin/he"
       }
     },
+    "node_modules/immutable": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/katex": {
       "version": "0.16.11",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.11.tgz",
@@ -1488,6 +1854,14 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -1577,6 +1951,20 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
@@ -1620,6 +2008,27 @@
         "@rollup/rollup-win32-x64-gnu": "4.62.2",
         "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.102.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.102.0.tgz",
+      "integrity": "sha512-NSOyTnaQF7rTAEOtI2fwb386vL+akyiQLBZu8Na7hXCb+umJy0GAqlcMIaqACZ6Z1VgTBS4K9PG6B3IdjHGJsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
       }
     },
     "node_modules/semver": {

--- a/plugins/f-provider/package.json
+++ b/plugins/f-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechat-ocr-provider",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "基于微信内置 OCR 引擎的离线图片文字识别 ZTools Provider",
   "type": "module",
   "scripts": {
@@ -21,6 +21,7 @@
     "@vitejs/plugin-vue": "^5.2.1",
     "@ztools-center/ztools-api-types": "^1.0.1",
     "onnxruntime-node": "^1.20.1",
+    "sass": "^1.102.0",
     "typescript": "^5.3.0",
     "vite": "^6.0.11",
     "vue-tsc": "^2.0.0"

--- a/plugins/f-provider/public/plugin.json
+++ b/plugins/f-provider/public/plugin.json
@@ -4,7 +4,7 @@
   "title": "ZTools 提供商",
   "description": "OCR + 翻译提供商集合（百度/谷歌/有道/微软翻译、微信 OCR）",
   "author": "kaineooo",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "main": "index.html",
   "preload": "preload/services.js",
   "logo": "logo.png",
@@ -118,30 +118,30 @@
   ],
   "native": {
     "win": {
-      "downloadUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.4/native-win.zip",
+      "downloadUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.5/native-win.zip",
       "sha256": "",
-      "version": "1.0.4"
+      "version": "1.0.5"
     },
     "mac": {
-      "downloadUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.4/native-mac.zip",
+      "downloadUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.5/native-mac.zip",
       "sha256": "",
-      "version": "1.0.4"
+      "version": "1.0.5"
     }
   },
   "nativeLatex": {
     "win": {
-      "ortUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.4/latex-ort-win.zip",
-      "modelsUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.4/latex-models.zip",
+      "ortUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.5/latex-ort-win.zip",
+      "modelsUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.5/latex-models.zip",
       "ortSha256": "",
       "modelsSha256": "",
-      "version": "1.0.4"
+      "version": "1.0.5"
     },
     "mac": {
-      "ortUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.4/latex-ort-mac.zip",
-      "modelsUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.4/latex-models.zip",
+      "ortUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.5/latex-ort-mac.zip",
+      "modelsUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.5/latex-models.zip",
       "ortSha256": "",
       "modelsSha256": "",
-      "version": "1.0.4"
+      "version": "1.0.5"
     }
   }
 }

--- a/plugins/f-provider/src/Manage/index.vue
+++ b/plugins/f-provider/src/Manage/index.vue
@@ -5,8 +5,10 @@ import type { NavItem } from '../components/SettingLayout.vue'
 import Settings from '../views/Settings.vue'
 import Recognize from '../views/Recognize.vue'
 import Translate from '../views/Translate.vue'
+import HistoryView from '../components/HistoryView.vue'
 import { useNativeEngine } from '../composables/useNativeEngine'
 import { useLatexEngine } from '../composables/useLatexEngine'
+import { useHistory } from '../composables/useHistory'
 
 /**
  * 管理主入口（唯一 feature，跨平台）：底部悬浮栏式布局。
@@ -30,6 +32,16 @@ const props = defineProps<{
 
 const { nativeVersion, checkNative } = useNativeEngine()
 const { latexVersion, checkLatex } = useLatexEngine()
+const { loadHistory, pushHistory } = useHistory()
+
+/**
+ * 接收子组件（Recognize / Translate）上抛的历史记录条目，
+ * 补全 id / ts 后写入历史记录单例（同步至 dbStorage）。
+ * 集中在 Manage 处理，子组件不直接依赖 dbStorage。
+ */
+function onHistory(item: HistoryEmitItem) {
+  pushHistory(item)
+}
 
 const activeKey = ref('settings')
 
@@ -80,6 +92,12 @@ const items = computed<NavItem[]>(() => [
     label: '翻译',
     icon: '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><!-- Icon from Material Symbols by Google - https://github.com/google/material-design-icons/blob/master/LICENSE --><path fill="currentColor" d="m12 22l-1-3H4q-.825 0-1.412-.587Q2 17.825 2 17V4q0-.825.588-1.413Q3.175 2 4 2h6l.875 3H20q.875 0 1.438.562Q22 6.125 22 7v13q0 .825-.562 1.413Q20.875 22 20 22Zm-4.85-7.4q1.725 0 2.838-1.112Q11.1 12.375 11.1 10.6q0-.2-.012-.363q-.013-.162-.063-.337h-3.95v1.55H9.3q-.2.7-.763 1.087q-.562.388-1.362.388q-.975 0-1.675-.7c-.7-.7-.7-1.725 0-2.45c.7-.7 1.05-.7 1.675-.7q.45 0 .85.162q.4.163.725.488L9.975 7.55Q9.45 7 8.713 6.7q-.738-.3-1.563-.3q-1.675 0-2.862 1.187Q3.1 8.775 3.1 10.5q0 1.725 1.188 2.912Q5.475 14.6 7.15 14.6Zm6.7.5l.55-.525q-.35-.425-.637-.825q-.288-.4-.563-.85Zm1.25-1.275q.7-.825 1.063-1.575q.362-.75.487-1.175h-3.975l.3 1.05h1q.2.375.475.813q.275.437.65.887ZM13 21h7q.45 0 .725-.288Q21 20.425 21 20V7q0-.45-.275-.725Q20.45 6 20 6h-8.825l1.175 4.05h1.975V9h1.025v1.05H19v1.025h-1.275q-.25.95-.75 1.85q-.5.9-1.175 1.675l2.725 2.675L17.8 18l-2.7-2.7l-.9.925L15 19Z"/></svg>',
     component: markRaw(Translate)
+  },
+  {
+    key: 'history',
+    label: '历史记录',
+    icon: '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><!-- Icon from Material Symbols by Google - https://github.com/google/material-design-icons/blob/master/LICENSE --><path fill="currentColor" d="M13 3a9 9 0 0 0-9 9H1l3.75 3.75L5.5 16L9 12H6a7 7 0 0 1 7-7a7 7 0 0 1 7 7a7 7 0 0 1-7 7c-1.93 0-3.68-.79-4.95-2.05l-1.42 1.42A8.954 8.954 0 0 0 13 21a9 9 0 0 0 0-18m2.5 11.25l-3.5-3.5V7h2v3.25l2.75 2.75z"/></svg>',
+    component: markRaw(HistoryView)
   }
 ])
 
@@ -144,6 +162,8 @@ onMounted(() => {
   // 读取 plugin.json 中的 native / nativeLatex 版本号用于侧边栏展示
   checkNative()
   checkLatex()
+  // 载入历史记录到单例 ref（供 HistoryView 读取）
+  loadHistory()
 })
 </script>
 
@@ -154,23 +174,39 @@ onMounted(() => {
     :version="nativeVersion || latexVersion || undefined"
     :dock-align="dockAlign"
   >
-    <!--
-      :key 绑定为「activeKey + enterSeq」：切换 tab 或重新进入插件都会重建组件，
-      保证进入时预填的 initialImage / initialText 被全新实例消费、状态不残留。
-    -->
-    <Settings v-if="activeKey === 'settings'" :key="'settings-' + enterSeq" />
+  <!--
+    Recognize / Translate 用 <KeepAlive> 缓存实例：底部悬浮栏切 tab 不再卸载，
+    切回时图片、识别结果、译文等用户数据完整保留。Settings 不过 keep-alive，
+    切走即卸载（设置页无用户输入，重 check 引擎状态即可）。
+    :key 仍绑 enterSeq：仅当 onPluginEnter 重新进入（enterSeq++)时 key 改变，
+    keep-alive 内 key 变更会销毁旧实例、挂载全新实例，确保新一轮预填生效、状态不残留。
+    切 tab 不改 enterSeq，故 key 不变，缓存命中。
+  -->
+  <Settings v-if="activeKey === 'settings'" :key="'settings-' + enterSeq" />
+  <KeepAlive>
     <Recognize
-      v-else-if="activeKey === 'recognize'"
+      v-if="activeKey === 'recognize'"
       :key="'recognize-' + enterSeq"
       :initial-image="initialImage"
       :initial-mode="initialMode"
       :auto-capture="autoCapture"
       @mode-change="onRecognizeModeChange"
+      @history="onHistory"
     />
+  </KeepAlive>
+  <KeepAlive>
     <Translate
-      v-else-if="activeKey === 'translate'"
+      v-if="activeKey === 'translate'"
       :key="'translate-' + enterSeq"
       :initial-text="initialText"
+      @history="onHistory"
     />
+  </KeepAlive>
+  <KeepAlive>
+    <HistoryView
+      v-if="activeKey === 'history'"
+      :key="'history-' + enterSeq"
+    />
+  </KeepAlive>
   </SettingLayout>
 </template>

--- a/plugins/f-provider/src/components/HistoryView.vue
+++ b/plugins/f-provider/src/components/HistoryView.vue
@@ -1,0 +1,797 @@
+<script setup lang="ts">
+import { ref, computed, watch, nextTick } from 'vue'
+import { ZButton, useToast } from 'ztools-ui'
+import katex from 'katex'
+import 'katex/dist/katex.min.css'
+import OcrImageViewer from './OcrImageViewer.vue'
+import { useSegmentIndicator } from '../composables/useSegmentIndicator'
+import { useHistory } from '../composables/useHistory'
+
+const { historyList, removeHistory } = useHistory()
+const { success } = useToast()
+
+// ─── 子分类切换：OCR / 翻译 ──────────────────────────────────────────
+type HistoryTab = 'ocr' | 'translate'
+const historyMode = ref<HistoryTab>('ocr')
+
+// 文字 / 公式两种 OCR 都归到「OCR」分类（缩略列表内部天然区分），「翻译」单独一类。
+function matchesTab(item: HistoryItem, tab: HistoryTab): boolean {
+  if (tab === 'ocr') return item.kind === 'ocr-text' || item.kind === 'ocr-formula'
+  return item.kind === 'translate'
+}
+
+function switchTab(next: HistoryTab) {
+  if (historyMode.value === next) return
+  historyMode.value = next
+  // 切换 tab 后自动选中第一条（若列表非空）
+  const first = filteredList.value[0]
+  activeId.value = first ? first.id : null
+}
+
+// 当前 tab 下的历史列表（historyList 本身是新→旧顺序，无需再 reverse）
+const filteredList = computed(() =>
+  historyList.value.filter((it) => matchesTab(it, historyMode.value))
+)
+
+const historyModeIndex = computed(() => (historyMode.value === 'ocr' ? 0 : 1))
+const {
+  containerRef: tabSwitchRef,
+  setItemRef: setTabItemRef,
+  pos: tabIndicator,
+  noAnim: tabNoAnim
+} = useSegmentIndicator(historyModeIndex)
+
+// ─── 选中项 ─────────────────────────────────────────────────────────
+const activeId = ref<string | null>(null)
+const activeItem = computed(() =>
+  historyList.value.find((it) => it.id === activeId.value) || null
+)
+/** 类型收敛后的当前 OCR 文字记录（仅 kind === 'ocr-text' 时有效）。 */
+const activeOcrText = computed(
+  () => (activeItem.value?.kind === 'ocr-text' ? activeItem.value : null) as
+    | (HistoryItem & { kind: 'ocr-text'; payload: { kind: 'ocr-text'; imageSrc: string; lines: OcrLine[] } })
+    | null
+)
+/** 类型收敛后的当前 OCR 公式记录。 */
+const activeOcrFormula = computed(
+  () => (activeItem.value?.kind === 'ocr-formula' ? activeItem.value : null) as
+    | (HistoryItem & { kind: 'ocr-formula'; payload: { kind: 'ocr-formula'; imageSrc: string; latex: string } })
+    | null
+)
+/** 类型收敛后的当前翻译记录。 */
+const activeTranslate = computed(
+  () => (activeItem.value?.kind === 'translate' ? activeItem.value : null) as
+    | (HistoryItem & {
+        kind: 'translate'
+        payload: {
+          kind: 'translate'
+          source: string
+          target: string
+          from: string
+          to: string
+          provider: TranslateProviderName
+        }
+      })
+    | null
+)
+
+// 自动选中第一条：挂载时、切换 tab 后若未选中则选第一条
+watch(
+  filteredList,
+  (list) => {
+    if (list.length && (!activeId.value || !list.some((it) => it.id === activeId.value))) {
+      activeId.value = list[0].id
+    } else if (list.length === 0) {
+      activeId.value = null
+    }
+  },
+  { immediate: true }
+)
+
+function selectRow(item: HistoryItem) {
+  if (item.id !== activeId.value) activeId.value = item.id
+}
+
+// ─── 翻译缩略图：原文首字 + 背景色 ──────────────────────────────────
+const TRANSLATE_COLORS = ['#1976d2', '#43a047', '#fb8c00', '#8e24aa']
+
+function translateAvatarColor(source: string): string {
+  let hash = 0
+  for (let i = 0; i < source.length; i++) {
+    hash = (hash * 31 + source.charCodeAt(i)) >>> 0
+  }
+  return TRANSLATE_COLORS[hash % TRANSLATE_COLORS.length]
+}
+
+function translateAvatarText(source: string): string {
+  const ch = source.trim().charAt(0)
+  return ch || 'T'
+}
+
+// ─── 时间格式化 MM-DD HH:mm ──────────────────────────────────────────
+function formatTs(ts: number): string {
+  const d = new Date(ts)
+  const MM = String(d.getMonth() + 1).padStart(2, '0')
+  const DD = String(d.getDate()).padStart(2, '0')
+  const HH = String(d.getHours()).padStart(2, '0')
+  const mm = String(d.getMinutes()).padStart(2, '0')
+  return `${MM}-${DD} ${HH}:${mm}`
+}
+
+// ─── 缩略图全屏预览（OCR 记录） ──────────────────────────────────────
+// 为当前选中项挂载一个 OcrImageViewer 实例，点击缩略图时调其 expose 的 openFullscreen。
+const viewerRef = ref<InstanceType<typeof OcrImageViewer> | null>(null)
+
+/**
+ * 点击缩略图：
+ *   - OCR 记录：触发 OcrImageViewer 的全屏预览能力（通过 ref 调 openFullscreen）。
+ *   - 翻译记录：等同于点击行其它区域，选中并展示右侧详情（缩略图不可全屏）。
+ */
+function onThumbClick(item: HistoryItem) {
+  // 翻译记录无全屏预览，缩小为「选中行」语义
+  selectRow(item)
+  // OCR 记录：等下一帧 viewer 挂载到位再触发全屏（若尚未挂载）
+  if (item.kind === 'ocr-text' || item.kind === 'ocr-formula') {
+    selectRow(item)
+    // 若当前查看的不是这条，先选中，下一帧再开全屏
+    if (activeItem.value?.id !== item.id) {
+      activeId.value = item.id
+      nextTick(() => viewerRef.value?.openFullscreen())
+    } else {
+      viewerRef.value?.openFullscreen()
+    }
+  }
+}
+
+// ─── 详情面板：OCR 文字明细行复制 ──────────────────────────────────
+// OcrImageViewer 通过 @copy 事件把文字上抛给父，这里用 toast 提示。
+function onViewerCopy(text: string) {
+  window.ztools.copyText(text)
+  success('已复制该行')
+}
+
+// ─── 详情面板：LaTeX 渲染（公式记录） ────────────────────────────────
+const latexHtml = computed(() => {
+  const item = activeOcrFormula.value
+  if (!item) return ''
+  const val = item.payload.latex
+  if (!val) return ''
+  try {
+    return katex.renderToString(val, {
+      displayMode: true,
+      throwOnError: false,
+      output: 'html'
+    })
+  } catch (e: any) {
+    return '<span class="katex-error">渲染失败：' + (e?.message || String(e)) + '</span>'
+  }
+})
+
+function copyLatex(kind: 'raw' | 'inline' | 'display') {
+  const item = activeOcrFormula.value
+  if (!item) return
+  const latex = item.payload.latex
+  if (!latex) return
+  let text = latex
+  if (kind === 'inline') text = '$' + latex + '$'
+  else if (kind === 'display') text = '$$' + latex + '$$'
+  window.ztools.copyText(text)
+  success(
+    kind === 'raw'
+      ? '已复制 LaTeX 源码'
+      : kind === 'inline'
+        ? '已复制 $…$ 形式'
+        : '已复制 $$…$$ 形式'
+  )
+}
+
+// ─── 翻译详情：语言 label 映射（本地定义，避免循环引用 Translate.vue）───
+const LANG_LABELS: Record<string, string> = {
+  auto: '自动检测',
+  'zh-CN': '中文（简体）',
+  'zh-TW': '中文（繁體）',
+  en: '英语',
+  ja: '日语',
+  ko: '韩语',
+  fr: '法语',
+  es: '西班牙语',
+  ru: '俄语',
+  de: '德语',
+  it: '意大利语',
+  th: '泰语',
+  vi: '越南语',
+  ar: '阿拉伯语'
+}
+
+const PROVIDER_LABELS: Record<TranslateProviderName, string> = {
+  baidu: '百度翻译',
+  google: '谷歌翻译',
+  youdao: '有道翻译',
+  microsoft: '微软翻译'
+}
+
+function langLabel(code: string): string {
+  return LANG_LABELS[code] || code
+}
+
+// 类型守卫式读取：在模板内直接 item.payload.source 无法通过类型收窄，
+// 用此 helper 在列表 v-for 中拿到翻译记录的原文以便生成首字缩略图。
+function translateSourceOf(item: HistoryItem): string {
+  if (item.kind === 'translate') {
+    return (item as HistoryItem & { payload: { kind: 'translate'; source: string } }).payload.source
+  }
+  return ''
+}
+
+/**
+ * 删除一条历史记录。
+ * 阻止冒泡避免触发选中行；删除后若当前选中项被移除，由 watch 自动补选第一条。
+ */
+function removeItem(id: string, e: MouseEvent) {
+  e.stopPropagation()
+  removeHistory(id)
+}
+</script>
+
+<template>
+  <div class="history-view">
+    <!-- 主体：左右结构 -->
+    <div class="stage">
+      <!-- 左：分类切换 + 缩略列表 -->
+      <div class="pane pane-list">
+        <!-- 顶部 OCR / 翻译 切换条 -->
+        <div
+          class="mode-switch"
+          role="tablist"
+          aria-label="历史记录分类"
+          ref="tabSwitchRef"
+        >
+          <span
+            class="mode-indicator"
+            :class="{ 'no-anim': tabNoAnim }"
+            :style="{
+              transform: `translateX(${tabIndicator.x}px)`,
+              width: tabIndicator.w ? `${tabIndicator.w}px` : '0px'
+            }"
+          ></span>
+          <button
+            type="button"
+            role="tab"
+            class="mode-btn"
+            :class="{ active: historyMode === 'ocr' }"
+            :aria-selected="historyMode === 'ocr'"
+            :ref="(el) => setTabItemRef(el, 0)"
+            @click="switchTab('ocr')"
+          >
+            OCR
+          </button>
+          <button
+            type="button"
+            role="tab"
+            class="mode-btn"
+            :class="{ active: historyMode === 'translate' }"
+            :aria-selected="historyMode === 'translate'"
+            :ref="(el) => setTabItemRef(el, 1)"
+            @click="switchTab('translate')"
+          >
+            翻译
+          </button>
+        </div>
+
+        <!-- 缩略列表 -->
+        <div class="list-scroll">
+          <div
+            v-for="item in filteredList"
+            :key="item.id"
+            class="row"
+            :class="{ active: item.id === activeId }"
+            @click="selectRow(item)"
+          >
+            <!-- 缩略图：固定大小容器，contain -->
+            <div class="thumb" @click.stop="onThumbClick(item)">
+              <img
+                v-if="item.kind === 'ocr-text' || item.kind === 'ocr-formula'"
+                :src="item.thumbnail"
+                :alt="item.title"
+                class="thumb-img"
+              />
+              <div
+                v-else-if="item.kind === 'translate'"
+                class="thumb-translate"
+                :style="{
+                  background: translateAvatarColor(translateSourceOf(item))
+                }"
+              >
+                {{ translateAvatarText(translateSourceOf(item)) }}
+              </div>
+            </div>
+
+            <!-- 右侧：标题 + 时间 -->
+            <div class="row-info">
+              <div class="row-title">{{ item.title }}</div>
+              <div class="row-time">{{ formatTs(item.ts) }}</div>
+            </div>
+
+            <!-- 删除按钮：悬浮行时展示 -->
+            <button
+              type="button"
+              class="row-remove"
+              :title="'删除该记录'"
+              @click="removeItem(item.id, $event)"
+            >
+              <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+                <path d="M1 1L9 9M9 1L1 9" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" />
+              </svg>
+            </button>
+          </div>
+
+          <!-- 空态 -->
+          <div v-if="filteredList.length === 0" class="list-empty">
+            {{ historyMode === 'ocr' ? '暂无 OCR 历史记录' : '暂无翻译历史记录' }}
+          </div>
+        </div>
+      </div>
+
+      <!-- 右：详情面板 -->
+      <div class="pane pane-detail">
+        <!-- 未选中时的空态 -->
+        <div v-if="!activeItem" class="result-empty placeholder">
+          选择左侧记录查看详情
+        </div>
+
+        <!-- ocr-text：仅展示识别明细列表（不展示原图，缩略图点击仍可全屏预览） -->
+        <OcrImageViewer
+          v-else-if="activeOcrText"
+          ref="viewerRef"
+          :image-src="activeOcrText.payload.imageSrc"
+          :lines="activeOcrText.payload.lines"
+          :hide-result="false"
+          :hide-image="true"
+          empty-text=""
+          class="ocr-image-viewer"
+          @copy="onViewerCopy"
+        />
+
+        <!-- ocr-formula：上下结构，KaTeX 预览 + LaTeX 源码 -->
+        <div v-else-if="activeOcrFormula" class="formula-layout">
+          <!-- 上半：渲染预览 -->
+          <div class="result-section formula-half">
+            <div class="section-title">渲染预览</div>
+            <div class="katex-preview" v-html="latexHtml"></div>
+          </div>
+          <!-- 下半：LaTeX 源码（只读） -->
+          <div class="result-section formula-half">
+            <div class="section-title">LaTeX 源码</div>
+            <textarea
+              class="latex-source"
+              :value="activeOcrFormula.payload.latex"
+              readonly
+              spellcheck="false"
+              autocomplete="off"
+              autocorrect="off"
+              autocapitalize="off"
+            ></textarea>
+          </div>
+          <div class="copy-actions">
+            <ZButton @click="copyLatex('raw')">复制源码</ZButton>
+            <ZButton @click="copyLatex('inline')">复制 $…$</ZButton>
+            <ZButton @click="copyLatex('display')">复制 $$…$$</ZButton>
+          </div>
+        </div>
+
+        <!-- translate：上下结构，原文 + 译文 -->
+        <div v-else-if="activeTranslate" class="translate-layout">
+          <!-- 顶部小头：provider + 语言方向 -->
+          <div class="translate-meta">
+            <span class="meta-provider">{{
+              PROVIDER_LABELS[activeTranslate.payload.provider]
+            }}</span>
+            <span class="meta-lang">
+              {{ langLabel(activeTranslate.payload.from) }}
+              <span class="meta-arrow">→</span>
+              {{ langLabel(activeTranslate.payload.to) }}
+            </span>
+          </div>
+
+          <!-- 上半：原文 -->
+          <div class="result-section translate-half">
+            <div class="section-title">原文</div>
+            <div class="tr-output-text readonly">{{ activeTranslate.payload.source }}</div>
+          </div>
+
+          <!-- 下半：译文 -->
+          <div class="result-section translate-half">
+            <div class="section-title">译文</div>
+            <div class="tr-output-text readonly">{{ activeTranslate.payload.target }}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.history-view {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  height: 100%;
+}
+
+/* ── 主体左右结构 ── */
+.stage {
+  flex: 1;
+  display: flex;
+  gap: 14px;
+  min-height: 0;
+  padding: 14px;
+}
+
+/* 左：分类切换 + 缩略列表 */
+.pane-list {
+  flex: 0 0 280px;
+  width: 280px;
+  min-width: 0;
+  max-width: 280px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+}
+
+/* 模式切换条（复用 Recognize.vue 的 .mode-switch 样式结构） */
+.mode-switch {
+  position: relative;
+  display: flex;
+  gap: 2px;
+  padding: 3px;
+  background: var(--sub-bar-bg, rgba(0, 0, 0, 0.05));
+  border-radius: 9px;
+  flex-shrink: 0;
+}
+
+.mode-indicator {
+  position: absolute;
+  top: 3px;
+  bottom: 3px;
+  left: 0;
+  border-radius: 7px;
+  background: var(--sub-item-active-bg, #fff);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  pointer-events: none;
+  z-index: 0;
+  transition:
+    transform 0.28s cubic-bezier(0.4, 0, 0.2, 1),
+    width 0.28s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.mode-indicator.no-anim {
+  transition: none;
+}
+
+:global(html.dark) .mode-indicator {
+  background: var(--sub-item-active-bg, rgba(255, 255, 255, 0.14));
+}
+
+.mode-btn {
+  flex: 1;
+  padding: 6px 14px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+  border-radius: 7px;
+  cursor: pointer;
+  font-family: inherit;
+  position: relative;
+  z-index: 1;
+  transition: color 0.15s;
+  white-space: nowrap;
+}
+
+.mode-btn.active {
+  color: var(--primary-color, #1976d2);
+  font-weight: 600;
+}
+
+/* 列表滚动区 */
+.list-scroll {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  /* 始终让滚动区域占据剩余高度，哪怕只有一两条 */
+  min-height: 0;
+}
+
+/* 每一行：缩略图 + 标题 + 时间 */
+.row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
+}
+
+.row:hover {
+  background: var(--hover-bg, rgba(0, 0, 0, 0.05));
+}
+
+.row.active {
+  background: var(--active-bg, color-mix(in srgb, var(--primary-color, #1976d2) 8%, transparent));
+  border-color: color-mix(in srgb, var(--primary-color, #1976d2), transparent 55%);
+}
+
+/* 缩略图：固定大小容器，contain */
+.thumb {
+  flex-shrink: 0;
+  width: 64px;
+  height: 64px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color, #e5e6eb);
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--hover-bg, rgba(0, 0, 0, 0.04));
+  /* 鼠标在缩略图上提示可点开全屏（OCR 记录） */
+  cursor: pointer;
+}
+
+.thumb-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+}
+
+/* 翻译缩略图：圆形首字 + 背景色 */
+.thumb-translate {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-size: 18px;
+  font-weight: 600;
+  user-select: none;
+}
+
+.row-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* 删除按钮：默认隐藏，悬浮行时显示 */
+.row-remove {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-secondary, #999);
+  cursor: pointer;
+  opacity: 0;
+  transition:
+    opacity 0.15s,
+    color 0.15s,
+    background 0.15s;
+  padding: 0;
+}
+
+.row:hover .row-remove {
+  opacity: 1;
+}
+
+.row-remove:hover {
+  color: #fff;
+  background: var(--primary-color, #1976d2);
+}
+
+.row-title {
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text-color, #333);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.row-time {
+  font-size: 11px;
+  color: var(--text-secondary, #999);
+}
+
+/* 列表空态 */
+.list-empty {
+  padding: 40px 16px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--text-secondary, #999);
+}
+
+/* 右：详情面板 */
+.pane-detail {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.ocr-image-viewer ::v-deep(.empty) {
+  display: none;
+}
+.ocr-image-viewer ::v-deep(.result-tip) {
+  display: none;
+}
+.ocr-image-viewer ::v-deep(.result) {
+  border-top: none;
+  padding-top: 0;
+}
+/* 空态 */
+.result-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  color: var(--text-secondary, #999);
+  font-size: 14px;
+  text-align: center;
+}
+
+.result-empty.placeholder {
+  opacity: 0.7;
+}
+
+/* 公式详情：上下结构 */
+.formula-layout {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+}
+
+.formula-half {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.section-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary, #666);
+  flex-shrink: 0;
+}
+
+.katex-preview {
+  flex: 1 1 0;
+  min-height: 0;
+  padding: 16px;
+  background: #fff;
+  border-radius: 8px;
+  border: 1px solid var(--border-color, #e5e6eb);
+  overflow: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+:global(html.dark) .katex-preview {
+  background: #2a2a2a;
+}
+
+.katex-error {
+  color: #e53935;
+  font-size: 13px;
+}
+
+.latex-source {
+  flex: 1 1 0;
+  min-height: 0;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 12px;
+  background: var(--code-bg, #f5f5f5);
+  border-radius: 8px;
+  border: 1px solid var(--border-color, #e5e6eb);
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  resize: none;
+  color: var(--text-color, #333);
+  outline: none;
+}
+
+.copy-actions {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+  margin-bottom: 28px;
+}
+
+/* 翻译详情：上下结构 */
+.translate-layout {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+  padding-bottom: 28px;
+}
+
+.translate-meta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+.meta-provider {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-color, #333);
+}
+
+.meta-lang {
+  font-size: 12px;
+  color: var(--text-secondary, #999);
+}
+
+.meta-arrow {
+  margin: 0 4px;
+}
+
+.translate-half {
+  flex: 1 1 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tr-output-text {
+  flex: 1 1 0;
+  min-height: 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border-color, #e5e6eb);
+  border-radius: 10px;
+  background: var(--card-bg, transparent);
+  overflow-y: auto;
+  font-size: 15px;
+  line-height: 1.7;
+  white-space: pre-wrap;
+  word-break: break-all;
+  user-select: text;
+  box-sizing: border-box;
+}
+
+/* 让 OcrImageViewer 内的 viewer 填满详情面板 */
+.pane-detail > :deep(.viewer) {
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/plugins/f-provider/src/components/OcrImageViewer.vue
+++ b/plugins/f-provider/src/components/OcrImageViewer.vue
@@ -27,8 +27,12 @@ const props = withDefaults(
     emptyText?: string
     /** 隐藏内置结果列表（父组件自行渲染右侧结果面板时使用）。 */
     hideResult?: boolean
+    /** 隐藏图片预览区（仅保留结果列表，常用于历史记录文字 OCR 详情）。 */
+    hideImage?: boolean
+    /** 结果列表底部留白（px），用于避开外层悬浮导航栏遮挡。 */
+    resultPadBottom?: number
   }>(),
-  { loading: false, emptyText: '', hideResult: false }
+  { loading: false, emptyText: '', hideResult: false, hideImage: false, resultPadBottom: 0 }
 )
 
 const emit = defineEmits<{
@@ -213,6 +217,10 @@ function closeFullscreen() {
   dragging.value = false
 }
 
+// 对外暴露打开全屏：供 HistoryView 等父组件点击 OCR 缩略图时直接触发，
+// 复用内部 canvas 绘图 + 文字层 + 缩放/拖拽的整套全屏预览能力。
+defineExpose({ openFullscreen })
+
 // 滚轮缩放：以鼠标位置为锚点
 function onFsWheel(e: WheelEvent) {
   e.preventDefault()
@@ -361,7 +369,7 @@ onUnmounted(() => {
 <template>
   <div class="viewer">
     <div
-      v-if="imageSrc"
+      v-if="imageSrc && !hideImage"
       class="canvas-stage"
       :class="{ 'is-dragging': inlineDragging }"
       @wheel.prevent="onInlineWheel"
@@ -443,7 +451,11 @@ onUnmounted(() => {
     </div>
 
     <!-- 明细结果列表（可由父组件通过 hideResult 接管渲染） -->
-    <div v-if="hasResult && !hideResult" class="result">
+    <div
+      v-if="hasResult && !hideResult"
+      class="result"
+      :style="{ paddingBottom: resultPadBottom ? resultPadBottom + 'px' : undefined }"
+    >
       <div class="result-head">
         <span class="result-title">识别明细（{{ lines.length }} 行）</span>
         <span class="result-tip">图上文字可直接鼠标选中，或点击对应文字复制</span>

--- a/plugins/f-provider/src/composables/useHistory.ts
+++ b/plugins/f-provider/src/composables/useHistory.ts
@@ -1,0 +1,83 @@
+import { ref } from 'vue'
+
+/**
+ * 历史记录单例：跨组件共享同一份历史列表。
+ *
+ * - Recognize / Translate 完成识别/翻译后，由 Manage 调用 pushHistory 写入。
+ * - HistoryView 读取 historyList 渲染左侧缩略列表与右侧详情面板。
+ * - 持久化到 window.ztools.dbStorage（key: `history.list`），最多保留 100 条。
+ *
+ * 与 useNativeEngine 同构的「模块级单例」模式：切 tab 卸载组件时数据不丢，
+ * 重新挂载仍读到同一份列表。
+ */
+
+/** dbStorage 中存储历史记录的 key。 */
+const STORAGE_KEY = 'history.list'
+
+/** 最多保留的历史记录条数。超出自动淘汰最旧的（数组末尾）。 */
+const MAX_ITEMS = 100
+
+// ─── 模块级单例（进程内唯一，跨组件共享）────────────────────────────────
+const historyList = ref<HistoryItem[]>([])
+
+/** 从 dbStorage 载入历史记录到单例 ref。启动时调一次。 */
+function loadHistory(): void {
+  try {
+    const stored = window.ztools.dbStorage.getItem<HistoryItem[]>(STORAGE_KEY)
+    historyList.value = Array.isArray(stored) ? stored : []
+  } catch (_) {
+    // dbStorage 不可用等异常：保持空列表，不阻塞 UI
+    historyList.value = []
+  }
+}
+
+/** 同步当前单例列表到 dbStorage。 */
+function persist(): void {
+  try {
+    window.ztools.dbStorage.setItem(STORAGE_KEY, historyList.value)
+  } catch (_) {
+    /* 写入失败不阻塞 UI */
+  }
+}
+
+/**
+ * 新增一条历史记录：unshift 到头部，超 MAX_ITEMS 条尾裁剪，并同步到 dbStorage。
+ * @param item 不含 id / ts 的条目，由本函数补全。
+ */
+function pushHistory(item: HistoryEmitItem): void {
+  const full: HistoryItem = {
+    ...item,
+    id:
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : String(Date.now()) + '-' + Math.random().toString(36).slice(2, 10),
+    ts: Date.now()
+  }
+  historyList.value.unshift(full)
+  if (historyList.value.length > MAX_ITEMS) {
+    historyList.value.length = MAX_ITEMS
+  }
+  persist()
+}
+
+/** 删除指定 id 的历史记录。 */
+function removeHistory(id: string): void {
+  historyList.value = historyList.value.filter((it) => it.id !== id)
+  persist()
+}
+
+/** 清空全部历史记录。 */
+function clearHistory(): void {
+  historyList.value = []
+  persist()
+}
+
+export function useHistory() {
+  return {
+    historyList,
+    loadHistory,
+    pushHistory,
+    removeHistory,
+    clearHistory
+  }
+}

--- a/plugins/f-provider/src/env.d.ts
+++ b/plugins/f-provider/src/env.d.ts
@@ -89,6 +89,47 @@ declare global {
     cancelled?: boolean
   }
 
+  // ─── 历史记录 ─────────────────────────────────────────────────────────
+  /** 历史记录的类型：OCR 文字 / OCR 公式 / 翻译。 */
+  type HistoryKind = 'ocr-text' | 'ocr-formula' | 'translate'
+
+  /**
+   * 历史记录条目。由 Recognize / Translate 在完成识别/翻译后上抛给 Manage，
+   * 由 Manage 统一写入 dbStorage（key: `history.list`），最多保留 100 条。
+   *
+   * - OCR 记录：thumbnail / payload.imageSrc 均为 data URI（用户选择直接存，
+   *   不落盘），点缩略图可复用 OcrImageViewer 的全屏预览能力。
+   * - 翻译记录：thumbnail 字段不用（HistoryView 按 payload.source 首字动态渲染
+   *   圆形首字缩略图），故置空串；payload 含原文 / 译文 / 语言 / provider。
+   */
+  interface HistoryItem {
+    /** 唯一 id（crypto.randomUUID()）。 */
+    id: string
+    /** 记录类型。 */
+    kind: HistoryKind
+    /** 缩略图源：OCR 为 data URI，翻译为空串（渲染时按首字动态生成）。 */
+    thumbnail: string
+    /** 标题：截取的一段结果文本，约 40 字。 */
+    title: string
+    /** 触发时间戳（ms）。 */
+    ts: number
+    /** 类型相关的明细 payload。 */
+    payload:
+      | { kind: 'ocr-text'; imageSrc: string; lines: OcrLine[] }
+      | { kind: 'ocr-formula'; imageSrc: string; latex: string }
+      | {
+          kind: 'translate'
+          source: string
+          target: string
+          from: string
+          to: string
+          provider: TranslateProviderName
+        }
+  }
+
+  /** 上抛给父级的历史记录条目（不含 id / ts，由父级补全）。 */
+  type HistoryEmitItem = Omit<HistoryItem, 'id' | 'ts'>
+
   // ─── 翻译 Provider 相关 ───────────────────────────────────────────────
   /** 翻译 Provider 输出（对齐宿主 TranslationOutput）。 */
   interface TranslateProviderOutput {

--- a/plugins/f-provider/src/views/Recognize.vue
+++ b/plugins/f-provider/src/views/Recognize.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, watch, nextTick } from "vue";
+import { ref, computed, onMounted, onUnmounted, onActivated, onDeactivated, watch, nextTick } from "vue";
 import { ZButton, ZTag, useToast } from "ztools-ui";
 import katex from "katex";
 import "katex/dist/katex.min.css";
@@ -47,9 +47,13 @@ const props = withDefaults(
  * 模式变化时上报父组件：公式模式下底部悬浮导航栏会移到左下角，
  * 避免遮挡右下角的三个复制按钮（见 SettingLayout 的 dockAlign）。
  * immediate：组件每次按 :key 重建时同步当前模式，保证 dock 位置正确。
+ *
+ * 识别成功后上抛 history 事件：由 Manage 统一写入历史记录单例（dbStorage），
+ * 不在子组件内直接依赖 dbStorage。
  */
 const emit = defineEmits<{
   (e: "mode-change", mode: "text" | "formula"): void;
+  (e: "history", item: HistoryEmitItem): void;
 }>();
 
 const { success, error } = useToast();
@@ -250,7 +254,22 @@ async function recognizeText() {
     if (result.ok) {
       ocrLines.value = result.lines ?? [];
       if (ocrLines.value.length === 0) error("未识别到文字");
-      else success(`识别完成，共 ${ocrLines.value.length} 行`);
+      else {
+        success(`识别完成，共 ${ocrLines.value.length} 行`);
+        // 上抛历史记录：只有真正调识别服务成功才留一笔（命中缓存不会进此分支）
+        emit("history", {
+          kind: "ocr-text",
+          thumbnail: imageSrc.value,
+          title: ocrLines.value[0]?.text
+            ? ocrLines.value[0].text.slice(0, 40)
+            : "（未识别到文字）",
+          payload: {
+            kind: "ocr-text",
+            imageSrc: imageSrc.value,
+            lines: ocrLines.value.map((l) => ({ ...l })),
+          },
+        });
+      }
     } else {
       ocrError.value = result.error || "识别失败";
       error(ocrError.value);
@@ -278,7 +297,20 @@ async function recognizeFormula() {
     if (result.ok) {
       latex.value = result.latex || "";
       if (!latex.value) error("未识别到公式");
-      else success("公式识别完成");
+      else {
+        success("公式识别完成");
+        // 上抛历史记录：只有真正调识别服务成功才留一笔（命中缓存不会进此分支）
+        emit("history", {
+          kind: "ocr-formula",
+          thumbnail: imageSrc.value,
+          title: latex.value.slice(0, 40),
+          payload: {
+            kind: "ocr-formula",
+            imageSrc: imageSrc.value,
+            latex: latex.value,
+          },
+        });
+      }
     } else {
       latexError.value = result.error || "识别失败";
       error(latexError.value);
@@ -400,6 +432,21 @@ onMounted(() => {
   // 截图识别 feature（screen-ocr / screen-latex）进入即自动截屏：
   // 引擎已就绪则立即截图，否则由上方 nativeReady/latexReady watcher 在就绪后触发。
   maybeAutoCapture();
+});
+
+// keep-alive 缓存后切 tab 触发 onActivated/onDeactivated（而非重新挂载）：
+//   - activated：重绑 paste 监听（deactivated 时已移除）、重新 check 引擎状态
+//     （长时间切走后 ready 可能已过期），不再重复触发自动截图（autoCaptureDone
+//     在缓存实例中保留为 true，未触发过的由引擎就绪 watcher 补截图）。
+//   - deactivated：暂停 paste 监听，避免非可见时仍响应剪贴板。
+onActivated(() => {
+  window.addEventListener("paste", onPaste);
+  checkNative();
+  checkLatex();
+});
+
+onDeactivated(() => {
+  window.removeEventListener("paste", onPaste);
 });
 
 onUnmounted(() => {

--- a/plugins/f-provider/src/views/Translate.vue
+++ b/plugins/f-provider/src/views/Translate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted, nextTick, watch } from 'vue'
+import { ref, computed, onMounted, onUnmounted, onActivated, nextTick, watch } from 'vue'
 import { ZInput, ZSelect, ZButton, ZSwitch, useToast } from 'ztools-ui'
 
 /**
@@ -15,6 +15,10 @@ import { ZInput, ZSelect, ZButton, ZSwitch, useToast } from 'ztools-ui'
 const props = defineProps<{
   /** 进入时预填的待翻译文本（regex 入口）。 */
   initialText?: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'history', item: HistoryEmitItem): void
 }>()
 
 const { success } = useToast()
@@ -171,6 +175,22 @@ async function run() {
       error: '',
       ms: Math.round(performance.now() - t0)
     }
+    // 上抛历史记录：真正调翻译服务成功才留一笔（auto 翻译/手动翻译均走此分支）
+    if (out.text) {
+      emit('history', {
+        kind: 'translate',
+        thumbnail: '',
+        title: out.text.slice(0, 40),
+        payload: {
+          kind: 'translate',
+          source: sourceText.value,
+          target: out.text,
+          from: sourceLang.value,
+          to: targetLang.value,
+          provider: provider.value
+        }
+      })
+    }
   } catch (e: any) {
     result.value = {
       loading: false,
@@ -239,15 +259,22 @@ watch(
 onMounted(() => {
   refreshProviderStatus()
   provider.value = pickDefaultProvider()
-  // 进入/回到翻译视图时默认聚焦输入框并选中全文，便于直接覆盖输入。
+  // 首次挂载聚焦原文输入框并全选，便于直接覆盖输入。
   // nextTick 确保 DOM（含 v-model 文本）已渲染完成后再 select。
   nextTick(focusAndSelectAll)
   // 兜底：窗口被宿主隐藏→恢复（未触发 onPluginEnter、组件未重建）的场景。
   // Electron 下用 win.hide() 隐藏窗口不会触发 document 的 visibilitychange，
   // 但会触发 window 的 blur/focus，故监听 window 级 focus：仅当此前确实失焦过
   // （即窗口曾进入后台）才在恢复时重新聚焦 + 全选，避免页面内交互误触发。
+  // keep-alive 缓存后切 tab 不重挂载，监听只需在 onMounted 挂一次、onUnmounted 移除。
   window.addEventListener('blur', onWinBlur)
   window.addEventListener('focus', onWinFocus)
+})
+
+// keep-alive 缓存后切回翻译 tab 触发 onActivated：聚焦 + 全选原文，
+// 复用 onMounted 同一逻辑（此处不再 refreshProviderStatus / 重挂窗监听）。
+onActivated(() => {
+  nextTick(focusAndSelectAll)
 })
 
 // 记录窗口是否进入过后台。仅当为 true 时，下一次 focus 才视为「从后台恢复」。


### PR DESCRIPTION
## 插件信息

- **名称**: ZTools 提供商
- **插件ID**: f-provider
- **版本**: 1.0.5
- **描述**: OCR + 翻译提供商集合（百度/谷歌/有道/微软翻译、微信 OCR）
- **作者**: kaineooo
- **类型**: 更新

## 本次变更

- feat: ZTools OCR + 翻译提供商插件（截图识别 / 代码翻译 / manage）
- chore: 调整插件命名空间
- chore: 调整资源url
- feat: 微信 OCR 原生模块支持 macOS（libwxocr.dylib）
- feat: 截图识别结果改为独立窗口展示（左图右文 + 拖动缩放）
- feat: 翻译视图进入/恢复时自动聚焦并全选原文
- fix: 翻译/代码翻译命令的 regex match 补回 /…/ 边界
- chore: 版本号升至 1.0.2，开发端口改为 5179
- refactor: native 引擎改由 npmmirror npm 包分发，落地至 userData 目录
- chore: 版本号升至 1.0.3
- refactor: 截图识别结果窗口改用原生标题栏并隐藏菜单栏，初始尺寸下限 800×600
- feat: 新增 LaTeX 公式识别引擎及去重打包发布链路
- feat: HTTP 请求支持系统代理（CONNECT 隧道），谷歌翻译改用官方 translate.googleapis.com 接口
- refactor: 翻译/代码翻译入口由 regex 改为 over 类型
- feat: native/LaTeX 引擎改由 GitHub Release 分发并单例化引擎状态
- fix: 为 Electron 沙箱 preload 补全 setImmediate polyfill
- feat: 引擎下载支持镜像竞速/加速点选择/取消，合并识别子页并重构设置布局
- fix: 收敛 onPluginEnter 至 App.vue 避免覆盖式劫持，版本升至 1.0.4
- refactor: 截图识别收敛至插件内流程并移除独立结果窗口
- feat: 新增历史记录模块及 tab 状态缓存
- chore: 升级版本号至 1.0.5
- docs: 对齐 README 至现状，补充 LaTeX/历史记录与 macOS 支持，修正微信复用措辞

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/f-provider/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
