### PR TITLE
Update plugin ZTools 提供商 v1.1.0

### DIFF
--- a/plugins/f-provider/package-lock.json
+++ b/plugins/f-provider/package-lock.json
@@ -11,7 +11,7 @@
         "katex": "^0.16.11",
         "vue": "^3.5.13",
         "vue-router": "^4.6.4",
-        "ztools-ui": "^0.1.3"
+        "ztools-ui": "^0.1.5"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^5.2.1",
@@ -645,9 +645,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -669,9 +666,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -693,9 +687,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -717,9 +708,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -741,9 +729,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,9 +750,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2249,9 +2231,9 @@
       }
     },
     "node_modules/ztools-ui": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ztools-ui/-/ztools-ui-0.1.3.tgz",
-      "integrity": "sha512-Pr+3y1QUtf4lE74U49vE440sgaptYHcngieu2rYfK1n4KuYXV07Xqd9Yn7Mm4UpUilE1G/tW2H4JTLh4Uf9pYA==",
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/ztools-ui/-/ztools-ui-0.1.5.tgz",
+      "integrity": "sha512-ZcFEGXHr1il9/yK72cFCNwlOf04obNcCrvwtPzGjlT/VTdedFnyufi8O+p0W6MN8+AFbNqTptWSpCRDMemfjtw==",
       "dependencies": {
         "@vueuse/core": "^12.7.0",
         "marked": "^15.0.7"

--- a/plugins/f-provider/package.json
+++ b/plugins/f-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wechat-ocr-provider",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "基于微信内置 OCR 引擎的离线图片文字识别 ZTools Provider",
   "type": "module",
   "scripts": {
@@ -15,7 +15,7 @@
     "katex": "^0.16.11",
     "vue": "^3.5.13",
     "vue-router": "^4.6.4",
-    "ztools-ui": "^0.1.3"
+    "ztools-ui": "^0.1.5"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.1",

--- a/plugins/f-provider/public/plugin.json
+++ b/plugins/f-provider/public/plugin.json
@@ -4,7 +4,7 @@
   "title": "ZTools 提供商",
   "description": "OCR + 翻译提供商集合（百度/谷歌/有道/微软翻译、微信 OCR）",
   "author": "kaineooo",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "main": "index.html",
   "preload": "preload/services.js",
   "logo": "logo.png",
@@ -16,11 +16,6 @@
       "type": "ocr",
       "label": "微信 OCR",
       "description": "调用本机微信内置 OCR 引擎，离线识别图片文字"
-    },
-    "latex-ocr": {
-      "type": "ocr",
-      "label": "公式识别",
-      "description": "本地 ONNX 神经网络识别图片中的数学公式为 LaTeX（离线，无需密钥）"
     },
     "baidu": {
       "type": "translation",
@@ -41,6 +36,16 @@
       "type": "translation",
       "label": "微软翻译",
       "description": "微软 Edge 翻译（免密钥，两种鉴权方案）"
+    },
+    "ai-translation": {
+      "type": "translation",
+      "label": "AI 翻译",
+      "description": "基于大语言模型翻译（复用 ZTools 已配置的 AI 模型，无需密钥）"
+    },
+    "ai-ocr": {
+      "type": "ocr",
+      "label": "AI 识图",
+      "description": "基于视觉模型识别图片文字（需选择支持视觉的模型）"
     }
   },
   "features": [
@@ -114,34 +119,60 @@
       "cmds": [
         "截图识别公式"
       ]
+    },
+    {
+      "code": "ocr-translate",
+      "explain": "识别图片文字并翻译",
+      "icon": "logo.png",
+      "cmds": [
+        {
+          "type": "img",
+          "label": "识别图片并翻译"
+        },
+        {
+          "type": "files",
+          "extensions": ["png", "jpg", "jpeg", "gif", "bmp", "webp"],
+          "maxLength": 1,
+          "label": "识别图片并翻译"
+        }
+      ]
+    },
+    {
+      "code": "screen-ocr-translate",
+      "explain": "截屏并识别图中文字翻译",
+      "icon": "logo.png",
+      "platform": ["win32", "darwin"],
+      "cmds": [
+        "截图识别并翻译"
+      ]
     }
   ],
   "native": {
     "win": {
-      "downloadUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.5/native-win.zip",
+      "downloadUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.1.0/native-win.zip",
       "sha256": "",
-      "version": "1.0.5"
+      "version": "1.1.0"
     },
     "mac": {
-      "downloadUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.5/native-mac.zip",
+      "downloadUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.1.0/native-mac.zip",
       "sha256": "",
-      "version": "1.0.5"
+      "version": "1.1.0"
     }
   },
   "nativeLatex": {
     "win": {
-      "ortUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.5/latex-ort-win.zip",
-      "modelsUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.5/latex-models.zip",
+      "ortUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.1.0/latex-ort-win.zip",
+      "modelsUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.1.0/latex-models.zip",
       "ortSha256": "",
       "modelsSha256": "",
-      "version": "1.0.5"
+      "version": "1.1.0"
     },
     "mac": {
-      "ortUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.5/latex-ort-mac.zip",
-      "modelsUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.0.5/latex-models.zip",
+      "ortUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.1.0/latex-ort-mac.zip",
+      "modelsUrl": "https://github.com/kaineooo/f-provider/releases/download/v1.1.0/latex-models.zip",
       "ortSha256": "",
       "modelsSha256": "",
-      "version": "1.0.5"
+      "version": "1.1.0"
     }
   }
 }

--- a/plugins/f-provider/public/preload/services.js
+++ b/plugins/f-provider/public/preload/services.js
@@ -6,6 +6,77 @@ const http = require('node:http')
 const crypto = require('node:crypto')
 const { URL } = require('node:url')
 
+// ─── multipart/form-data body 构造（图床文件上传用）──────────────────────────
+// 手搓 boundary 拼装，避免引入第三方 form-data 包。
+//   fields：字符串键值对（如 { storage_destination: 'r2' }）
+//   files ：{ key: { filename, contentType, data: Buffer } }
+// 返回可直接作为 HTTP body 写出的完整 Buffer。
+function _buildMultipartBody(boundary, multipart) {
+  const parts = []
+  const enc = (s) => Buffer.from(s, 'utf8')
+  if (multipart.fields) {
+    for (const [k, v] of Object.entries(multipart.fields)) {
+      parts.push(enc(
+        '--' + boundary + '\r\n' +
+        'Content-Disposition: form-data; name="' + k + '"\r\n\r\n' +
+        String(v) + '\r\n'
+      ))
+    }
+  }
+  if (multipart.files) {
+    for (const [k, f] of Object.entries(multipart.files)) {
+      const fn = (f && f.filename) || 'upload.bin'
+      const ct = (f && f.contentType) || 'application/octet-stream'
+      const data = f && f.data
+      if (!Buffer.isBuffer(data)) continue
+      parts.push(enc(
+        '--' + boundary + '\r\n' +
+        'Content-Disposition: form-data; name="' + k + '"; filename="' + fn + '"\r\n' +
+        'Content-Type: ' + ct + '\r\n\r\n'
+      ))
+      parts.push(data)
+      parts.push(enc('\r\n'))
+    }
+  }
+  parts.push(enc('--' + boundary + '--\r\n'))
+  return Buffer.concat(parts)
+}
+
+// ─── 图床适配器注册表（可扩展）─────────────────────────────────────────────
+// 每个图床一个对象：{ name, description, upload(buf, ext, mime) -> { url } }。
+// upload 内 this 绑定为 services，可复用 this._httpRequest（代理/重定向/超时统一）。
+// 后续新增图床只需在此表加一项 + ImageHostType 联合类型扩一项即可。
+const IMAGE_HOST_ADAPTORS = {
+  'img-scdn': {
+    name: 'img.scdn.io',
+    description: '免鉴权图床，支持 Cloudflare R2 存储（storage_destination=r2）',
+    // buf: 图片二进制 Buffer；ext/mime 用于 multipart 文件头。返回 { url }。
+    async upload(buf, ext, mime) {
+      const filename = 'upload.' + (ext || 'png')
+      const resp = await this._httpRequest('POST', 'https://img.scdn.io/api/v1.php', {
+        multipart: {
+          fields: { storage_destination: 'r2' },
+          files: { image: { filename, contentType: mime, data: buf } }
+        },
+        timeoutMs: 30000
+      })
+      if (resp.status >= 400) {
+        throw new Error('img.scdn.io 上传失败：HTTP ' + resp.status)
+      }
+      let json
+      try { json = JSON.parse(resp.body) }
+      catch (e) {
+        throw new Error('img.scdn.io 返回非 JSON：' + String(resp.body).slice(0, 200))
+      }
+      if (!json || !json.success || !json.url) {
+        const msg = (json && (json.message || json.error)) ? (json.message || json.error) : 'img.scdn.io 未返回 url'
+        throw new Error(msg)
+      }
+      return { url: json.url }
+    }
+  }
+}
+
 // GitHub Release 下载加速镜像列表（竞速选最快）。
 // 对 github.com 域名的下载 URL，并发请求各镜像，谁先返回响应头即胜出，
 // 全部失败/超时则回退原始 URL 直连，保证不卡死。
@@ -1026,6 +1097,13 @@ async _httpRequest(method, url, opts) {
       bodyBuf = Buffer.from(new URLSearchParams(opts.form).toString(), 'utf8')
       headers['Content-Type'] = headers['Content-Type'] || 'application/x-www-form-urlencoded'
       headers['Content-Length'] = bodyBuf.length
+    } else if (opts.multipart !== undefined) {
+      // multipart/form-data 文件上传（图床用）：手搓 boundary，
+      // 由 _buildMultipartBody 拼装 fields + 文件 Buffer 为完整 body。
+      const boundary = '----ztools' + crypto.randomBytes(8).toString('hex')
+      bodyBuf = _buildMultipartBody(boundary, opts.multipart)
+      headers['Content-Type'] = headers['Content-Type'] || ('multipart/form-data; boundary=' + boundary)
+      headers['Content-Length'] = bodyBuf.length
     } else if (opts.body !== undefined) {
       bodyBuf = Buffer.from(String(opts.body), 'utf8')
       headers['Content-Length'] = bodyBuf.length
@@ -1155,7 +1233,12 @@ getTranslateSettings(provider) {
     baidu: { appID: '', appKey: '' },
     google: {},
     youdao: { appKey: '', appSecret: '' },
-    microsoft: { requestMode: 'signature' } // 'signature' | 'edge'
+    microsoft: { requestMode: 'signature' }, // 'signature' | 'edge'
+    // AI 翻译：复用宿主已配置的 AI 模型（走 ztools.ai），此处只存模型选择与 prompt 模板，不存密钥。
+    'ai-translation': {
+      model: '',
+      systemPrompt: '你是一个专业翻译。将用户输入翻译成 {to}，只输出译文，不要解释或附加说明。'
+    }
   }
   const base = defaults[provider] || {}
   const stored = window.ztools.dbStorage.getItem('translate.' + provider) || {}
@@ -1170,6 +1253,84 @@ getTranslateSettings(provider) {
 setTranslateSettings(provider, data) {
   data = data || {}
   window.ztools.dbStorage.setItem('translate.' + provider, data)
+},
+
+// 读某 OCR provider 的设置（合并默认值）。现有 ocr 无配置，
+// ai-ocr 与 ai-latex-ocr 复用宿主 AI 视觉模型，需模型选择与 prompt 模板（不存密钥）。
+getOcrSettings(provider) {
+  const defaults = {
+    'ai-ocr': {
+      model: '',
+      systemPrompt: '识别图片中的所有文字，按原文逐行输出，只输出识别到的文字，不要解释或附加说明。'
+    },
+    'ai-latex-ocr': {
+      model: '',
+      systemPrompt: '识别图片中的数学公式并输出对应的 LaTeX 源码。只输出 LaTeX 代码，不要用 $ 或 $$ 包裹，不要解释或附加说明。'
+    }
+  }
+  const base = defaults[provider] || {}
+  const stored = window.ztools.dbStorage.getItem('ocr.' + provider) || {}
+  return Object.assign({}, base, stored)
+},
+
+// 写某 OCR provider 的设置到 ztools.dbStorage。
+setOcrSettings(provider, data) {
+  data = data || {}
+  window.ztools.dbStorage.setItem('ocr.' + provider, data)
+},
+
+// ─── 图床（AI 识图/公式识别的图片上传通道，可扩展）─────────────────────────
+// 配置存 dbStorage key 'ocr.image-host'，ai-ocr 与 ai-latex-ocr 共用。
+// 默认 enabled=true：升级即生效；关闭或上传失败由 ocrAi/latexAi 回退 base64 直传。
+getImageHostSettings() {
+  const defaults = { enabled: true, type: 'img-scdn' }
+  const stored = window.ztools.dbStorage.getItem('ocr.image-host') || {}
+  return Object.assign({}, defaults, stored)
+},
+
+setImageHostSettings(data) {
+  data = data || {}
+  window.ztools.dbStorage.setItem('ocr.image-host', data)
+},
+
+// 把图片上传到已启用图床，返回可访问 URL；关闭/未知类型/上传失败返回 null。
+// image 可为 本地路径 / data URI / http(s) URL；已是 URL 直接原样返回不二次转存。
+async uploadImage(image) {
+  if (!image) return null
+  const cfg = this.getImageHostSettings()
+  if (!cfg || !cfg.enabled) { console.debug('[image-host] disabled, skip'); return null }
+  const adapter = IMAGE_HOST_ADAPTORS[cfg.type]
+  if (!adapter) { console.debug('[image-host] unknown type, skip:', cfg.type); return null }
+  // 已是 http(s) URL（如已有图床链接或网络图片），图床无需二次转存，直接返回。
+  if (/^https?:\/\//i.test(image)) { console.debug('[image-host] http(s) url passthrough'); return image }
+  // 归一化为 { buf, ext, mime }
+  let buf, ext, mime
+  const mimeMap = {
+    png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg',
+    gif: 'image/gif', bmp: 'image/bmp', webp: 'image/webp', svg: 'image/svg+xml'
+  }
+  if (/^data:/i.test(image)) {
+    const m = /^data:([^;]+);base64,/i.exec(image)
+    mime = (m && m[1]) || 'image/png'
+    ext = (mime.split('/')[1] || 'png').replace('svg+xml', 'svg').toLowerCase()
+    buf = Buffer.from(image.split(',')[1] || '', 'base64')
+  } else {
+    // 本地路径：读取二进制，按扩展名推断 mime。
+    buf = fs.readFileSync(image)
+    ext = (path.extname(image).replace(/^\./, '').toLowerCase()) || 'png'
+    mime = mimeMap[ext] || 'image/png'
+  }
+  console.debug('[image-host] uploading', { type: cfg.type, ext, mime, bytes: buf.length })
+  const t0 = Date.now()
+  try {
+    const out = await adapter.upload.call(this, buf, ext, mime)
+    const url = (out && out.url) || null
+    console.debug('[image-host] upload ok', { ms: Date.now() - t0, urlLen: url ? url.length : 0 })
+    return url
+  } catch (e) {
+    console.warn('[image-host] upload failed (' + (Date.now() - t0) + 'ms), fallback to base64:', e && e.message ? e.message : e)
+    return null
+  }
 },
 
 // 把中性语言码映射到 provider 自家码；不支持的语种返回 null。
@@ -1358,7 +1519,135 @@ async translateMicrosoft(text, from, to) {
     throw new Error('微软翻译返回异常: ' + resp.body.slice(0, 200))
   }
   return { text: arr[0].translations[0].text, detectedFrom: from }
+  },
+
+// ─── AI 翻译 / AI OCR（走宿主 ztools.ai）─────────────────────────────────
+// 复用宿主已配置的 AI 模型，本插件不存 apiKey/baseUrl，仅存模型选择与 prompt 模板。
+// ztools.ai 非流式返回 { content, reasoning_content? }；system 提示须放进 messages[0]。
+// 注意：handler 内 this 不是 services，故这两个方法经 window.services.xxx 调用时，
+// 内部若要读配置须用 this.getTranslateSettings / this.getOcrSettings（与其它翻译方法一致）。
+
+// AI 翻译：input { text, from?, to? } -> { text, detectedFrom? }
+// model 留空则 ztools.ai 自动按宿主已启用供应商顺序选首个模型；prompt 模板支持 {from}/{to} 占位。
+async translateAi(text, from, to) {
+  if (!to) to = this._resolveDefaultTargetLang(text) // 未指定目标语言时按内容推断（中→英，其余→中）
+  const { model, systemPrompt } = this.getTranslateSettings('ai-translation')
+  const prompt = (systemPrompt || '')
+    .replace(/\{from\}/g, from && from !== 'auto' ? from : '自动检测')
+    .replace(/\{to\}/g, to)
+  const res = await window.ztools.ai({
+    model: model || undefined,
+    messages: [
+      { role: 'system', content: prompt },
+      { role: 'user', content: text || '' }
+    ]
+  })
+  const out = (res && res.content ? String(res.content) : '').trim()
+  if (!out) throw new Error('AI 翻译返回为空，请检查 ZTools AI 模型配置')
+  return { text: out, detectedFrom: from }
+},
+
+// AI OCR：input { image, lang? } -> { text, blocks?, confidence? }
+// image 可为 本地路径 / data URI / http(s) URL：本地路径经 readFileAsDataURL 转 data URI 后传入。
+// 必须选择支持视觉的模型，宿主不识别「视觉模型」概念，纯文本模型会由远端报错透传。
+async ocrAi(image, lang) {
+  const { model, systemPrompt } = this.getOcrSettings('ai-ocr')
+  if (!model) throw new Error('AI 识图未选择模型，请在「翻译/OCR 提供商」设置页选择支持视觉的模型')
+  if (!image) throw new Error('AI 识图未提供图片')
+  console.debug('[ai-ocr] start', { model, lang: lang || null, src: image.slice(0, 24) + (image.length > 24 ? '…(' + image.length + ')' : '') })
+  // 先走图床（开启时）拿可访问 URL，省 token 且防大图 base64 截断；
+  // 关闭 / 未知类型 / 上传失败时 uploadImage 返回 null，回退本地路径转 data URI。
+  let imageUrl = await this.uploadImage(image)
+  if (!imageUrl) {
+    if (!/^https?:\/\//i.test(image) && !/^data:/i.test(image)) {
+      imageUrl = this.readFileAsDataURL(image)
+      console.debug('[ai-ocr] image-host miss → local-path data URI', { dataUriLen: imageUrl.length })
+    } else {
+      imageUrl = image
+      console.debug('[ai-ocr] image-host miss → input passthrough', { kind: /^data:/i.test(image) ? 'data-uri' : 'http' })
+    }
+  } else {
+    console.debug('[ai-ocr] image-host hit', { urlLen: imageUrl.length })
   }
+  const t0 = Date.now()
+  const res = await window.ztools.ai({
+    model,
+    messages: [
+      { role: 'system', content: systemPrompt || '识别图片中的所有文字，只输出识别到的文字。' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: lang ? `请识别这张图片中的文字（语言：${lang}）。` : '请识别这张图片中的所有文字。' },
+          { type: 'image_url', image_url: { url: imageUrl, detail: 'high' } }
+        ]
+      }
+    ]
+  })
+  const out = (res && res.content ? String(res.content) : '').trim()
+  console.debug('[ai-ocr] ai done', { ms: Date.now() - t0, contentLen: out.length })
+  if (!out) throw new Error('AI 识图返回为空，请确认所选模型支持视觉输入')
+  return { text: out }
+},
+
+// AI 公式识别：input { image } -> { latex }
+// 复用宿主 AI 视觉模型（与 ocrAi 同机制），但走独立的 ai-latex-ocr 配置块
+// （独立 model + systemPrompt，prompt 要求输出 LaTeX 源码）。
+// image 可为 本地路径 / data URI / http(s) URL：本地路径经 readFileAsDataURL 转 data URI 后传入。
+// 防御性剔除 AI 可能误加的 markdown 代码块围栏与 $/$$ 包裹，保证 KaTeX 可直接渲染。
+async latexAi(image) {
+  const { model, systemPrompt } = this.getOcrSettings('ai-latex-ocr')
+  if (!model) throw new Error('AI 公式识别未选择模型，请在「翻译/OCR 提供商」设置页选择支持视觉的模型')
+  if (!image) throw new Error('AI 公式识别未提供图片')
+  console.debug('[ai-latex] start', { model, src: image.slice(0, 24) + (image.length > 24 ? '…(' + image.length + ')' : '') })
+  // 先走图床（开启时）拿可访问 URL；关闭/失败回退本地路径转 data URI（与 ocrAi 一致）。
+  let imageUrl = await this.uploadImage(image)
+  if (!imageUrl) {
+    if (!/^https?:\/\//i.test(image) && !/^data:/i.test(image)) {
+      imageUrl = this.readFileAsDataURL(image)
+      console.debug('[ai-latex] image-host miss → local-path data URI', { dataUriLen: imageUrl.length })
+    } else {
+      imageUrl = image
+      console.debug('[ai-latex] image-host miss → input passthrough', { kind: /^data:/i.test(image) ? 'data-uri' : 'http' })
+    }
+  } else {
+    console.debug('[ai-latex] image-host hit', { urlLen: imageUrl.length })
+  }
+  const t0 = Date.now()
+  const res = await window.ztools.ai({
+    model,
+    messages: [
+      { role: 'system', content: systemPrompt || '识别图片中的数学公式并输出对应的 LaTeX 源码。只输出 LaTeX 代码，不要用 $ 或 $$ 包裹，不要解释或附加说明。' },
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: '请识别这张图片中的数学公式并输出 LaTeX 源码。' },
+          { type: 'image_url', image_url: { url: imageUrl, detail: 'high' } }
+        ]
+      }
+    ]
+  })
+  let out = (res && res.content ? String(res.content) : '').trim()
+  console.debug('[ai-latex] ai done', { ms: Date.now() - t0, contentLen: out.length })
+  if (!out) throw new Error('AI 公式识别返回为空，请确认所选模型支持视觉输入')
+  const before = out.length
+  out = this._stripLatexFencing(out)
+  console.debug('[ai-latex] stripped fencing', { before, after: out.length })
+  return { latex: out }
+},
+
+// 剔除 AI 输出常见的 markdown 代码块围栏与 $/$$ 包裹，得到纯净 LaTeX 源码。
+// 处理：```latex\n...\n``` / ```\n...\n``` 围栏；首尾的 $$...$$ / $...$ 包裹。
+_stripLatexFencing(s) {
+  let t = String(s || '').trim()
+  // ```lang\n...\n``` 或 ```\n...\n```
+  const fence = t.match(/^```[a-zA-Z]*\s*\n([\s\S]*?)\n```$/)
+  if (fence) t = fence[1].trim()
+  // 首尾 $$...$$
+  if (t.startsWith('$$') && t.endsWith('$$')) t = t.slice(2, -2).trim()
+  // 首尾 $...$（避免误伤 $ 内部含 $ 的情形：仅当首尾各恰好一个 $ 时剥离）
+  else if (t.startsWith('$') && t.endsWith('$') && t.length >= 2) t = t.slice(1, -1).trim()
+  return t
+}
 }
 
 // ─── 注册 Providers ──────────────────────────────────────────────────────
@@ -1367,13 +1656,6 @@ async translateMicrosoft(text, from, to) {
 ztools.registerProvider('ocr', async (input) => {
   const { image } = input || {}
   return await window.services.ocrRecognize(image)
-})
-
-// LaTeX 公式识别 OCR 契约（与 ocr 一致）：input { image } -> { text, blocks, confidence }
-// text 为识别出的 LaTeX 源码；blocks 为单元素数组（整段公式）。
-ztools.registerProvider('latex-ocr', async (input) => {
-  const { image } = input || {}
-  return await window.services.latexRecognize(image)
 })
 
 // 翻译契约（对齐宿主 TranslationInput/Output）：
@@ -1395,4 +1677,16 @@ ztools.registerProvider('youdao', async (input) => {
 ztools.registerProvider('microsoft', async (input) => {
   const { text, from, to } = input || {}
   return await window.services.translateMicrosoft(text, from, to)
+})
+
+// AI 翻译（走宿主 ztools.ai）：input { text, from?, to? } -> { text, detectedFrom? }
+ztools.registerProvider('ai-translation', async (input) => {
+  const { text, from, to } = input || {}
+  return await window.services.translateAi(text, from, to)
+})
+
+// AI 识图（走宿主 ztools.ai，需视觉模型）：input { image, lang? } -> { text }
+ztools.registerProvider('ai-ocr', async (input) => {
+  const { image, lang } = input || {}
+  return await window.services.ocrAi(image, lang)
 })

--- a/plugins/f-provider/src/Manage/index.vue
+++ b/plugins/f-provider/src/Manage/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, markRaw, watch, onMounted } from 'vue'
+import { ref, computed, markRaw, watch, onMounted, nextTick } from 'vue'
 import SettingLayout from '../components/SettingLayout.vue'
 import type { NavItem } from '../components/SettingLayout.vue'
 import Settings from '../views/Settings.vue'
@@ -43,6 +43,41 @@ function onHistory(item: HistoryEmitItem) {
   pushHistory(item)
 }
 
+/**
+ * 识别并翻译联动：Recognize 文字识别成功后上抛识别文字，
+ * 切到「翻译」tab 并预填原文、重建 Translate 实例触发一次翻译
+ * （:key 含 enterSeq，重建后 initialText watcher 立即 run，即使文本相同也重跑）。
+ */
+function onOcrToTranslate(text: string) {
+  if (!text) return
+  initialText.value = text
+  // 清空 ocrText：自动联动走重建实例 + initialText watch 预填，
+  // 不再让下方 watch(activeKey) 二次 applyText（避免新实例就绪前后重复翻译）。
+  ocrText.value = ''
+  activeKey.value = 'translate'
+  enterSeq.value++
+}
+
+/**
+ * Recognize 文字识别成功后同步当前识别文本：供用户手动切到「翻译」tab 时带入。
+ * 与 onOcrToTranslate（translateAfterOcr 自动联动、重建实例）不同：
+ * 此处仅暂存文本，不切 tab、不重建，等用户手动切到翻译 tab 时由
+ * watch(activeKey) 调用 Translate 实例的 applyText 预填（保留已有翻译结果）。
+ */
+const ocrText = ref('')
+function onOcrTextResult(text: string) {
+  ocrText.value = text
+}
+
+/**
+ * Translate 组件实例引用：用于手动切 tab 时调用其 applyText 预填 OCR 文本。
+ * .vue 的模块声明丢失 defineExpose 类型，故用本地接口约束可见方法。
+ */
+interface TranslateExposed {
+  applyText: (text: string) => void
+}
+const translateRef = ref<TranslateExposed | null>(null)
+
 const activeKey = ref('settings')
 
 // 识别页当前模式（由 Recognize 上报）：公式模式下底部悬浮栏左对齐，
@@ -71,6 +106,12 @@ const initialMode = ref<'text' | 'formula'>('text')
  * 截图结果留在主窗口内展示，不再弹独立窗口。
  */
 const autoCapture = ref(false)
+/**
+ * 进入即识别完成并自动翻译（screen-ocr-translate / ocr-translate feature）。
+ * 仅这两个「识别并翻译」入口置 true，由 Recognize 在文字识别成功后上抛 translate 事件，
+ * 本容器接收后切到「翻译」tab 并预填识别文字、触发一次翻译。
+ */
+const autoTranslateAfterOcr = ref(false)
 // 组件重建 key：每次进入递增，强制 <component> 卸载旧实例、挂载全新实例。
 const enterSeq = ref(0)
 
@@ -126,6 +167,8 @@ watch(
     initialText.value = ''
     initialMode.value = 'text'
     autoCapture.value = false
+    autoTranslateAfterOcr.value = false
+    ocrText.value = ''
     // 截图识别 feature：进入「OCR 识别」并自动触发截屏，结果留主窗口内展示
     if (action.code === 'screen-ocr' || action.code === 'screen-latex') {
       initialMode.value = action.code === 'screen-latex' ? 'formula' : 'text'
@@ -134,11 +177,25 @@ watch(
       enterSeq.value++
       return
     }
+    // 截图识别并翻译 feature：进入「OCR 识别」+ 文字模式 + 自动截屏 + 识别完成自动翻译
+    if (action.code === 'screen-ocr-translate') {
+      initialMode.value = 'text'
+      activeKey.value = 'recognize'
+      autoCapture.value = true
+      autoTranslateAfterOcr.value = true
+      enterSeq.value++
+      return
+    }
     if (action.type === 'img' || action.type === 'files') {
       const img = extractImage(action)
       if (img) {
-        // latex-recognize feature → 公式模式；其它 → 文字模式
-        initialMode.value = action.code === 'latex-recognize' ? 'formula' : 'text'
+        // 模式判定：latex-recognize → 公式；ocr-translate → 文字 + 识别后翻译；其它 → 文字
+        if (action.code === 'ocr-translate') {
+          initialMode.value = 'text'
+          autoTranslateAfterOcr.value = true
+        } else {
+          initialMode.value = action.code === 'latex-recognize' ? 'formula' : 'text'
+        }
         activeKey.value = 'recognize'
         initialImage.value = img
         enterSeq.value++
@@ -157,6 +214,22 @@ watch(
   },
   { immediate: true }
 )
+
+/**
+ * 用户手动切到「翻译」tab 时，若当前有 OCR 识别结果，带入翻译输入框。
+ * 走 translateRef.applyText 而非重建实例：保留翻译 tab 已有的译文/渠道等状态，
+ * 仅预填原文并触发一次翻译（applyText 内已 suppress 自动翻译避免重复）。
+ * 自动联动场景（translateAfterOcr）已在 onOcrToTranslate 中清空 ocrText 并重建实例，
+ * 此处不会二次触发。
+ */
+watch(activeKey, (key) => {
+  if (key !== 'translate') return
+  if (!ocrText.value) return
+  // 下一 tick 确保 keep-alive 缓存实例已激活、translateRef 已绑定
+  nextTick(() => {
+    translateRef.value?.applyText(ocrText.value)
+  })
+})
 
 onMounted(() => {
   // 读取 plugin.json 中的 native / nativeLatex 版本号用于侧边栏展示
@@ -190,13 +263,17 @@ onMounted(() => {
       :initial-image="initialImage"
       :initial-mode="initialMode"
       :auto-capture="autoCapture"
+      :translate-after-ocr="autoTranslateAfterOcr"
       @mode-change="onRecognizeModeChange"
       @history="onHistory"
+      @translate="onOcrToTranslate"
+      @text-result="onOcrTextResult"
     />
   </KeepAlive>
   <KeepAlive>
     <Translate
       v-if="activeKey === 'translate'"
+      ref="translateRef"
       :key="'translate-' + enterSeq"
       :initial-text="initialText"
       @history="onHistory"

--- a/plugins/f-provider/src/components/HistoryView.vue
+++ b/plugins/f-provider/src/components/HistoryView.vue
@@ -210,7 +210,8 @@ const PROVIDER_LABELS: Record<TranslateProviderName, string> = {
   baidu: '百度翻译',
   google: '谷歌翻译',
   youdao: '有道翻译',
-  microsoft: '微软翻译'
+  microsoft: '微软翻译',
+  'ai-translation': 'AI 翻译'
 }
 
 function langLabel(code: string): string {

--- a/plugins/f-provider/src/components/OcrImageViewer.vue
+++ b/plugins/f-provider/src/components/OcrImageViewer.vue
@@ -123,14 +123,18 @@ interface OverlayLine {
 }
 
 const overlays = computed<OverlayLine[]>(() =>
-  props.lines.map((l) => ({
-    text: l.text,
-    rate: l.rate,
-    left: pct(l.left, naturalWidth.value),
-    top: pct(l.top, naturalHeight.value),
-    width: pct(l.right - l.left, naturalWidth.value),
-    height: pct(l.bottom - l.top, naturalHeight.value)
-  }))
+  // 过滤坐标无效的行（AI 识图渠道返回的伪 OcrLine 坐标全 0），
+  // 避免文字叠层全部叠到图片左上角。真实微信 OCR 行坐标恒为正，不受影响。
+  props.lines
+    .filter((l) => l.right > l.left && l.bottom > l.top)
+    .map((l) => ({
+      text: l.text,
+      rate: l.rate,
+      left: pct(l.left, naturalWidth.value),
+      top: pct(l.top, naturalHeight.value),
+      width: pct(l.right - l.left, naturalWidth.value),
+      height: pct(l.bottom - l.top, naturalHeight.value)
+    }))
 )
 
 // 列表↔图片高亮联动：鼠标在某一侧 hover 时另一侧同步高亮

--- a/plugins/f-provider/src/components/ProviderLogo.vue
+++ b/plugins/f-provider/src/components/ProviderLogo.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 /**
- * 翻译服务商 logo（来自官网 favicon，本地图片，无外链）。
+ * 翻译/OCR 服务商 logo（传统厂商来自官网 favicon 本地图片，无外链）。
+ * AI 系列无独立图标，使用内联 SVG dataURI 作为占位（紫底白字 AI）。
  */
 import baiduLogo from '../assets/baidu.png'
 import googleLogo from '../assets/google.png'
@@ -9,14 +10,46 @@ import microsoftLogo from '../assets/microsoft.png'
 
 defineProps<{
   /** 服务商 key */
-  name: 'baidu' | 'google' | 'youdao' | 'microsoft'
+  name:
+    | 'baidu'
+    | 'google'
+    | 'youdao'
+    | 'microsoft'
+    | 'ai-translation'
+    | 'ai-ocr'
+    | 'ai-latex-ocr'
+    | 'image-host'
 }>()
 
-const logos: Record<'baidu' | 'google' | 'youdao' | 'microsoft', string> = {
+// AI provider 的占位图标：紫色圆角方块 + 白色 "AI" 字样。
+const aiLogo =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">' +
+      '<rect width="48" height="48" rx="10" fill="#6c5ce7"/>' +
+      '<text x="24" y="32" font-family="Arial,sans-serif" font-size="20" font-weight="bold" fill="#fff" text-anchor="middle">AI</text>' +
+      '</svg>'
+  )
+
+// 图床占位图标：紫底白"图"字（与 AI 系列同结构，便于视觉区分）。
+const imageHostLogo =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">' +
+      '<rect width="48" height="48" rx="10" fill="#6c5ce7"/>' +
+      '<text x="24" y="32" font-family="Arial,sans-serif" font-size="20" font-weight="bold" fill="#fff" text-anchor="middle">图</text>' +
+      '</svg>'
+  )
+
+const logos = {
   baidu: baiduLogo,
   google: googleLogo,
   youdao: youdaoLogo,
-  microsoft: microsoftLogo
+  microsoft: microsoftLogo,
+  'ai-translation': aiLogo,
+  'ai-ocr': aiLogo,
+  'ai-latex-ocr': aiLogo,
+  'image-host': imageHostLogo
 }
 </script>
 

--- a/plugins/f-provider/src/composables/useHistory.ts
+++ b/plugins/f-provider/src/composables/useHistory.ts
@@ -20,13 +20,27 @@ const MAX_ITEMS = 100
 // ─── 模块级单例（进程内唯一，跨组件共享）────────────────────────────────
 const historyList = ref<HistoryItem[]>([])
 
-/** 从 dbStorage 载入历史记录到单例 ref。启动时调一次。 */
+/**
+ * 是否已完成首次载入。
+ *
+ * 历史记录单例是模块级 ref，进程内始终存活，无需每次 Manage 重新挂载都重读
+ * dbStorage。更关键的是：若在 pushHistory（写入内存 + 触发异步写盘）之后
+ * Manage 被卸载重建触发 loadHistory，会用 dbStorage 里的旧快照覆盖内存中
+ * 刚写入的新记录，导致历史丢失。故 loadHistory 只在模块首次加载时执行一次，
+ * 后续重复调用直接跳过。
+ */
+let loaded = false
+
+/** 从 dbStorage 载入历史记录到单例 ref。仅在模块首次加载时执行一次。 */
 function loadHistory(): void {
+  if (loaded) return
+  loaded = true
   try {
     const stored = window.ztools.dbStorage.getItem<HistoryItem[]>(STORAGE_KEY)
     historyList.value = Array.isArray(stored) ? stored : []
-  } catch (_) {
-    // dbStorage 不可用等异常：保持空列表，不阻塞 UI
+  } catch (e) {
+    // dbStorage 不可用等异常：保持空列表，不阻塞 UI；记录原因便于排查
+    console.warn('[useHistory] loadHistory 读取 dbStorage 失败:', e)
     historyList.value = []
   }
 }
@@ -34,9 +48,15 @@ function loadHistory(): void {
 /** 同步当前单例列表到 dbStorage。 */
 function persist(): void {
   try {
-    window.ztools.dbStorage.setItem(STORAGE_KEY, historyList.value)
-  } catch (_) {
-    /* 写入失败不阻塞 UI */
+    // historyList 是 ref，读出的 value 及嵌套元素是 Vue 响应式 Proxy；
+    // dbStorage.setItem 底层走 Electron 同步 IPC 的结构化克隆，无法克隆 Proxy，
+    // 会抛 "An object could not be cloned" 导致历史记录丢失。
+    // 这里经 JSON 序列化一次，剥离 Proxy 得到纯数据再写入。
+    const plain = JSON.parse(JSON.stringify(historyList.value))
+    window.ztools.dbStorage.setItem(STORAGE_KEY, plain)
+  } catch (e) {
+    // 写入失败不阻塞 UI，但输出告警：便于排查（如 OCR data URI 过大触发写盘失败）
+    console.warn('[useHistory] persist 写入 dbStorage 失败:', e)
   }
 }
 

--- a/plugins/f-provider/src/env.d.ts
+++ b/plugins/f-provider/src/env.d.ts
@@ -138,7 +138,12 @@ declare global {
   }
 
   /** 翻译 Provider 名称（即 plugin.json providers 字段的 key）。 */
-  type TranslateProviderName = 'baidu' | 'google' | 'youdao' | 'microsoft'
+  type TranslateProviderName =
+    | 'baidu'
+    | 'google'
+    | 'youdao'
+    | 'microsoft'
+    | 'ai-translation'
 
   /** 微软翻译鉴权方案。 */
   type MicrosoftRequestMode = 'edge' | 'signature'
@@ -149,6 +154,30 @@ declare global {
     google: Record<string, never>
     youdao: { appKey: string; appSecret: string }
     microsoft: { requestMode: MicrosoftRequestMode }
+    /** AI 翻译：复用宿主 AI 模型，不存密钥；model 留空走宿主默认。 */
+    'ai-translation': { model: string; systemPrompt: string }
+  }
+
+  /** AI OCR provider 的设置（复用宿主 AI 视觉模型，不存密钥）。 */
+  interface OcrSettingsMap {
+    'ai-ocr': { model: string; systemPrompt: string }
+    /** AI 公式识别：独立 model + systemPrompt（prompt 要求输出 LaTeX 源码）。 */
+    'ai-latex-ocr': { model: string; systemPrompt: string }
+  }
+
+  /** 图床类型联合：后续新增图床在此扩展。 */
+  type ImageHostType = 'img-scdn'
+
+  /**
+   * 图床设置（ai-ocr / ai-latex-ocr 共用）。AI 识图默认先把图片上传图床，
+   * 拿到可访问 URL 再发给视觉模型，省 token 且避免大图 base64 截断；
+   * 关闭或上传失败自动回退 base64 data URI 直传。
+   */
+  interface ImageHostSettings {
+    /** 是否启用图床上传（关闭则 base64 直发 AI）。默认 true。 */
+    enabled: boolean
+    /** 图床适配器类型（当前仅 img-scdn，预留扩展）。 */
+    type: ImageHostType
   }
 
   interface Services {
@@ -225,19 +254,24 @@ declare global {
 
     // ─── 翻译 ───
     /** 通用 HTTP 请求；非 2xx 抛错。 */
-    _httpRequest: (
-      method: string,
-      url: string,
-      opts?: {
-        headers?: Record<string, string>
-        query?: Record<string, string | number>
-        json?: unknown
-        form?: Record<string, string>
-        body?: string
-        timeoutMs?: number
-        maxRedirects?: number
+  _httpRequest: (
+    method: string,
+    url: string,
+    opts?: {
+      headers?: Record<string, string>
+      query?: Record<string, string | number>
+      json?: unknown
+      form?: Record<string, string>
+      /** multipart/form-data 文件上传（图床用）；data 为 Buffer 二进制。 */
+      multipart?: {
+        fields?: Record<string, string>
+        files?: Record<string, { filename?: string; contentType?: string; data: Buffer }>
       }
-    ) => Promise<{ status: number; headers: Record<string, string>; body: string }>
+      body?: string
+      timeoutMs?: number
+      maxRedirects?: number
+    }
+  ) => Promise<{ status: number; headers: Record<string, string>; body: string }>
     /** 语言映射表（provider -> 中性码 -> 自家码；null 表示不支持）。 */
     TRANSLATE_LANG_MAP: Record<TranslateProviderName, Record<string, string | null>>
     /** 读某 provider 的设置（合并默认值）。 */
@@ -254,6 +288,26 @@ declare global {
     translateYoudao: (text: string, from?: string, to?: string) => Promise<TranslateProviderOutput>
     /** 微软翻译。 */
     translateMicrosoft: (text: string, from?: string, to?: string) => Promise<TranslateProviderOutput>
+    /** 读某 OCR provider 的设置（合并默认值）。 */
+    getOcrSettings: <P extends keyof OcrSettingsMap>(provider: P) => OcrSettingsMap[P]
+    /** 写某 OCR provider 的设置。 */
+    setOcrSettings: <P extends keyof OcrSettingsMap>(provider: P, data: OcrSettingsMap[P]) => void
+    /** 读图床设置（ai-ocr / ai-latex-ocr 共用，合并默认值 enabled=true）。 */
+    getImageHostSettings: () => ImageHostSettings
+    /** 写图床设置。 */
+    setImageHostSettings: (data: ImageHostSettings) => void
+    /**
+     * 上传图片到已启用图床，返回可访问 URL。
+     * 关闭 / 未知类型 / 上传失败时返回 null，由调用方回退 base64 data URI 直传。
+     * 入参 image 可为 本地路径 / data URI / http(s) URL；已是 URL 时直接原样返回不二次转存。
+     */
+    uploadImage: (image: string) => Promise<string | null>
+    /** AI 翻译（走宿主 ztools.ai，model 留空走宿主默认模型）。 */
+    translateAi: (text: string, from?: string, to?: string) => Promise<TranslateProviderOutput>
+    /** AI 识图（走宿主 ztools.ai，需选择支持视觉的模型）。 */
+    ocrAi: (image: string, lang?: string) => Promise<OcrProviderOutput>
+    /** AI 公式识别（走宿主 ztools.ai，需选择支持视觉的模型）。返回 LaTeX 源码。 */
+    latexAi: (image: string) => Promise<{ latex: string }>
   }
 
   interface Window {

--- a/plugins/f-provider/src/views/Recognize.vue
+++ b/plugins/f-provider/src/views/Recognize.vue
@@ -39,8 +39,15 @@ const props = withDefaults(
      * 由 watcher 触发。截图结果留在本页展示，不再弹独立窗口。
      */
     autoCapture?: boolean;
+    /**
+     * 文字识别成功后自动上抛 translate 事件，由父组件切到「翻译」tab 预填并翻译
+     * （screen-ocr-translate / ocr-translate feature）。
+     * 门控 translateFired 确保同一张图只联动一次；换新图（resetResults）后重置，
+     * 允许再次联动。OCR 空结果 / 失败不上抛。
+     */
+    translateAfterOcr?: boolean;
   }>(),
-  { initialImage: "", initialMode: "text", autoCapture: false },
+  { initialImage: "", initialMode: "text", autoCapture: false, translateAfterOcr: false },
 );
 
 // 响应式暗色标记：宿主切换主题时同步，用于避免 :global(html.dark) 在 scoped 下不生效。
@@ -57,11 +64,130 @@ const { isDark } = useColorScheme();
 const emit = defineEmits<{
   (e: "mode-change", mode: "text" | "formula"): void;
   (e: "history", item: HistoryEmitItem): void;
+  (e: "translate", text: string): void;
+  /**
+   * 文字识别成功后上抛当前识别文本（供父组件在用户手动切到翻译 tab 时带入）。
+   * 与 translate 事件不同：translate 仅 translateAfterOcr 联动场景触发且只一次，
+   * text-result 在每次文字识别成功（含重识别、切渠道重识别）后都同步最新结果。
+   * 空结果不上抛。
+   */
+  (e: "text-result", text: string): void;
 }>();
 
 const { success, error } = useToast();
 const { nativeReady, checkNative } = useNativeEngine();
 const { latexReady, checkLatex } = useLatexEngine();
+
+// ─── 渠道选择（文字：微信 OCR / AI 识图；公式：本地引擎 / AI 公式识别）─────
+// 模式按钮右侧内嵌 sparkle 图标作为 AI 渠道开关：高亮=已启用 AI，点击在
+// AI / 非 AI 渠道间切换；未配置 AI 模型时置灰不可点。dbStorage 持久化上次渠道。
+// AI 渠道走宿主 ztools.ai 视觉模型，不依赖本机引擎（engineReady 视为就绪）；
+// 返回整段文本无坐标，文字渠道下图片叠层隐藏（viewerLines 传空，见下）。
+type TextProviderName = "ocr" | "ai-ocr";
+type FormulaProviderName = "latex" | "ai-latex-ocr";
+
+const textProviderLabels: Record<TextProviderName, string> = {
+  ocr: "微信 OCR",
+  "ai-ocr": "AI 识图",
+};
+const formulaProviderLabels: Record<FormulaProviderName, string> = {
+  latex: "本地引擎",
+  "ai-latex-ocr": "AI 公式识别",
+};
+
+// AI 渠道配置状态（是否已选模型）；微信 OCR / 本地引擎恒可用。
+const providerConfigured = ref<Record<"ai-ocr" | "ai-latex-ocr", boolean>>({
+  "ai-ocr": false,
+  "ai-latex-ocr": false,
+});
+function refreshProviderStatus() {
+  try {
+    const ao = window.services.getOcrSettings("ai-ocr");
+    const alo = window.services.getOcrSettings("ai-latex-ocr");
+    providerConfigured.value = {
+      "ai-ocr": !!ao.model,
+      "ai-latex-ocr": !!alo.model,
+    };
+  } catch (_) {
+    /* preload 异常：保持默认，不阻塞 */
+  }
+}
+
+// 上次使用的渠道持久化（dbStorage）：切渠道后留存，下次进入自动复用；
+// 失效（AI 渠道未配模型）时回落默认（微信 OCR / 本地引擎）。
+const LAST_TEXT_PROVIDER_KEY = "ocr.textProvider";
+const LAST_FORMULA_PROVIDER_KEY = "ocr.formulaProvider";
+function loadLastTextProvider(): TextProviderName | null {
+  try {
+    const v = window.ztools.dbStorage.getItem<string>(LAST_TEXT_PROVIDER_KEY);
+    if (v && v in textProviderLabels) {
+      const p = v as TextProviderName;
+      if (p === "ocr" || providerConfigured.value["ai-ocr"]) return p;
+    }
+  } catch (_) {
+    /* dbStorage 不可用：回落默认 */
+  }
+  return null;
+}
+function loadLastFormulaProvider(): FormulaProviderName | null {
+  try {
+    const v = window.ztools.dbStorage.getItem<string>(LAST_FORMULA_PROVIDER_KEY);
+    if (v && v in formulaProviderLabels) {
+      const p = v as FormulaProviderName;
+      if (p === "latex" || providerConfigured.value["ai-latex-ocr"]) return p;
+    }
+  } catch (_) {
+    /* dbStorage 不可用：回落默认 */
+  }
+  return null;
+}
+function saveLastTextProvider(p: TextProviderName): void {
+  try {
+    window.ztools.dbStorage.setItem(LAST_TEXT_PROVIDER_KEY, p);
+  } catch (_) {
+    /* 写入失败忽略 */
+  }
+}
+function saveLastFormulaProvider(p: FormulaProviderName): void {
+  try {
+    window.ztools.dbStorage.setItem(LAST_FORMULA_PROVIDER_KEY, p);
+  } catch (_) {
+    /* 写入失败忽略 */
+  }
+}
+
+/**
+ * 切换文字模式 AI 识图开关：未配置 AI 模型时提示并保持原渠道；
+ * 已配置则在 微信 OCR ↔ AI 识图 间切换，watch(textProvider) 会触发重识别。
+ */
+function toggleTextAi(): void {
+  if (!providerConfigured.value["ai-ocr"]) {
+    error("请先在设置中配置 AI 识图模型");
+    return;
+  }
+  textProvider.value = textProvider.value === "ai-ocr" ? "ocr" : "ai-ocr";
+}
+
+/**
+ * 切换公式模式 AI 公式识别开关：未配置 AI 模型时提示并保持原渠道；
+ * 已配置则在 本地引擎 ↔ AI 公式识别 间切换，watch(formulaProvider) 会触发重识别。
+ */
+function toggleFormulaAi(): void {
+  if (!providerConfigured.value["ai-latex-ocr"]) {
+    error("请先在设置中配置 AI 公式识别模型");
+    return;
+  }
+  formulaProvider.value =
+    formulaProvider.value === "ai-latex-ocr" ? "latex" : "ai-latex-ocr";
+}
+
+// setup 期初始化渠道：先刷新配置状态，再回填上次渠道；失效回落默认。
+// 在 setup 期完成，确保挂载时渠道已是最终值，避免 initialImage 首次识别用错渠道。
+refreshProviderStatus();
+const textProvider = ref<TextProviderName>(loadLastTextProvider() || "ocr");
+const formulaProvider = ref<FormulaProviderName>(
+  loadLastFormulaProvider() || "latex",
+);
 
 // ─── 模式 ────────────────────────────────────────────────────────────
 const mode = ref<"text" | "formula">(props.initialMode);
@@ -75,10 +201,12 @@ function switchMode(next: "text" | "formula") {
   autoRecognize();
 }
 
-// 引擎就绪态按模式映射
-const engineReady = computed(() =>
-  mode.value === "text" ? nativeReady.value : latexReady.value,
-);
+// 引擎就绪态按模式 + 渠道映射：AI 渠道不依赖本机引擎，视为就绪。
+const engineReady = computed(() => {
+  if (mode.value === "text")
+    return textProvider.value === "ai-ocr" ? true : nativeReady.value;
+  return formulaProvider.value === "ai-latex-ocr" ? true : latexReady.value;
+});
 
 // 模式切换条滑动高亮：文字=0、公式=1
 const modeIndex = computed(() => (mode.value === "text" ? 0 : 1));
@@ -101,6 +229,36 @@ const ocrLoading = ref(false);
 const ocrError = ref("");
 const ocrLines = ref<OcrLine[]>([]);
 const ocrDone = ref(false); // 标记是否已识别过（区分空结果与未识别）
+// AI 文字渠道返回整段文本无坐标，叠层隐藏：传给 OcrImageViewer 的 lines 在
+// AI 渠道下置空，只显示原图；微信 OCR 渠道保留坐标高亮联动。
+const viewerLines = computed(() =>
+  textProvider.value === "ai-ocr" ? [] : ocrLines.value,
+);
+
+/**
+ * AI 识图结果编辑/展示模式。
+ * AI 渠道返回整段文本无坐标也无真实置信度（伪 OcrLine rate 恒为 1），
+ * 故右侧改用可编辑的整段文本呈现，并支持两种模式按需切换：
+ * - aiEditMode：false=展示（行列表，无置信度，单击复制该行）；
+ *               true=编辑（textarea 双向绑定 aiText，复制全部以编辑后为准）。
+ * - aiText：可编辑的整段识别文本，识别成功时回填。
+ * - aiDisplayLines：展示模式按行拆分（去掉末尾多余换行避免出现空行）。
+ * 切渠道 / 换图时随 resetTextResult 一并重置。
+ */
+const aiEditMode = ref(false);
+const aiText = ref("");
+const aiDisplayLines = computed(() => {
+  const t = aiText.value;
+  if (!t) return [];
+  // 去掉末尾连续换行后再拆行，避免列表尾部出现可点击的空行。
+  return t.replace(/(\r?\n)+$/, "").split(/\r?\n/);
+});
+
+/**
+ * 识别并翻译联动门控：translateAfterOcr 下首次文字识别成功才上抛一次 translate，
+ * 切回本 tab 对同一图重识别不二次跳翻译；换新图经 resetResults 重置后可再次联动。
+ */
+const translateFired = ref(false);
 
 // 公式识别结果
 const latexLoading = ref(false);
@@ -206,13 +364,25 @@ function maybeAutoCapture() {
   captureScreen();
 }
 
-function resetResults() {
+/** 清空文字模式结果（切渠道 / 换图时调用）。 */
+function resetTextResult() {
   ocrLines.value = [];
   ocrError.value = "";
   ocrDone.value = false;
+  translateFired.value = false;
+  aiEditMode.value = false;
+  aiText.value = "";
+}
+/** 清空公式模式结果（切渠道 / 换图时调用）。 */
+function resetFormulaResult() {
   latex.value = "";
   latexError.value = "";
   latexDone.value = false;
+}
+/** 清空两种模式的结果与 done 标记（换新图时调用）。 */
+function resetResults() {
+  resetTextResult();
+  resetFormulaResult();
 }
 
 async function onFileChange(e: Event) {
@@ -244,8 +414,48 @@ async function onPaste(e: ClipboardEvent) {
 }
 
 // ─── 识别执行 ────────────────────────────────────────────────────────
+/**
+ * 文字识别成功后的统一处理：填 ocrLines、提示、上抛历史与联动翻译。
+ * 微信 OCR 渠道传入带坐标的真实 lines；AI 渠道传入按文本拆出的伪 lines（无坐标）。
+ */
+function applyOcrLines(lines: OcrLine[]) {
+  ocrLines.value = lines;
+  if (lines.length === 0) {
+    error("未识别到文字");
+    // 空结果不上抛 text-result，避免清空翻译框
+    return;
+  }
+  success(`识别完成，共 ${lines.length} 行`);
+  // 同步当前识别文本给父组件：供用户手动切到翻译 tab 时带入翻译输入框。
+  // AI 渠道以 aiText 为准（可被用户编辑），微信 OCR 渠道拼装各行文本。
+  const text =
+    textProvider.value === "ai-ocr"
+      ? aiText.value
+      : lines.map((l) => l.text).join("\n");
+  emit("text-result", text);
+  // 上抛历史记录：只有真正调识别服务成功才留一笔（命中缓存不会进此分支）
+  emit("history", {
+    kind: "ocr-text",
+    thumbnail: imageSrc.value,
+    title: lines[0]?.text ? lines[0].text.slice(0, 40) : "（未识别到文字）",
+    payload: {
+      kind: "ocr-text",
+      imageSrc: imageSrc.value,
+      lines: lines.map((l) => ({ ...l })),
+    },
+  });
+  // 识别并翻译联动：translateAfterOcr 下首次成功才上抛一次（门控 translateFired），
+  // 父组件切到「翻译」tab 预填识别文字并触发翻译。换新图重置门控后可再次联动。
+  if (props.translateAfterOcr && !translateFired.value) {
+    translateFired.value = true;
+    emit("translate", text);
+  }
+}
+
 async function recognizeText() {
-  if (!recognizeSrc.value || !nativeReady.value) return;
+  if (!recognizeSrc.value) return;
+  // AI 渠道不依赖本机引擎；微信 OCR 渠道需引擎就绪。
+  if (textProvider.value === "ocr" && !nativeReady.value) return;
   // 并发保护：onMounted 的 checkNative 会让 ready 态瞬时抖动（ready→checking→ready），
   // 从而二次触发引擎就绪 watcher；此处避免对同一图片并发识别。
   if (ocrLoading.value) return;
@@ -253,29 +463,32 @@ async function recognizeText() {
   ocrError.value = "";
   ocrLines.value = [];
   try {
-    const result = await window.services.ocrImageDetail(recognizeSrc.value);
-    if (result.ok) {
-      ocrLines.value = result.lines ?? [];
-      if (ocrLines.value.length === 0) error("未识别到文字");
-      else {
-        success(`识别完成，共 ${ocrLines.value.length} 行`);
-        // 上抛历史记录：只有真正调识别服务成功才留一笔（命中缓存不会进此分支）
-        emit("history", {
-          kind: "ocr-text",
-          thumbnail: imageSrc.value,
-          title: ocrLines.value[0]?.text
-            ? ocrLines.value[0].text.slice(0, 40)
-            : "（未识别到文字）",
-          payload: {
-            kind: "ocr-text",
-            imageSrc: imageSrc.value,
-            lines: ocrLines.value.map((l) => ({ ...l })),
-          },
-        });
-      }
+    if (textProvider.value === "ai-ocr") {
+      // AI 识图：返回整段文本，按行拆成伪 OcrLine（无坐标），复用列表/复制/联动逻辑。
+      // 同时回填 aiText 供右侧编辑/展示模式使用（rate 恒为 1 不展示置信度）。
+      const out = await window.services.ocrAi(recognizeSrc.value);
+      const text = (out && out.text) || "";
+      aiText.value = text;
+      applyOcrLines(
+        text
+          ? text.split(/\r?\n/).map((t) => ({
+              text: t,
+              rate: 1,
+              left: 0,
+              top: 0,
+              right: 0,
+              bottom: 0,
+              boxPoints: [] as OcrLine["boxPoints"],
+            }))
+          : [],
+      );
     } else {
-      ocrError.value = result.error || "识别失败";
-      error(ocrError.value);
+      const result = await window.services.ocrImageDetail(recognizeSrc.value);
+      if (result.ok) applyOcrLines(result.lines ?? []);
+      else {
+        ocrError.value = result.error || "识别失败";
+        error(ocrError.value);
+      }
     }
   } catch (err: any) {
     ocrError.value = err?.message ? String(err.message) : String(err);
@@ -286,37 +499,52 @@ async function recognizeText() {
   }
 }
 
+/**
+ * 公式识别成功后的统一处理：填 latex、提示、上抛历史记录。
+ * 本地引擎与 AI 渠道结果同为 LaTeX 源码，处理一致。
+ */
+function applyLatexResult(ltx: string) {
+  latex.value = ltx;
+  if (!ltx) {
+    error("未识别到公式");
+    return;
+  }
+  success("公式识别完成");
+  // 上抛历史记录：只有真正调识别服务成功才留一笔（命中缓存不会进此分支）
+  emit("history", {
+    kind: "ocr-formula",
+    thumbnail: imageSrc.value,
+    title: ltx.slice(0, 40),
+    payload: {
+      kind: "ocr-formula",
+      imageSrc: imageSrc.value,
+      latex: ltx,
+    },
+  });
+}
+
 async function recognizeFormula() {
-  if (!recognizeSrc.value || !latexReady.value) return;
+  if (!recognizeSrc.value) return;
+  // AI 渠道不依赖本机引擎；本地引擎需就绪。
+  if (formulaProvider.value === "latex" && !latexReady.value) return;
   // 并发保护：与 recognizeText 同理，防止引擎就绪态抖动引发的重复识别。
   if (latexLoading.value) return;
   latexLoading.value = true;
   latexError.value = "";
   latex.value = "";
   try {
-    const result = await window.services.latexRecognizeDetail(
-      recognizeSrc.value,
-    );
-    if (result.ok) {
-      latex.value = result.latex || "";
-      if (!latex.value) error("未识别到公式");
-      else {
-        success("公式识别完成");
-        // 上抛历史记录：只有真正调识别服务成功才留一笔（命中缓存不会进此分支）
-        emit("history", {
-          kind: "ocr-formula",
-          thumbnail: imageSrc.value,
-          title: latex.value.slice(0, 40),
-          payload: {
-            kind: "ocr-formula",
-            imageSrc: imageSrc.value,
-            latex: latex.value,
-          },
-        });
-      }
+    if (formulaProvider.value === "ai-latex-ocr") {
+      const out = await window.services.latexAi(recognizeSrc.value);
+      applyLatexResult(out.latex || "");
     } else {
-      latexError.value = result.error || "识别失败";
-      error(latexError.value);
+      const result = await window.services.latexRecognizeDetail(
+        recognizeSrc.value,
+      );
+      if (result.ok) applyLatexResult(result.latex || "");
+      else {
+        latexError.value = result.error || "识别失败";
+        error(latexError.value);
+      }
     }
   } catch (err: any) {
     latexError.value = err?.message ? String(err.message) : String(err);
@@ -340,7 +568,11 @@ function copyLine(text: string) {
 }
 
 function copyAllText() {
-  const text = ocrLines.value.map((l) => l.text).join("\n");
+  // AI 渠道复制编辑后的整段文本；微信 OCR 渠道拼装各行文本。
+  const text =
+    textProvider.value === "ai-ocr"
+      ? aiText.value
+      : ocrLines.value.map((l) => l.text).join("\n");
   if (!text) return;
   window.ztools.copyText(text);
   success("已复制全部文字");
@@ -409,8 +641,11 @@ watch(
 
 // 文字引擎就绪后补识别：覆盖「下载期间选图」与「切到文字模式时引擎仍在下载」两种场景。
 // 另覆盖 autoCapture（screen-ocr 入口）：引擎未就绪时截图被搁置，就绪后自动补截图。
+// AI 渠道不依赖本机引擎（engineReady 恒就绪），由 setup 期 autoRecognize 直接触发；
+// 此 watcher 跳过 AI 渠道，避免引擎下载完成时对 AI 渠道误触发重识别。
 watch(nativeReady, (ready) => {
-  if (!ready || mode.value !== "text") return;
+  if (!ready || mode.value !== "text" || textProvider.value === "ai-ocr")
+    return;
   if (recognizeSrc.value && !ocrDone.value) {
     nextTick(() => recognizeText());
   } else if (props.autoCapture && !autoCaptureDone.value) {
@@ -419,12 +654,36 @@ watch(nativeReady, (ready) => {
 });
 
 // 公式引擎就绪后补识别：与文字引擎对称，含 autoCapture（screen-latex 入口）补截图。
+// AI 渠道同理跳过。
 watch(latexReady, (ready) => {
-  if (!ready || mode.value !== "formula") return;
+  if (
+    !ready ||
+    mode.value !== "formula" ||
+    formulaProvider.value === "ai-latex-ocr"
+  )
+    return;
   if (recognizeSrc.value && !latexDone.value) {
     nextTick(() => recognizeFormula());
   } else if (props.autoCapture && !autoCaptureDone.value) {
     maybeAutoCapture();
+  }
+});
+
+// 切换渠道：持久化上次渠道，并立即按当前图片重识别当前模式
+// （参考 Translate 切 provider 不 debounce 立即 run）。
+// 已有图片但引擎未就绪时跳过，就绪后由上方 watcher 补识别。
+watch(textProvider, () => {
+  saveLastTextProvider(textProvider.value);
+  if (recognizeSrc.value && engineReady.value) {
+    resetTextResult();
+    nextTick(() => recognizeText());
+  }
+});
+watch(formulaProvider, () => {
+  saveLastFormulaProvider(formulaProvider.value);
+  if (recognizeSrc.value && engineReady.value) {
+    resetFormulaResult();
+    nextTick(() => recognizeFormula());
   }
 });
 
@@ -446,6 +705,8 @@ onActivated(() => {
   window.addEventListener("paste", onPaste);
   checkNative();
   checkLatex();
+  // 重读 AI 渠道配置状态（用户可能在设置页改了模型），与 Translate onMounted 一致。
+  refreshProviderStatus();
 });
 
 onDeactivated(() => {
@@ -475,7 +736,7 @@ onUnmounted(() => {
           <OcrImageViewer
             v-if="mode === 'text'"
             :image-src="imageSrc"
-            :lines="ocrLines"
+            :lines="viewerLines"
             :loading="ocrLoading"
             :hide-result="true"
             empty-text="选择图片或截图识别，也可拖入 / 粘贴图片"
@@ -566,7 +827,38 @@ onUnmounted(() => {
             :ref="(el) => setModeItemRef(el, 0)"
             @click="switchMode('text')"
           >
-            文字
+            <span class="mode-label">文字</span>
+            <!-- AI 渠道开关：图标高亮表示当前已启用 AI 识图；
+                 未配置 AI 模型时禁用；点击切换 微信 OCR ↔ AI 识图。 -->
+            <span
+              class="ai-chip"
+              :class="{
+                active: textProvider === 'ai-ocr',
+                disabled: !providerConfigured['ai-ocr'],
+              }"
+              :title="
+                !providerConfigured['ai-ocr']
+                  ? '未配置 AI 识图模型，请先在设置中配置'
+                  : textProvider === 'ai-ocr'
+                    ? '已启用 AI 识图，点击关闭改用微信 OCR'
+                    : 'AI 识图就绪，点击启用'
+              "
+              @click.stop="toggleTextAi"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <!-- Icon from Material Symbols (auto_awesome / sparkle) - https://github.com/google/material-design-icons/blob/master/LICENSE -->
+                <path
+                  fill="currentColor"
+                  d="m19 9l1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25L19 9zm-7.5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12l-5.5-2.5zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25L19 15z"
+                />
+              </svg>
+            </span>
           </button>
           <button
             type="button"
@@ -577,7 +869,38 @@ onUnmounted(() => {
             :ref="(el) => setModeItemRef(el, 1)"
             @click="switchMode('formula')"
           >
-            公式
+            <span class="mode-label">公式</span>
+            <!-- AI 渠道开关：图标高亮表示当前已启用 AI 公式识别；
+                 未配置 AI 模型时禁用；点击切换 本地引擎 ↔ AI 公式识别。 -->
+            <span
+              class="ai-chip"
+              :class="{
+                active: formulaProvider === 'ai-latex-ocr',
+                disabled: !providerConfigured['ai-latex-ocr'],
+              }"
+              :title="
+                !providerConfigured['ai-latex-ocr']
+                  ? '未配置 AI 公式识别模型，请先在设置中配置'
+                  : formulaProvider === 'ai-latex-ocr'
+                    ? '已启用 AI 公式识别，点击关闭改用本地引擎'
+                    : 'AI 公式识别就绪，点击启用'
+              "
+              @click.stop="toggleFormulaAi"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="13"
+                height="13"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <!-- Icon from Material Symbols (auto_awesome / sparkle) - https://github.com/google/material-design-icons/blob/master/LICENSE -->
+                <path
+                  fill="currentColor"
+                  d="m19 9l1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25L19 9zm-7.5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12l-5.5-2.5zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25L19 15z"
+                />
+              </svg>
+            </span>
           </button>
         </div>
 
@@ -609,27 +932,116 @@ onUnmounted(() => {
               选择图片或截图后自动识别，结果将在此显示
             </div>
             <template v-else>
-              <div class="result-head">
-                <span class="result-title"
-                  >识别明细（{{ ocrLines.length }} 行）</span
-                >
-                <ZButton size="small" @click="copyAllText">复制全部</ZButton>
-              </div>
-              <div class="line-list">
-                <div
-                  v-for="(line, i) in ocrLines"
-                  :key="i"
-                  class="result-line"
-                  :class="{ active: hoveredIndex === i }"
-                  @mouseenter="hoveredIndex = i"
-                  @mouseleave="hoveredIndex = -1"
-                  @click="copyLine(line.text)"
-                >
-                  <span class="result-rate"
-                    >{{ (line.rate * 100).toFixed(0) }}%</span
+              <!-- 微信 OCR：带置信度的行列表，与图上文字双向高亮联动 -->
+              <template v-if="textProvider !== 'ai-ocr'">
+                <div class="result-head">
+                  <span class="result-title"
+                    >识别明细（{{ ocrLines.length }} 行）</span
                   >
-                  <span class="result-text">{{ line.text }}</span>
+                  <ZButton size="small" @click="copyAllText">复制全部</ZButton>
                 </div>
+                <div class="line-list">
+                  <div
+                    v-for="(line, i) in ocrLines"
+                    :key="i"
+                    class="result-line"
+                    :class="{ active: hoveredIndex === i }"
+                    @mouseenter="hoveredIndex = i"
+                    @mouseleave="hoveredIndex = -1"
+                    @click="copyLine(line.text)"
+                  >
+                    <span class="result-rate"
+                      >{{ (line.rate * 100).toFixed(0) }}%</span
+                    >
+                    <span class="result-text">{{ line.text }}</span>
+                  </div>
+                </div>
+              </template>
+              <!-- AI 识图：不展示置信度，提供展示/编辑模式图标切换 -->
+              <div v-else class="ai-result" :class="{ dark: isDark }">
+                <div class="result-head">
+                  <span class="result-title"
+                    >识别结果（{{ aiDisplayLines.length }} 行）</span
+                  >
+                  <div class="result-head-actions">
+                    <!-- 展示模式（eye）· 编辑模式（pencil）图标切换组 -->
+                    <div
+                      class="mode-toggle"
+                      role="group"
+                      aria-label="结果模式"
+                    >
+                      <button
+                        type="button"
+                        class="mode-toggle-btn"
+                        :class="{ active: !aiEditMode }"
+                        title="展示模式"
+                        aria-label="展示模式"
+                        @click="aiEditMode = false"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          aria-hidden="true"
+                        >
+                          <!-- Icon from Material Symbols (visibility) - https://github.com/google/material-design-icons/blob/master/LICENSE -->
+                          <path
+                            fill="currentColor"
+                            d="M12 4.5C7 4.5 2.73 7.61 1 12c1.73 4.39 6 7.5 11 7.5s9.27-3.11 11-7.5c-1.73-4.39-6-7.5-11-7.5zM12 17c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5zm0-8c-1.66 0-3 1.34-3 3s1.34 3 3 3 3-1.34 3-3-1.34-3-3-3z"
+                          />
+                        </svg>
+                      </button>
+                      <button
+                        type="button"
+                        class="mode-toggle-btn"
+                        :class="{ active: aiEditMode }"
+                        title="编辑模式"
+                        aria-label="编辑模式"
+                        @click="aiEditMode = true"
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          aria-hidden="true"
+                        >
+                          <!-- Icon from Material Symbols (edit) - https://github.com/google/material-design-icons/blob/master/LICENSE -->
+                          <path
+                            fill="currentColor"
+                            d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25zM20.71 7.04c.39-.39.39-1.02 0-1.41l-2.34-2.34a.9959.9959 0 0 0-1.41 0l-1.83 1.83 3.75 3.75 1.83-1.83z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                    <ZButton size="small" @click="copyAllText"
+                      >复制全部</ZButton
+                    >
+                  </div>
+                </div>
+                <!-- 展示模式：行列表（无置信度），单击复制该行 -->
+                <div v-if="!aiEditMode" class="line-list">
+                  <div
+                    v-for="(line, i) in aiDisplayLines"
+                    :key="i"
+                    class="result-line"
+                    @click="copyLine(line)"
+                  >
+                    <span class="result-text">{{ line }}</span>
+                  </div>
+                </div>
+                <!-- 编辑模式：可编辑整段文本，复制全部以编辑后为准 -->
+                <textarea
+                  v-else
+                  class="ai-text-edit"
+                  v-model="aiText"
+                  spellcheck="false"
+                  autocomplete="off"
+                  autocorrect="off"
+                  autocapitalize="off"
+                  placeholder="可编辑识别结果，切换到展示模式查看行列表"
+                ></textarea>
               </div>
             </template>
           </div>
@@ -839,6 +1251,11 @@ onUnmounted(() => {
 
 .mode-btn {
   flex: 1;
+  /* 文字与右侧 AI 图标横向居中排列 */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   padding: 6px 14px;
   border: none;
   background: transparent;
@@ -859,6 +1276,45 @@ onUnmounted(() => {
 .mode-btn.active {
   color: var(--primary-color, #1976d2);
   font-weight: 600;
+}
+
+/* AI 渠道开关：嵌在模式按钮文字右侧，sparkle 图标。
+   - active：当前已启用 AI 渠道，主色 + 浅色底；
+   - 默认态：灰色，hover 主色 + 浅底；
+   - disabled：未配置 AI 模型，置灰不可点。 */
+.ai-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 9px;
+  color: var(--text-secondary, #999);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    color 0.15s,
+    background 0.15s;
+}
+
+.ai-chip:not(.active):not(.disabled):hover {
+  color: var(--primary-color, #1976d2);
+  background: var(--hover-bg, rgba(0, 0, 0, 0.08));
+}
+
+.ai-chip.active {
+  color: var(--primary-color, #1976d2);
+  background: color-mix(in srgb, var(--primary-color, #1976d2), transparent 85%);
+}
+
+.ai-chip.disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+/* scoped 下 :global 失效，用 .dark 类驱动暗色 hover 背景 */
+.mode-switch.dark .ai-chip:not(.active):not(.disabled):hover {
+  background: var(--hover-bg, rgba(255, 255, 255, 0.08));
 }
 
 /* 引擎引导 */
@@ -942,6 +1398,99 @@ onUnmounted(() => {
   white-space: pre-wrap;
   word-break: break-all;
   user-select: text;
+}
+
+/* AI 识图结果容器（展示/编辑模式） */
+.ai-result {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+}
+
+.result-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* 展示模式（eye，左）· 编辑模式（pencil，右）图标切换组 */
+.mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  background: var(--sub-bar-bg, rgba(0, 0, 0, 0.05));
+  border-radius: 6px;
+}
+
+.mode-toggle-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 22px;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary, #999);
+  border-radius: 5px;
+  cursor: pointer;
+  transition:
+    color 0.15s,
+    background 0.15s;
+}
+
+.mode-toggle-btn:hover {
+  color: var(--primary-color, #1976d2);
+}
+
+.mode-toggle-btn.active {
+  color: var(--primary-color, #1976d2);
+  background: var(--sub-item-active-bg, #fff);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+/* scoped 下 :global 失效，用 .dark 类驱动暗色切换组 */
+.ai-result.dark .mode-toggle {
+  background: var(--sub-bar-bg, rgba(255, 255, 255, 0.08));
+}
+
+.ai-result.dark .mode-toggle-btn.active {
+  background: var(--sub-item-active-bg, rgba(255, 255, 255, 0.08));
+  box-shadow: none;
+}
+
+/* AI 展示模式行列表：撑满并内部滚动 */
+.ai-result .line-list {
+  flex: 1;
+  min-height: 0;
+}
+
+/* 编辑模式：整段可编辑文本 */
+.ai-text-edit {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 12px;
+  background: var(--code-bg, #f5f5f5);
+  border-radius: 8px;
+  border: 1px solid var(--border-color, #e5e6eb);
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  resize: none;
+  color: var(--text-color, #333);
+  outline: none;
+}
+
+/* scoped 下 :global 失效，用 .dark 类驱动暗色编辑框 */
+.ai-result.dark .ai-text-edit {
+  background: var(--code-bg, #2a2a2a);
+  color: var(--text-color, #f3f4f6);
+  border-color: var(--border-color, #374151);
 }
 
 /* 公式结果 */

--- a/plugins/f-provider/src/views/Settings.vue
+++ b/plugins/f-provider/src/views/Settings.vue
@@ -120,9 +120,28 @@ const baidu = ref({ appID: '', appKey: '' })
 const youdao = ref({ appKey: '', appSecret: '' })
 const microsoft = ref<{ requestMode: 'edge' | 'signature' }>({ requestMode: 'edge' })
 
+// AI 翻译 / AI OCR：复用宿主已配置的 AI 模型，此处仅存模型选择与 prompt 模板（不存密钥）。
+const aiTranslation = ref({ model: '', systemPrompt: '' })
+const aiOcr = ref({ model: '', systemPrompt: '' })
+const aiLatexOcr = ref({ model: '', systemPrompt: '' })
+// 图床设置（ai-ocr / ai-latex-ocr 共用）：默认开启，关闭则 AI 识图回退 base64 直传。
+const imageHost = ref<ImageHostSettings>({ enabled: true, type: 'img-scdn' })
+// 宿主已配置的 AI 模型列表（ztools.allAiModels()），用于模型下拉。
+const aiModels = ref<{ id: string; label: string }[]>([])
+// 模型下拉选项：未配置模型时只给一个禁用占位，避免误选空值。
+const aiModelOptions = computed(() => {
+  if (!aiModels.value.length) return [{ label: '尚未配置 AI 模型', value: '', disabled: true }]
+  return [{ label: '使用 ZTools 默认模型', value: '' }, ...aiModels.value.map((m) => ({ label: m.label, value: m.id }))]
+})
+
 const requestModeOptions = [
   { label: 'Signature（X-MT-Signature，推荐）', value: 'signature' },
   { label: 'Edge Token（Authorization Bearer，兜底）', value: 'edge' }
+]
+
+// 图床类型下拉：后续新增图床在此加一项 + ImageHostType 联合类型扩一项。
+const imageHostTypeOptions = [
+  { label: 'img.scdn.io', value: 'img-scdn' }
 ]
 
 async function loadSettings(): Promise<void> {
@@ -135,6 +154,27 @@ async function loadSettings(): Promise<void> {
     microsoft.value = {
       requestMode: (m.requestMode as 'edge' | 'signature') || 'edge'
     }
+    // AI 翻译 / AI OCR 配置回填
+    const at = window.services.getTranslateSettings('ai-translation')
+    aiTranslation.value = { model: at.model || '', systemPrompt: at.systemPrompt || '' }
+    const ao = window.services.getOcrSettings('ai-ocr')
+    aiOcr.value = { model: ao.model || '', systemPrompt: ao.systemPrompt || '' }
+    const alo = window.services.getOcrSettings('ai-latex-ocr')
+    aiLatexOcr.value = { model: alo.model || '', systemPrompt: alo.systemPrompt || '' }
+    // 图床配置回填（enabled 默认 true：旧数据无该 key 时兜底为开启）
+    const ih = window.services.getImageHostSettings()
+    imageHost.value = {
+      enabled: ih.enabled !== false,
+      type: (ih.type as ImageHostType) || 'img-scdn'
+    }
+    // 拉取宿主已配置的 AI 模型列表，用于模型下拉
+    try {
+      const list = await window.ztools.allAiModels()
+      aiModels.value = (list || []).map((m) => ({ id: m.id, label: m.label }))
+    } catch (e) {
+      console.error('加载宿主 AI 模型列表失败', e)
+      aiModels.value = []
+    }
   } catch (e) {
     console.error('加载翻译设置失败', e)
   }
@@ -143,13 +183,30 @@ async function loadSettings(): Promise<void> {
 // 逐卡保存的 loading 态
 const saving = ref(false)
 
-async function saveProvider(p: 'baidu' | 'youdao' | 'microsoft'): Promise<void> {
+async function saveProvider(
+  p:
+    | 'baidu'
+    | 'youdao'
+    | 'microsoft'
+    | 'ai-translation'
+    | 'ai-ocr'
+    | 'ai-latex-ocr'
+    | 'image-host'
+): Promise<void> {
   saving.value = true
   try {
     if (p === 'baidu') window.services.setTranslateSettings('baidu', { ...baidu.value })
     else if (p === 'youdao')
       window.services.setTranslateSettings('youdao', { ...youdao.value })
-    else window.services.setTranslateSettings('microsoft', { ...microsoft.value })
+    else if (p === 'microsoft')
+      window.services.setTranslateSettings('microsoft', { ...microsoft.value })
+    else if (p === 'ai-translation')
+      window.services.setTranslateSettings('ai-translation', { ...aiTranslation.value })
+    else if (p === 'ai-ocr') window.services.setOcrSettings('ai-ocr', { ...aiOcr.value })
+    else if (p === 'ai-latex-ocr')
+      window.services.setOcrSettings('ai-latex-ocr', { ...aiLatexOcr.value })
+    else if (p === 'image-host')
+      window.services.setImageHostSettings({ ...imageHost.value })
     success('已保存')
     closeModal()
   } catch (e: any) {
@@ -160,7 +217,15 @@ async function saveProvider(p: 'baidu' | 'youdao' | 'microsoft'): Promise<void> 
 }
 
 // ─── Provider 元数据 ─────────────────────────────────────────────────
-type ProviderKey = 'baidu' | 'google' | 'youdao' | 'microsoft'
+type ProviderKey =
+  | 'baidu'
+  | 'google'
+  | 'youdao'
+  | 'microsoft'
+  | 'ai-translation'
+  | 'ai-ocr'
+  | 'ai-latex-ocr'
+  | 'image-host'
 
 interface ProviderMeta {
   key: ProviderKey
@@ -191,6 +256,27 @@ const providers: ProviderMeta[] = [
     key: 'microsoft',
     name: '微软翻译',
     desc: '免授权，可选 Signature 或 Edge Token 鉴权方案。'
+  },
+  {
+    key: 'ai-translation',
+    name: 'AI 翻译',
+    desc: '基于大语言模型翻译，复用 ZTools 已配置的 AI 模型，无需密钥。'
+  },
+  {
+    key: 'ai-ocr',
+    name: 'AI 识图',
+    desc: '基于视觉模型识别图片文字，需选择支持视觉的模型。'
+  },
+  {
+    key: 'ai-latex-ocr',
+    name: 'AI 公式识别',
+    desc: '基于视觉模型识别数学公式为 LaTeX，需选择支持视觉的模型。'
+  },
+  {
+    key: 'image-host',
+    name: '图床',
+    desc: 'AI 识图/公式识别的图片来源：先上传图床再发 AI（省 token、防截断），默认开启，失败自动回退直传。',
+    docsUrl: 'https://img.scdn.io/api_docs.php'
   }
 ]
 
@@ -201,15 +287,23 @@ const configured = computed(
       baidu: !!(baidu.value.appID && baidu.value.appKey),
       google: true,
       youdao: !!(youdao.value.appKey && youdao.value.appSecret),
-      microsoft: true
+      microsoft: true,
+      'ai-translation': true, // 模型可留空走宿主默认，始终视为可用
+      'ai-ocr': !!aiOcr.value.model,
+      'ai-latex-ocr': !!aiLatexOcr.value.model,
+      'image-host': imageHost.value.enabled
     }) as Record<ProviderKey, boolean>
 )
 
 function providerStatus(
   p: ProviderMeta
 ): { type: 'success' | 'warning'; text: string } {
-  if (p.key === 'google' || p.key === 'microsoft')
+  if (p.key === 'google' || p.key === 'microsoft' || p.key === 'ai-translation')
     return { type: 'success', text: '已安装' }
+  if (p.key === 'image-host')
+    return imageHost.value.enabled
+      ? { type: 'success', text: '已启用' }
+      : { type: 'warning', text: '已停用' }
   return configured.value[p.key]
     ? { type: 'success', text: '已安装' }
     : { type: 'warning', text: '待配置' }
@@ -491,13 +585,99 @@ onMounted(() => {
           </template>
 
           <!-- 谷歌 -->
-          <template v-else>
+          <template v-else-if="activeProvider.key === 'google'">
             <p class="field-hint">
               使用 Google 官方免费接口 <code>translate.googleapis.com</code>，无需凭据。
             </p>
             <p class="field-hint">
               该域名为 Google 官方地址，国内网络通常无法直连，需走系统代理；如不可用可改用其他 provider。
             </p>
+          </template>
+
+          <!-- AI 翻译（走宿主 ztools.ai，复用宿主已配置的 AI 模型） -->
+          <template v-else-if="activeProvider.key === 'ai-translation'">
+            <div class="field">
+              <label>模型</label>
+              <ZSelect
+                v-model="aiTranslation.model"
+                :options="aiModelOptions"
+                placeholder="选择模型（留空走 ZTools 默认）"
+              />
+            </div>
+            <div class="field">
+              <label>系统提示词（支持 {from}/{to} 占位替换）</label>
+              <textarea
+                v-model="aiTranslation.systemPrompt"
+                class="ai-textarea"
+                rows="4"
+                placeholder="如：你是一个专业翻译。将用户输入翻译成 {to}，只输出译文，不要解释。"
+              ></textarea>
+            </div>
+            <p class="field-hint">无需密钥：复用 ZTools「AI 模型」中已配置的模型与 API Key。</p>
+          </template>
+
+          <!-- AI 识图（走宿主 ztools.ai，需支持视觉的模型） -->
+          <template v-else-if="activeProvider.key === 'ai-ocr'">
+            <div class="field">
+              <label>模型（须选支持视觉的模型）</label>
+              <ZSelect
+                v-model="aiOcr.model"
+                :options="aiModelOptions"
+                placeholder="选择支持视觉的模型"
+              />
+            </div>
+            <div class="field">
+              <label>系统提示词</label>
+              <textarea
+                v-model="aiOcr.systemPrompt"
+                class="ai-textarea"
+                rows="4"
+                placeholder="如：识别图片中的所有文字，按原文逐行输出，只输出文字。"
+              ></textarea>
+            </div>
+            <p class="field-hint">纯文本模型无法识图，请选择如 GPT-4o 等支持视觉输入的模型。</p>
+          </template>
+
+          <!-- AI 公式识别（走宿主 ztools.ai，需支持视觉的模型） -->
+          <template v-else-if="activeProvider.key === 'ai-latex-ocr'">
+            <div class="field">
+              <label>模型（须选支持视觉的模型）</label>
+              <ZSelect
+                v-model="aiLatexOcr.model"
+                :options="aiModelOptions"
+                placeholder="选择支持视觉的模型"
+              />
+            </div>
+            <div class="field">
+              <label>系统提示词</label>
+              <textarea
+                v-model="aiLatexOcr.systemPrompt"
+                class="ai-textarea"
+                rows="4"
+                placeholder="如：识别图片中的数学公式并输出对应的 LaTeX 源码，只输出 LaTeX 代码。"
+              ></textarea>
+            </div>
+            <p class="field-hint">提示词应要求只输出 LaTeX 源码、不加 $ 包裹；AI 误加的围栏会被自动剔除。</p>
+          </template>
+
+          <!-- 图床（ai-ocr / ai-latex-ocr 共用的图片上传通道） -->
+          <template v-else-if="activeProvider.key === 'image-host'">
+            <div class="field">
+              <label class="switch-field">
+                <input type="checkbox" v-model="imageHost.enabled" />
+                <span>启用图床上传</span>
+              </label>
+              <p class="field-hint">关闭后 AI 识图改用 base64 直传 vision 模型（大图易超 token / 触发截断）。</p>
+            </div>
+            <div class="field" v-if="imageHost.enabled">
+              <label>图床类型</label>
+              <ZSelect
+                v-model="imageHost.type"
+                :options="imageHostTypeOptions"
+                placeholder="选择图床"
+              />
+              <p class="field-hint">当前 img.scdn.io 走 Cloudflare R2 存储（storage_destination=r2），免鉴权。上传失败或被限流（429）时自动回退 base64 直传。</p>
+            </div>
           </template>
         </div>
 
@@ -508,7 +688,7 @@ onMounted(() => {
             type="primary"
             size="small"
             :loading="saving"
-            @click="saveProvider(activeProvider.key as 'baidu' | 'youdao' | 'microsoft')"
+            @click="saveProvider(activeProvider.key as 'baidu' | 'youdao' | 'microsoft' | 'ai-translation' | 'ai-ocr' | 'ai-latex-ocr' | 'image-host')"
           >
             保存
           </ZButton>
@@ -804,6 +984,24 @@ code {
 
 .field-hint a {
   color: var(--primary-color, #1976d2);
+}
+
+/* AI provider 配置弹窗的多行 prompt 输入框 */
+.ai-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary, #333);
+  background: var(--bg-input, #fff);
+  border: 1px solid var(--border-color, #ddd);
+  border-radius: 6px;
+  resize: vertical;
+  outline: none;
+}
+.ai-textarea:focus {
+  border-color: var(--primary-color, #1976d2);
 }
 
 /* ZModal 默认无宽度约束，这里限制弹窗宽度 */

--- a/plugins/f-provider/src/views/Translate.vue
+++ b/plugins/f-provider/src/views/Translate.vue
@@ -41,32 +41,36 @@ const langOptions = [
   { label: '阿拉伯语', value: 'ar' }
 ]
 
-type ProviderName = 'baidu' | 'google' | 'youdao' | 'microsoft'
+type ProviderName = 'baidu' | 'google' | 'youdao' | 'microsoft' | 'ai-translation'
 
 const providerLabels: Record<ProviderName, string> = {
   baidu: '百度翻译',
   google: '谷歌翻译',
   youdao: '有道翻译',
-  microsoft: '微软翻译'
+  microsoft: '微软翻译',
+  'ai-translation': 'AI 翻译'
 }
 
 // 各 provider 对应的 services 方法名。
 const providerFnNames: Record<
   ProviderName,
-  'translateBaidu' | 'translateGoogle' | 'translateYoudao' | 'translateMicrosoft'
+  'translateBaidu' | 'translateGoogle' | 'translateYoudao' | 'translateMicrosoft' | 'translateAi'
 > = {
   baidu: 'translateBaidu',
   google: 'translateGoogle',
   youdao: 'translateYoudao',
-  microsoft: 'translateMicrosoft'
+  microsoft: 'translateMicrosoft',
+  'ai-translation': 'translateAi'
 }
 
 // 读取各 provider 配置状态，用于在 provider 选择器旁标注「已配置 / 免授权」。
+// AI 翻译复用宿主已配置的 AI 模型、无需密钥，始终视为可用（与设置页一致）。
 const providerConfigured = ref<Record<ProviderName, boolean>>({
   baidu: false,
   google: true,
   youdao: false,
-  microsoft: true
+  microsoft: true,
+  'ai-translation': true
 })
 function refreshProviderStatus() {
   try {
@@ -76,7 +80,8 @@ function refreshProviderStatus() {
       baidu: !!(b.appID && b.appKey),
       google: true,
       youdao: !!(y.appKey && y.appSecret),
-      microsoft: true
+      microsoft: true,
+      'ai-translation': true
     }
   } catch (_) {
     /* preload 缺失等异常：保持默认值，不阻塞 */
@@ -98,7 +103,32 @@ function pickDefaultProvider(): ProviderName {
   return order.find((p) => providerConfigured.value[p]) || 'microsoft'
 }
 
-const provider = ref<ProviderName>('microsoft')
+// ─── 上次使用的翻译渠道持久化（dbStorage，与历史记录同库） ──────────
+// 切换渠道后留存，下次进入自动复用；存储值失效（渠道被禁用/移除）时回落默认。
+const LAST_PROVIDER_KEY = 'translate.lastProvider'
+function loadLastProvider(): ProviderName | null {
+  try {
+    const v = window.ztools.dbStorage.getItem<string>(LAST_PROVIDER_KEY)
+    if (v && v in providerLabels && providerConfigured.value[v as ProviderName]) {
+      return v as ProviderName
+    }
+  } catch (_) {
+    /* dbStorage 不可用等异常：回落默认，不阻塞 */
+  }
+  return null
+}
+function saveLastProvider(p: ProviderName): void {
+  try {
+    window.ztools.dbStorage.setItem(LAST_PROVIDER_KEY, p)
+  } catch (_) {
+    /* 写入失败忽略，不影响翻译流程 */
+  }
+}
+
+// 初始化渠道：先刷新各 provider 配置状态，再回填上次使用的渠道；失效时回落默认。
+// 在 setup 期完成，确保挂载时 provider 已是最终值，避免 initialText 首翻用错渠道。
+refreshProviderStatus()
+const provider = ref<ProviderName>(loadLastProvider() || pickDefaultProvider())
 const sourceLang = ref('auto')
 const targetLang = ref('auto') // auto = 走 preload 自动推断（中→英 / 其余→中）
 const sourceText = ref('') // 左侧原文（可编辑）
@@ -235,7 +265,9 @@ watch([sourceText, sourceLang, targetLang], () => {
 })
 
 // 切换 provider：立即翻译（不 debounce），让用户即时看到效果
+// 用户切换渠道时留存记录，下次进入自动复用。
 watch(provider, () => {
+  saveLastProvider(provider.value)
   if (hasInput.value) run()
 })
 
@@ -249,16 +281,29 @@ watch(
   () => props.initialText,
   (text) => {
     if (!text) return
-    suppressAuto = true
-    sourceText.value = text
-    run()
+    applyText(text)
   },
   { immediate: true }
 )
 
+/**
+ * 预填原文并立即翻译一次。
+ * - 抑制由程序化赋值引发的下一次自动翻译，避免「立即 run + 1s 后又 run」双重翻译。
+ * - 允许相同文本重复触发（不依赖 watch 值变化），供父组件在用户手动切 tab 时
+ *   把 OCR 识别结果带入翻译输入框。
+ */
+function applyText(text: string) {
+  if (!text) return
+  suppressAuto = true
+  sourceText.value = text
+  run()
+}
+
+// 暴露给父组件：手动切到翻译 tab 时预填 OCR 识别结果（不受 watch 值比较限制）
+defineExpose({ applyText })
+
 onMounted(() => {
-  refreshProviderStatus()
-  provider.value = pickDefaultProvider()
+  // 渠道回填已在 setup 期完成，此处仅做首挂聚焦 + 窗口失焦/恢复监听。
   // 首次挂载聚焦原文输入框并全选，便于直接覆盖输入。
   // nextTick 确保 DOM（含 v-model 文本）已渲染完成后再 select。
   nextTick(focusAndSelectAll)


### PR DESCRIPTION
## 插件信息

- **名称**: ZTools 提供商
- **插件ID**: f-provider
- **版本**: 1.1.0
- **描述**: OCR + 翻译提供商集合（百度/谷歌/有道/微软翻译、微信 OCR）
- **作者**: kaineooo
- **类型**: 更新

## 本次变更

- feat: ZTools OCR + 翻译提供商插件（截图识别 / 代码翻译 / manage）
- chore: 调整插件命名空间
- chore: 调整资源url
- feat: 微信 OCR 原生模块支持 macOS（libwxocr.dylib）
- feat: 截图识别结果改为独立窗口展示（左图右文 + 拖动缩放）
- feat: 翻译视图进入/恢复时自动聚焦并全选原文
- fix: 翻译/代码翻译命令的 regex match 补回 /…/ 边界
- chore: 版本号升至 1.0.2，开发端口改为 5179
- refactor: native 引擎改由 npmmirror npm 包分发，落地至 userData 目录
- chore: 版本号升至 1.0.3
- refactor: 截图识别结果窗口改用原生标题栏并隐藏菜单栏，初始尺寸下限 800×600
- feat: 新增 LaTeX 公式识别引擎及去重打包发布链路
- feat: HTTP 请求支持系统代理（CONNECT 隧道），谷歌翻译改用官方 translate.googleapis.com 接口
- refactor: 翻译/代码翻译入口由 regex 改为 over 类型
- feat: native/LaTeX 引擎改由 GitHub Release 分发并单例化引擎状态
- fix: 为 Electron 沙箱 preload 补全 setImmediate polyfill
- feat: 引擎下载支持镜像竞速/加速点选择/取消，合并识别子页并重构设置布局
- fix: 收敛 onPluginEnter 至 App.vue 避免覆盖式劫持，版本升至 1.0.4
- refactor: 截图识别收敛至插件内流程并移除独立结果窗口
- feat: 新增历史记录模块及 tab 状态缓存
- chore: 升级版本号至 1.0.5
- docs: 对齐 README 至现状，补充 LaTeX/历史记录与 macOS 支持，修正微信复用措辞
- fix: 修复 scoped 下暗色模式样式失效，改用 .dark 类驱动 KaTeX 预览与模式切换高亮
- feat: 新增 AI 翻译与 AI 识图 provider，复用宿主已配置的 AI 模型
- feat: 新增 OCR 识别并翻译 feature，识别图片文字后自动切到翻译 tab 预填并触发翻译
- feat: 新增 AI 公式识别与图床通道，补文字模式 AI 识图渠道切换
- chore: 文案调整及移除不需要开放的provider
- fix: 修复 OCR 识别后手动切翻译 tab 无法带入文本，及历史记录丢失
- chore: 升级版本号至 1.1.0

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [ ] plugin.json 的 name / title / version / description / author 字段均已检查
- [ ] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [ ] 本次 PR 的 diff 仅涉及 `plugins/f-provider/` 目录
- [ ] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [ ] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
