### PR TITLE
Update plugin 本地搜索Neo v1.1.1

### DIFF
--- a/plugins/local-search-neo/.editorconfig
+++ b/plugins/local-search-neo/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/plugins/local-search-neo/AGENTS.md
+++ b/plugins/local-search-neo/AGENTS.md
@@ -43,6 +43,6 @@
   - `addon/index.d.ts`
   - `addon/README.md`
 - 预览相关逻辑优先看 `src/Finder/composables/useFilePreview.ts`。
-- 文件类型判断和纯逻辑测试优先放在 `src/Finder/core/finderLogic.ts` / `.test.ts`。
+- 文件类型判断与纯逻辑测试优先放在 `src/Finder/core/`（如 `previewCandidate.ts`、`finderLogic.ts` 及对应 `.test.ts`）。
 - 不要直接假设 ZTools API 签名；先查 `node_modules/@ztools-center/ztools-api-types/ztools.api.d.ts`。
 - 查 Rust crate API 时优先看 docs.rs 文档，不要直接翻依赖源码。

--- a/plugins/local-search-neo/addon/index.d.ts
+++ b/plugins/local-search-neo/addon/index.d.ts
@@ -20,11 +20,11 @@ export interface EverythingQueryItem {
   name: string;
   path: string;
   fullPath: string;
-  highlightedName?: string;
-  highlightedPath?: string;
-  extension?: string;
-  size?: number;
-  modifiedAt?: number;
+  highlightedName: string;
+  highlightedPath: string;
+  extension: string;
+  size: number;
+  modifiedAt: number;
 }
 
 export interface EverythingQueryResult {

--- a/plugins/local-search-neo/addon/package.json
+++ b/plugins/local-search-neo/addon/package.json
@@ -11,7 +11,9 @@
     "build-release": "cargo-cp-artifact -nc index.node -- cargo build --message-format=json-render-diagnostics --release",
     "install": "npm run build-release",
     "test": "cargo test",
-    "test:everything": "node ../scripts/test-everything-addon.cjs"
+    "test:everything": "node ../scripts/test-everything-addon.cjs",
+    "format": "cargo fmt",
+    "format:check": "cargo fmt --check"
   },
   "devDependencies": {
     "cargo-cp-artifact": "^0.1"

--- a/plugins/local-search-neo/package-lock.json
+++ b/plugins/local-search-neo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "local-search-neo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "local-search-neo",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@lucide/vue": "^1.17.0",
         "markdown-it": "^14.2.0",

--- a/plugins/local-search-neo/package.json
+++ b/plugins/local-search-neo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-search-neo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "借助 Everything 来进行文件搜索",
   "type": "module",
   "scripts": {
@@ -9,10 +9,10 @@
     "build:addon": "npm run prepare:addon && npm --prefix addon run build-release && node scripts/copy-addon.cjs",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
-    "format": "oxfmt --write .",
-    "format:check": "oxfmt --check .",
+    "format": "oxfmt --write . && npm --prefix addon run format",
+    "format:check": "oxfmt --check . && npm --prefix addon run format:check",
     "check": "npm run lint && npm run format:check && npm test",
-    "test": "node scripts/run-ts-tests.cjs src/Finder/core/finderLogic.test.ts",
+    "test": "node scripts/run-ts-tests.cjs src/Finder/core/finderLogic.test.ts src/Finder/core/previewCandidate.test.ts",
     "test:everything-addon": "node scripts/test-everything-addon.cjs",
     "bench:everything": "node scripts/benchmark-everything-addon.cjs",
     "predev": "npm run prepare:pdfjs && npm run build:addon",

--- a/plugins/local-search-neo/public/plugin.json
+++ b/plugins/local-search-neo/public/plugin.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/guopenghui/local-search-neo",
   "title": "本地搜索Neo",
   "description": "借助 Everything 来进行文件搜索",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.html",
   "preload": "preload/services.js",
   "unpack": "Everything.*",

--- a/plugins/local-search-neo/public/preload/services.js
+++ b/plugins/local-search-neo/public/preload/services.js
@@ -156,10 +156,10 @@ ztools.registerTool("everything_search", async (params) => {
   const queryResult = everythingAddon.query(search, maxResults, "modified-desc", matchPath);
   return {
     total: queryResult.total,
-    results: (queryResult.items || []).map((item) => ({
+    results: queryResult.items.map((item) => ({
       fullPath: item.fullPath,
       size: item.size,
-      modified: item.modifiedAt ? new Date(item.modifiedAt).toISOString() : undefined,
+      modified: new Date(item.modifiedAt).toISOString(),
     })),
   };
 });

--- a/plugins/local-search-neo/src/App.vue
+++ b/plugins/local-search-neo/src/App.vue
@@ -2,7 +2,7 @@
 import { onMounted } from "vue";
 import Finder from "./Finder/index.vue";
 import { useFinderEnterAction } from "./Finder/composables/useFinderEnterAction";
-import { getFileIconDataUrl, warmUpFileIconCache } from "./Finder/core/fileIconCache";
+import { warmUpFileIconCache } from "./Finder/core/fileIconCache";
 import {
   DEFAULT_CATEGORIES,
   buildEverythingQuery,
@@ -74,9 +74,9 @@ onMounted(() => {
         const items: MainPushSearchResult[] = resultItems
           .slice(0, MAIN_PUSH_RESULT_LIMIT)
           .map((item) => ({
-            title: item.path ?? (item.fullPath ? getParentPath(item.fullPath) : ""),
+            title: item.path,
             text: item.name,
-            icon: item.fullPath ? window.ztools.getFileIcon(item.fullPath) : undefined,
+            icon: window.ztools.getFileIcon(item.fullPath),
             fullPath: item.fullPath,
           }));
 
@@ -102,11 +102,6 @@ onMounted(() => {
     },
   );
 });
-
-function getParentPath(fullPath: string): string {
-  const index = Math.max(fullPath.lastIndexOf("\\"), fullPath.lastIndexOf("/"));
-  return index > 0 ? fullPath.slice(0, index) : fullPath;
-}
 </script>
 
 <template>

--- a/plugins/local-search-neo/src/Finder/components/FinderFooter.vue
+++ b/plugins/local-search-neo/src/Finder/components/FinderFooter.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ArrowUpDown, Check, ChevronDown } from "@lucide/vue";
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { usePersistStorage } from "../composables/usePersistStorage";
 import type { FinderSortMode } from "../core/finderLogic";
@@ -49,7 +50,7 @@ function selectSortMode(mode: FinderSortMode) {
 function handleGlobalPointerdown(event: PointerEvent) {
   if (!showSortMenu.value) return;
   const target = event.target;
-  if (target instanceof HTMLElement) {
+  if (target instanceof Element) {
     if (target.closest(".sort-trigger") || target.closest(".sort-menu")) {
       return;
     }
@@ -78,23 +79,38 @@ onUnmounted(() => {
         @mousedown.left.prevent
         @click="toggleSortMenu"
       >
-        <span>{{ activeSortLabel }}</span>
-        <span class="sort-trigger-arrow" aria-hidden="true"></span>
+        <ArrowUpDown class="sort-trigger-icon" :size="13" :stroke-width="1.8" aria-hidden="true" />
+        <span class="sort-trigger-text">{{ activeSortLabel }}</span>
+        <ChevronDown
+          class="sort-trigger-chevron"
+          :size="13"
+          :stroke-width="1.8"
+          aria-hidden="true"
+        />
       </button>
-      <div v-if="showSortMenu" class="sort-menu">
-        <button
-          v-for="option in SORT_OPTIONS"
-          :key="option.value"
-          type="button"
-          class="sort-option"
-          :class="{ active: option.value === sortMode }"
-          tabindex="-1"
-          @mousedown.left.prevent
-          @click="selectSortMode(option.value)"
-        >
-          {{ option.label }}
-        </button>
-      </div>
+      <Transition name="sort-menu-pop">
+        <div v-if="showSortMenu" class="sort-menu">
+          <button
+            v-for="option in SORT_OPTIONS"
+            :key="option.value"
+            type="button"
+            class="sort-option"
+            :class="{ active: option.value === sortMode }"
+            tabindex="-1"
+            @mousedown.left.prevent
+            @click="selectSortMode(option.value)"
+          >
+            <span>{{ option.label }}</span>
+            <Check
+              v-if="option.value === sortMode"
+              class="sort-option-check"
+              :size="13"
+              :stroke-width="2"
+              aria-hidden="true"
+            />
+          </button>
+        </div>
+      </Transition>
     </div>
     <label class="preview-toggle">
       <span>{{ previewLabel }}</span>
@@ -140,7 +156,6 @@ onUnmounted(() => {
 }
 
 .sort-select {
-  --sort-select-width: 148px;
   position: relative;
   display: flex;
   align-items: center;
@@ -149,41 +164,62 @@ onUnmounted(() => {
 }
 
 .sort-trigger {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  width: var(--sort-select-width);
+  gap: 5px;
   height: 24px;
   box-sizing: border-box;
-  padding: 0 8px 0 10px;
-  color: #e7ebf0;
-  background: #34373b;
-  border: 1px solid #555b63;
+  padding: 0 6px;
+  color: #b8bec7;
+  background: transparent;
+  border: 1px solid transparent;
   border-radius: 4px;
-  font-size: 11.5px;
+  font-size: 12px;
   line-height: 1;
   cursor: pointer;
   transition:
     background-color 0.16s ease,
-    border-color 0.16s ease,
     color 0.16s ease;
 }
 
 .sort-trigger:hover,
 .sort-trigger[aria-expanded="true"] {
-  background: #3d4147;
-  border-color: #68707a;
+  color: #ffffff;
+  background: rgb(255 255 255 / 8%);
 }
 
-.sort-trigger-arrow {
-  width: 5px;
-  height: 5px;
-  margin-top: -3px;
-  border-right: 1.5px solid currentColor;
-  border-bottom: 1.5px solid currentColor;
-  color: #aeb4bb;
-  transform: rotate(45deg);
+.sort-trigger-icon {
+  flex-shrink: 0;
+  color: #9aa1ab;
+  pointer-events: none;
+  transition: color 0.16s ease;
+}
+
+.sort-trigger:hover .sort-trigger-icon,
+.sort-trigger[aria-expanded="true"] .sort-trigger-icon {
+  color: #ffffff;
+}
+
+.sort-trigger-text {
+  white-space: nowrap;
+}
+
+.sort-trigger-chevron {
+  flex-shrink: 0;
+  color: #8b929c;
+  pointer-events: none;
+  transition:
+    transform 0.16s ease,
+    color 0.16s ease;
+}
+
+.sort-trigger:hover .sort-trigger-chevron,
+.sort-trigger[aria-expanded="true"] .sort-trigger-chevron {
+  color: #ffffff;
+}
+
+.sort-trigger[aria-expanded="true"] .sort-trigger-chevron {
+  transform: rotate(180deg);
 }
 
 .sort-menu {
@@ -192,31 +228,72 @@ onUnmounted(() => {
   left: 0;
   z-index: 30;
   display: grid;
-  width: var(--sort-select-width);
+  width: 100%;
   box-sizing: border-box;
-  padding: 5px;
-  background: #2b2e33;
-  border: 1px solid #515862;
+  padding: 4px;
+  background: #25272a;
+  border: 1px solid rgb(255 255 255 / 10%);
   border-radius: 6px;
-  box-shadow: 0 12px 28px rgb(0 0 0 / 30%);
+  box-shadow:
+    0 12px 28px rgb(0 0 0 / 40%),
+    0 2px 6px rgb(0 0 0 / 20%);
+  transform-origin: bottom left;
+}
+
+.sort-menu-pop-enter-active {
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.sort-menu-pop-leave-active {
+  transition:
+    opacity 0.12s ease,
+    transform 0.12s ease;
+}
+
+.sort-menu-pop-enter-from {
+  opacity: 0;
+  transform: translateY(4px) scale(0.96);
+}
+
+.sort-menu-pop-leave-to {
+  opacity: 0;
+  transform: translateY(3px) scale(0.97);
 }
 
 .sort-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   height: 26px;
-  padding: 0 8px;
-  color: #dfe4ea;
+  padding: 0 6px;
+  color: #cfd4dc;
   background: transparent;
   border-radius: 4px;
-  font-size: 11.5px;
+  font-size: 12px;
   line-height: 1;
   text-align: left;
   cursor: pointer;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
 }
 
-.sort-option:hover,
+.sort-option:hover {
+  color: #ffffff;
+  background: rgb(255 255 255 / 8%);
+}
+
 .sort-option.active {
   color: #ffffff;
-  background: var(--primary-color-dark-subtle-hover, #424751);
+  background: var(--primary-color-dark-subtle-hover, rgb(255 255 255 / 12%));
+  font-weight: 500;
+}
+
+.sort-option-check {
+  flex-shrink: 0;
+  color: var(--primary-color, #60a5fa);
 }
 
 .preview-toggle {
@@ -274,35 +351,60 @@ onUnmounted(() => {
   }
 
   .sort-trigger {
-    color: #1f2937;
-    background: #ffffff;
-    border-color: #c8d0da;
+    color: #4f5b6a;
+    background: transparent;
+    border-color: transparent;
   }
 
   .sort-trigger:hover,
   .sort-trigger[aria-expanded="true"] {
-    background: #f4f7fb;
-    border-color: #aab4c2;
+    color: #111827;
+    background: rgb(0 0 0 / 6%);
   }
 
-  .sort-trigger-arrow {
+  .sort-trigger-icon {
     color: #667085;
+  }
+
+  .sort-trigger:hover .sort-trigger-icon,
+  .sort-trigger[aria-expanded="true"] .sort-trigger-icon {
+    color: #111827;
+  }
+
+  .sort-trigger-chevron {
+    color: #7d8896;
+  }
+
+  .sort-trigger:hover .sort-trigger-chevron,
+  .sort-trigger[aria-expanded="true"] .sort-trigger-chevron {
+    color: #111827;
   }
 
   .sort-menu {
     background: #ffffff;
-    border-color: #c8d0da;
-    box-shadow: 0 12px 28px rgb(15 23 42 / 16%);
+    border-color: rgb(15 23 42 / 12%);
+    box-shadow:
+      0 12px 28px rgb(15 23 42 / 14%),
+      0 2px 6px rgb(15 23 42 / 6%);
   }
 
   .sort-option {
-    color: #1f2937;
+    color: #374151;
   }
 
-  .sort-option:hover,
-  .sort-option.active {
+  .sort-option:hover {
     color: #111827;
-    background: var(--primary-color-subtle-hover);
+    background: rgb(0 0 0 / 5%);
+  }
+
+  .sort-option.active {
+    color: var(--primary-color, #2563eb);
+    background: var(--primary-color-subtle-hover, #eef2f8);
+    font-weight: 500;
+  }
+
+  .sort-option-check {
+    color: var(--primary-color, #2563eb);
   }
 
   .toggle-track {

--- a/plugins/local-search-neo/src/Finder/components/FinderPreviewPane.vue
+++ b/plugins/local-search-neo/src/Finder/components/FinderPreviewPane.vue
@@ -33,12 +33,12 @@ const {
 });
 
 function openImagePreviewMenu(event: MouseEvent) {
-  const imagePath = activeItem.value?.fullPath ?? "";
+  const imagePath = activeItem.value?.fullPath;
+  if (!imagePath) return;
   emit("context-menu", event, [
     {
       id: "copy-preview-image",
       label: "复制图片",
-      disabled: !imagePath,
       action: () => {
         window.ztools.copyFile(imagePath);
       },

--- a/plugins/local-search-neo/src/Finder/components/FinderResultList.vue
+++ b/plugins/local-search-neo/src/Finder/components/FinderResultList.vue
@@ -4,7 +4,8 @@ import { LoaderCircle } from "@lucide/vue";
 import type { ContextMenuItem } from "../composables/useContextMenu";
 import { useFileIcons } from "../composables/useFileIcons";
 import type { ResultActions } from "../composables/useResultActions";
-import { formatBytes, type FinderResult, type SelectionMode } from "../core/finderLogic";
+import type { FinderResult, SelectionMode } from "../core/finderLogic";
+import { formatBytes } from "../core/formatters";
 
 const props = defineProps<{
   visibleResults: FinderResult[];
@@ -32,8 +33,8 @@ const emit = defineEmits<{
 
 const selectedPathSet = computed(() => new Set(props.selectedPaths));
 
-function isRowSelected(fullPath?: string): boolean {
-  return !!fullPath && selectedPathSet.value.has(fullPath);
+function isRowSelected(fullPath: string): boolean {
+  return selectedPathSet.value.has(fullPath);
 }
 
 const { displayItem, iconFor } = useFileIcons({
@@ -59,7 +60,6 @@ function handleRowClick(event: MouseEvent, item: FinderResult) {
 
 function handleDragStart(event: DragEvent, item: FinderResult) {
   event.preventDefault();
-  if (!item.fullPath) return;
   if (!selectedPathSet.value.has(item.fullPath)) {
     emit("select", item, "single");
   }
@@ -111,50 +111,41 @@ function highlightSegments(value: string | undefined, fallback = ""): HighlightS
 }
 
 function openResultMenu(event: MouseEvent, item: FinderResult) {
-  if (item.fullPath && !selectedPathSet.value.has(item.fullPath)) {
+  if (!selectedPathSet.value.has(item.fullPath)) {
     emit("select", item, "single");
   }
 
-  const isMulti =
-    !!item.fullPath && selectedPathSet.value.has(item.fullPath) && props.selectedItems.length > 1;
-
+  const isMulti = selectedPathSet.value.has(item.fullPath) && props.selectedItems.length > 1;
   const targetItems = isMulti ? props.selectedItems : [item];
 
   const count = targetItems.length;
   const countSuffix = isMulti ? ` (${count} 项)` : "";
-  const hasFullPath = targetItems.some((r) => !!r.fullPath);
-  const hasDirectoryPath = targetItems.some((r) => !!r.path);
 
   emit("context-menu", event, [
     {
       id: "open-file",
       label: `打开文件${countSuffix}`,
-      disabled: !hasFullPath,
       action: () => props.actions.open(targetItems),
     },
     {
       id: "show-in-folder",
       label: `打开所在目录${countSuffix}`,
-      disabled: !hasFullPath,
       action: () => props.actions.showInFolder(targetItems),
     },
     { id: "separator-open", label: "", separator: true },
     {
       id: "copy-full-path",
       label: `复制路径${countSuffix}`,
-      disabled: !hasFullPath,
       action: () => props.actions.copyFullPath(targetItems),
     },
     {
       id: "copy-directory-path",
       label: `复制所在路径${countSuffix}`,
-      disabled: !hasDirectoryPath,
       action: () => props.actions.copyDirectoryPath(targetItems),
     },
     {
       id: "copy-file",
       label: `复制文件${countSuffix}`,
-      disabled: !hasFullPath,
       action: () => props.actions.copyFile(targetItems),
     },
     { id: "separator-delete", label: "", separator: true },
@@ -162,7 +153,6 @@ function openResultMenu(event: MouseEvent, item: FinderResult) {
       id: "trash-item",
       label: isMulti ? `删除 ${count} 项（回收站）` : "删除（回收站）",
       danger: true,
-      disabled: !hasFullPath,
       action: () => props.actions.trash(targetItems),
     },
   ]);
@@ -175,7 +165,7 @@ function openResultMenu(event: MouseEvent, item: FinderResult) {
       v-for="(item, index) in visibleResults"
       :key="item.fullPath"
       :data-result-index="index"
-      :draggable="!!item.fullPath"
+      :draggable="true"
       class="result-row"
       :class="{
         selected: isRowSelected(item.fullPath),
@@ -200,7 +190,7 @@ function openResultMenu(event: MouseEvent, item: FinderResult) {
             >{{ segment.text }}</span
           >
         </span>
-        <span class="file-path" :title="item.fullPath || item.path">
+        <span class="file-path" :title="item.fullPath">
           <span
             v-for="(segment, segmentIndex) in highlightSegments(item.highlightedPath, item.path)"
             :key="segmentIndex"
@@ -262,13 +252,13 @@ function openResultMenu(event: MouseEvent, item: FinderResult) {
 }
 
 .result-row.selected {
-  box-shadow: inset 3px 0 0 var(--primary-color-alpha-50);
+  box-shadow: inset 2px 0 0 var(--primary-color-alpha-50);
 }
 
 .result-row.selected.active-focus,
 .result-row.active-focus {
   background: var(--primary-color-dark-subtle-bg, #4a4b4d);
-  box-shadow: inset 3px 0 0 var(--primary-color);
+  box-shadow: inset 2px 0 0 var(--primary-color);
 }
 
 .file-icon {
@@ -385,13 +375,13 @@ function openResultMenu(event: MouseEvent, item: FinderResult) {
   }
 
   .result-row.selected {
-    box-shadow: inset 3px 0 0 var(--primary-color-alpha-50);
+    box-shadow: inset 2px 0 0 var(--primary-color-alpha-50);
   }
 
   .result-row.selected.active-focus,
   .result-row.active-focus {
     background: var(--primary-color-subtle-bg);
-    box-shadow: inset 3px 0 0 var(--primary-color-text, var(--primary-color));
+    box-shadow: inset 2px 0 0 var(--primary-color-text, var(--primary-color));
   }
 
   .file-name {

--- a/plugins/local-search-neo/src/Finder/components/FinderSidebar.vue
+++ b/plugins/local-search-neo/src/Finder/components/FinderSidebar.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import { Settings } from "@lucide/vue";
-import { computed } from "vue";
 import type { FinderCategory } from "../core/finderLogic";
 
-const props = defineProps<{
+defineProps<{
   categories: FinderCategory[];
   activeCategoryId: string;
 }>();
@@ -12,66 +11,72 @@ const emit = defineEmits<{
   select: [category: FinderCategory];
   openSettings: [];
 }>();
-
-const builtInCategories = computed(() =>
-  props.categories.filter((category) => category.kind !== "custom"),
-);
-const customCategories = computed(() =>
-  props.categories.filter((category) => category.kind === "custom"),
-);
 </script>
 
 <template>
   <aside class="finder-sidebar">
-    <button
-      v-for="category in builtInCategories"
-      :key="category.id"
-      class="category-button"
-      :class="{ active: category.id === activeCategoryId }"
-      tabindex="-1"
-      @mousedown.left.prevent
-      @click="emit('select', category)"
-    >
-      <span>{{ category.label }}</span>
-    </button>
+    <div class="sidebar-category-list">
+      <button
+        v-for="category in categories"
+        :key="category.id"
+        class="category-button"
+        :class="{
+          active: category.id === activeCategoryId,
+          'custom-category-button': category.kind === 'custom',
+        }"
+        :title="category.label"
+        tabindex="-1"
+        @mousedown.left.prevent
+        @click="emit('select', category)"
+      >
+        <span>{{ category.label }}</span>
+      </button>
+    </div>
 
-    <div v-if="customCategories.length > 0" class="category-separator"></div>
-
-    <button
-      v-for="category in customCategories"
-      :key="category.id"
-      class="category-button custom-category-button"
-      :class="{ active: category.id === activeCategoryId }"
-      tabindex="-1"
-      @mousedown.left.prevent
-      @click="emit('select', category)"
-    >
-      <span>{{ category.label }}</span>
-    </button>
-
-    <button
-      class="sidebar-settings"
-      title="设置"
-      tabindex="-1"
-      @mousedown.left.prevent
-      @click="emit('openSettings')"
-    >
-      <Settings class="sidebar-settings-icon" :size="18" :stroke-width="2" aria-hidden="true" />
-    </button>
+    <div class="sidebar-footer">
+      <button
+        class="sidebar-settings"
+        title="设置"
+        tabindex="-1"
+        @mousedown.left.prevent
+        @click="emit('openSettings')"
+      >
+        <Settings class="sidebar-settings-icon" :size="18" :stroke-width="2" aria-hidden="true" />
+      </button>
+    </div>
   </aside>
 </template>
 
 <style scoped>
 .finder-sidebar {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  min-height: 0;
+  height: 100%;
+  max-height: 100%;
+  overflow: hidden;
+  border-right: 1px solid #47494c;
+  background: #2b2d2f;
+  box-sizing: border-box;
+}
+
+.sidebar-category-list {
   display: flex;
   flex-direction: column;
   gap: 1px;
   min-height: 0;
-  max-height: 100%;
-  overflow: hidden auto;
-  padding: 10px 5px 8px;
-  border-right: 1px solid #47494c;
-  background: #2b2d2f;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 10px 5px 4px;
+}
+
+.sidebar-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 8px 5px 8px;
+  box-sizing: border-box;
 }
 
 .category-button,
@@ -95,13 +100,28 @@ const customCategories = computed(() =>
   align-items: center;
   justify-content: center;
   min-height: 38px;
-  padding: 0 2px;
+  height: auto;
+  padding: 6px 0;
   color: #c8d0db;
   cursor: pointer;
   font-size: 13px;
   font-weight: 500;
   letter-spacing: 0.3px;
-  white-space: nowrap;
+  white-space: normal;
+  word-break: break-all;
+  overflow-wrap: anywhere;
+  text-align: center;
+  line-height: 1.25;
+  box-sizing: border-box;
+}
+
+.category-button span {
+  display: block;
+  width: 100%;
+  word-break: break-all;
+  overflow-wrap: anywhere;
+  white-space: normal;
+  text-align: center;
 }
 
 .category-button.active {
@@ -116,25 +136,23 @@ const customCategories = computed(() =>
   color: #d4d8df;
 }
 
-.category-separator {
-  height: 1px;
-  margin: 6px 6px;
-  background: #444a53;
-}
-
 .sidebar-settings {
-  display: grid;
-  place-items: center;
-  width: 100%;
-  height: 34px;
-  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
   color: #d5d9df;
   cursor: pointer;
-  border-radius: 4px;
+  border-radius: 50%;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .sidebar-settings:hover {
   background: #3a3d42;
+  color: #ffffff;
 }
 
 .sidebar-settings-icon {
@@ -161,16 +179,13 @@ const customCategories = computed(() =>
     color: #374151;
   }
 
-  .category-separator {
-    background: #d7dee8;
-  }
-
   .sidebar-settings {
     color: #4f5b6a;
   }
 
   .sidebar-settings:hover {
     background: #dce3ec;
+    color: #111827;
   }
 }
 </style>

--- a/plugins/local-search-neo/src/Finder/components/SettingsDrawer.vue
+++ b/plugins/local-search-neo/src/Finder/components/SettingsDrawer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { GripVertical, RotateCcw } from "@lucide/vue";
+import { ref, watch } from "vue";
 import type { FinderCategory } from "../core/finderLogic";
 
 const props = defineProps<{
@@ -15,27 +16,24 @@ const emit = defineEmits<{
   removeCategory: [category: FinderCategory];
   setCategoryEnabled: [id: string, enabled: boolean];
   setMatchPathEnabled: [enabled: boolean];
+  reorderCategories: [fromIndex: number, toIndex: number];
+  resetCategoryOrder: [];
 }>();
 
 const label = ref("");
 const rule = ref("");
 const editingCategoryId = ref<string | undefined>();
 const isAdding = ref(false);
-const builtInCollapsed = ref(true);
-const builtInCategories = computed(() =>
-  props.categories.filter((category) => category.kind !== "custom"),
-);
-const customCategories = computed(() =>
-  props.categories.filter((category) => category.kind === "custom"),
-);
+
+const draggedIndex = ref<number | null>(null);
+const dragOverIndex = ref<number | null>(null);
+const dropPosition = ref<"above" | "below" | null>(null);
 
 watch(
   () => props.open,
-  (open) => {
+  () => {
     resetDraft();
-    if (open) {
-      builtInCollapsed.value = true;
-    }
+    resetDragState();
   },
 );
 
@@ -63,6 +61,7 @@ function startAddCategory() {
   isAdding.value = true;
   label.value = "";
   rule.value = "";
+  resetDragState();
 }
 
 function editCategory(category: FinderCategory) {
@@ -71,6 +70,7 @@ function editCategory(category: FinderCategory) {
   editingCategoryId.value = category.id;
   label.value = category.label;
   rule.value = category.rule;
+  resetDragState();
 }
 
 function removeCategory(category: FinderCategory) {
@@ -87,6 +87,7 @@ function resetDraft() {
 
 function closeDrawer() {
   resetDraft();
+  resetDragState();
   emit("close");
 }
 
@@ -107,8 +108,78 @@ function readChecked(event: Event) {
   return event.target instanceof HTMLInputElement && event.target.checked;
 }
 
-function toggleBuiltInCategories() {
-  builtInCollapsed.value = !builtInCollapsed.value;
+function onDragStart(index: number, event: DragEvent) {
+  if (editingCategoryId.value !== undefined || isAdding.value) {
+    event.preventDefault();
+    return;
+  }
+  draggedIndex.value = index;
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", String(index));
+  }
+}
+
+function onDragOver(index: number, event: DragEvent) {
+  if (draggedIndex.value === null) return;
+  event.preventDefault();
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = "move";
+  }
+
+  const currentTarget = event.currentTarget as HTMLElement | null;
+  if (currentTarget) {
+    const rect = currentTarget.getBoundingClientRect();
+    const offsetY = event.clientY - rect.top;
+    const isBelow = offsetY > rect.height / 2;
+    dragOverIndex.value = index;
+    dropPosition.value = isBelow ? "below" : "above";
+  }
+}
+
+function onDragLeave(index: number, event: DragEvent) {
+  if (dragOverIndex.value === index) {
+    const related = event.relatedTarget as Node | null;
+    const current = event.currentTarget as Node | null;
+    if (!current || !related || !current.contains(related)) {
+      dragOverIndex.value = null;
+      dropPosition.value = null;
+    }
+  }
+}
+
+function onDrop(targetIndex: number, event: DragEvent) {
+  event.preventDefault();
+  const from = draggedIndex.value;
+  if (from === null) return;
+
+  let to = targetIndex;
+  if (dropPosition.value === "below" && from < targetIndex) {
+    to = targetIndex;
+  } else if (dropPosition.value === "below" && from > targetIndex) {
+    to = targetIndex + 1;
+  } else if (dropPosition.value === "above" && from < targetIndex) {
+    to = targetIndex - 1;
+  } else if (dropPosition.value === "above" && from > targetIndex) {
+    to = targetIndex;
+  }
+
+  const clampedTo = Math.max(0, Math.min(props.categories.length - 1, to));
+  if (from !== clampedTo) {
+    emit("reorderCategories", from, clampedTo);
+  }
+
+  resetDragState();
+}
+
+function onDragEnd() {
+  resetDragState();
+}
+
+function resetDragState() {
+  draggedIndex.value = null;
+  dragOverIndex.value = null;
+  dropPosition.value = null;
 }
 </script>
 
@@ -151,10 +222,20 @@ function toggleBuiltInCategories() {
                 <h3>分组管理</h3>
                 <p>关闭后，该分组不会显示在左侧分组栏。内置分组不支持删除。</p>
               </div>
+              <button
+                type="button"
+                class="category-reset-order-btn"
+                title="恢复默认排序"
+                aria-label="恢复默认排序"
+                @click="emit('resetCategoryOrder')"
+              >
+                <RotateCcw :size="16" :stroke-width="2" aria-hidden="true" />
+              </button>
             </div>
 
             <div class="category-list">
               <div class="category-list-header">
+                <span class="category-handle-col"></span>
                 <span>启用</span>
                 <span>名称</span>
                 <span>规则</span>
@@ -162,51 +243,20 @@ function toggleBuiltInCategories() {
                 <span>操作</span>
               </div>
 
-              <div class="category-group">
-                <button
-                  type="button"
-                  class="category-group-toggle"
-                  :aria-expanded="!builtInCollapsed"
-                  @click="toggleBuiltInCategories"
-                >
-                  <span class="category-group-arrow" aria-hidden="true"></span>
-                  <span>内置分组</span>
-                  <span class="category-group-count">{{ builtInCategories.length }} 个</span>
-                </button>
-
-                <template v-if="!builtInCollapsed">
-                  <div
-                    v-for="category in builtInCategories"
-                    :key="category.id"
-                    class="category-row"
-                    :class="{ disabled: !category.enabled }"
-                  >
-                    <label class="category-switch" title="启用该分组">
-                      <input
-                        type="checkbox"
-                        :checked="category.enabled"
-                        @change="handleCategoryEnabledChange(category, $event)"
-                      />
-                      <span class="switch-track"></span>
-                    </label>
-                    <span class="category-name">{{ category.label }}</span>
-                    <span class="category-rule" :title="category.rule || '全部'">{{
-                      category.rule || "全部"
-                    }}</span>
-                    <span class="category-type">{{ categoryTypeLabel(category) }}</span>
-                    <span class="category-actions">
-                      <span class="built-in-note">内置</span>
-                    </span>
-                  </div>
-                </template>
-              </div>
-
-              <template v-for="category in customCategories" :key="category.id">
+              <template v-for="(category, index) in categories" :key="category.id">
                 <form
                   v-if="editingCategoryId === category.id"
                   class="category-row category-edit-row"
                   @submit.prevent="submitCategory"
                 >
+                  <span class="category-drag-handle disabled">
+                    <GripVertical
+                      class="category-drag-icon"
+                      :size="14"
+                      :stroke-width="2"
+                      aria-hidden="true"
+                    />
+                  </span>
                   <label class="category-switch" title="启用该分组">
                     <input
                       type="checkbox"
@@ -224,7 +274,32 @@ function toggleBuiltInCategories() {
                   </span>
                 </form>
 
-                <div v-else class="category-row" :class="{ disabled: !category.enabled }">
+                <div
+                  v-else
+                  class="category-row"
+                  :class="{
+                    disabled: !category.enabled,
+                    'is-dragging': draggedIndex === index,
+                    'drag-over-top':
+                      dragOverIndex === index && dropPosition === 'above' && draggedIndex !== index,
+                    'drag-over-bottom':
+                      dragOverIndex === index && dropPosition === 'below' && draggedIndex !== index,
+                  }"
+                  :draggable="editingCategoryId === undefined && !isAdding"
+                  @dragstart="onDragStart(index, $event)"
+                  @dragover="onDragOver(index, $event)"
+                  @dragleave="onDragLeave(index, $event)"
+                  @drop="onDrop(index, $event)"
+                  @dragend="onDragEnd"
+                >
+                  <span class="category-drag-handle" title="拖动调整顺序" aria-label="拖动调整顺序">
+                    <GripVertical
+                      class="category-drag-icon"
+                      :size="14"
+                      :stroke-width="2"
+                      aria-hidden="true"
+                    />
+                  </span>
                   <label class="category-switch" title="启用该分组">
                     <input
                       type="checkbox"
@@ -239,10 +314,13 @@ function toggleBuiltInCategories() {
                   }}</span>
                   <span class="category-type">{{ categoryTypeLabel(category) }}</span>
                   <span class="category-actions">
-                    <button type="button" @click="editCategory(category)">编辑</button>
-                    <button type="button" class="danger-action" @click="removeCategory(category)">
-                      删除
-                    </button>
+                    <template v-if="category.kind === 'custom'">
+                      <button type="button" @click="editCategory(category)">编辑</button>
+                      <button type="button" class="danger-action" @click="removeCategory(category)">
+                        删除
+                      </button>
+                    </template>
+                    <span v-else class="built-in-note">内置</span>
                   </span>
                 </div>
               </template>
@@ -252,7 +330,10 @@ function toggleBuiltInCategories() {
                 class="category-row category-edit-row"
                 @submit.prevent="submitCategory"
               >
-                <span class="category-add-marker">＋</span>
+                <span class="category-drag-handle disabled">
+                  <span class="category-add-marker">＋</span>
+                </span>
+                <span></span>
                 <input
                   v-model="label"
                   class="category-inline-input"
@@ -309,10 +390,10 @@ function toggleBuiltInCategories() {
   gap: 16px;
   position: relative;
   width: 100%;
-  height: 75vh;
-  max-height: 75vh;
+  height: calc(100% - 48px);
+  max-height: calc(100% - 48px);
   box-sizing: border-box;
-  padding: 18px 20px 20px;
+  padding: 18px 4px 0 0;
   overflow: hidden;
   color: #f5f7fa;
   background: #2d2f32;
@@ -371,6 +452,7 @@ function toggleBuiltInCategories() {
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
+  padding: 0 16px 0 20px;
 }
 
 .settings-header h2 {
@@ -423,7 +505,7 @@ function toggleBuiltInCategories() {
   overflow-x: hidden;
   overflow-y: auto;
   scrollbar-gutter: stable;
-  padding-right: 2px;
+  padding: 0 16px 20px 20px;
 }
 
 .settings-section::-webkit-scrollbar-button {
@@ -498,7 +580,7 @@ function toggleBuiltInCategories() {
 .category-list-header,
 .category-row {
   display: grid;
-  grid-template-columns: 46px minmax(82px, 130px) minmax(160px, 1fr) 60px 120px;
+  grid-template-columns: 24px 44px minmax(82px, 130px) minmax(160px, 1fr) 56px 110px;
   gap: 10px;
   align-items: center;
   min-height: 34px;
@@ -512,45 +594,89 @@ function toggleBuiltInCategories() {
   font-size: 12px;
 }
 
-.category-group {
-  display: grid;
-  border-top: 1px solid #3f4246;
-}
-
-.category-group-toggle {
-  display: flex;
+.category-reset-order-btn {
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  min-height: 34px;
-  padding: 0 10px;
-  background: #2b2d30;
-  text-align: left;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #727982;
+  border-radius: 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
-.category-group-arrow {
-  width: 6px;
-  height: 6px;
-  border-right: 1.5px solid currentColor;
-  border-bottom: 1.5px solid currentColor;
-  color: #aeb4bb;
-  transform: rotate(-45deg);
-  transition: transform 0.15s ease;
+.category-reset-order-btn:hover {
+  color: #cbd1d8;
+  background: #3a3d42;
 }
 
-.category-group-toggle[aria-expanded="true"] .category-group-arrow {
-  transform: rotate(45deg);
-}
-
-.category-group-count {
-  margin-left: auto;
-  color: #aeb4bb;
-  font-size: 12px;
+.category-reset-order-btn:focus,
+.category-reset-order-btn:focus-visible {
+  outline: none;
+  color: #cbd1d8;
+  background: #3a3d42;
 }
 
 .category-row {
   border-top: 1px solid #3f4246;
   background: #303234;
   font-size: 13px;
+  transition:
+    background-color 0.15s ease,
+    box-shadow 0.15s ease,
+    opacity 0.15s ease;
+}
+
+.category-row.is-dragging {
+  opacity: 0.35;
+  background: #25272a;
+}
+
+.category-row.drag-over-top {
+  box-shadow: inset 0 2px 0 0 var(--primary-color);
+}
+
+.category-row.drag-over-bottom {
+  box-shadow: inset 0 -2px 0 0 var(--primary-color);
+}
+
+.category-drag-handle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 24px;
+  color: #727982;
+  cursor: grab;
+  border-radius: 4px;
+  user-select: none;
+}
+
+.category-drag-handle:hover {
+  color: #cbd1d8;
+  background: #3a3d42;
+}
+
+.category-drag-handle.disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.category-drag-handle.disabled:hover {
+  color: #727982;
+  background: transparent;
+}
+
+.category-drag-icon {
+  display: block;
+  pointer-events: none;
 }
 
 .category-row.disabled .category-name,
@@ -740,13 +866,19 @@ function toggleBuiltInCategories() {
     background: #eef2f7;
   }
 
-  .category-group {
-    border-top-color: #e4e9f1;
+  .category-reset-order-btn {
+    color: #9aa4b2;
+    background: transparent;
+    border: 0;
   }
 
-  .category-group-toggle {
-    color: #1f2937;
-    background: #f8fafc;
+  .category-reset-order-btn:hover {
+    color: #374151;
+    background: #e5e9f0;
+  }
+
+  .category-row.is-dragging {
+    background: #f1f4f8;
   }
 
   .category-row,
@@ -754,6 +886,20 @@ function toggleBuiltInCategories() {
     color: #1f2937;
     background: #ffffff;
     border-top-color: #e4e9f1;
+  }
+
+  .category-drag-handle {
+    color: #9aa4b2;
+  }
+
+  .category-drag-handle:hover {
+    color: #374151;
+    background: #e5e9f0;
+  }
+
+  .category-drag-handle.disabled:hover {
+    color: #9aa4b2;
+    background: transparent;
   }
 
   .switch-track {

--- a/plugins/local-search-neo/src/Finder/components/SplitResizer.vue
+++ b/plugins/local-search-neo/src/Finder/components/SplitResizer.vue
@@ -1,0 +1,136 @@
+<script setup lang="ts">
+import { onUnmounted, ref } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: number;
+    min?: number;
+    max?: number | (() => number);
+    defaultWidth?: number;
+    title?: string;
+  }>(),
+  {
+    min: 0,
+    max: undefined,
+    defaultWidth: undefined,
+    title: "拖动调整宽度，双击恢复默认",
+  },
+);
+
+const emit = defineEmits<{
+  "update:modelValue": [value: number];
+  change: [value: number];
+  resizingChange: [isResizing: boolean];
+}>();
+
+const isResizing = ref(false);
+
+let startX = 0;
+let startWidth = 0;
+
+function resolveMax(): number {
+  if (typeof props.max === "function") {
+    const computedMax = props.max();
+    return typeof computedMax === "number" && !Number.isNaN(computedMax)
+      ? computedMax
+      : Number.POSITIVE_INFINITY;
+  }
+  return typeof props.max === "number" && !Number.isNaN(props.max)
+    ? props.max
+    : Number.POSITIVE_INFINITY;
+}
+
+function onMouseMove(event: MouseEvent) {
+  if (!isResizing.value) return;
+  const deltaX = event.clientX - startX;
+  const minVal = typeof props.min === "number" && !Number.isNaN(props.min) ? props.min : 0;
+  const maxVal = Math.max(minVal, resolveMax());
+  const targetWidth = Math.min(maxVal, Math.max(minVal, startWidth + deltaX));
+  emit("update:modelValue", targetWidth);
+}
+
+function onMouseUp(event: MouseEvent) {
+  if (!isResizing.value) return;
+  const deltaX = event.clientX - startX;
+  const minVal = typeof props.min === "number" && !Number.isNaN(props.min) ? props.min : 0;
+  const maxVal = Math.max(minVal, resolveMax());
+  const finalWidth = Math.min(maxVal, Math.max(minVal, startWidth + deltaX));
+
+  isResizing.value = false;
+  emit("resizingChange", false);
+  removeListeners();
+  emit("update:modelValue", finalWidth);
+  emit("change", finalWidth);
+}
+
+function removeListeners() {
+  window.removeEventListener("mousemove", onMouseMove);
+  window.removeEventListener("mouseup", onMouseUp);
+}
+
+function onMouseDown(event: MouseEvent) {
+  if (event.button !== 0) return;
+  event.preventDefault();
+
+  removeListeners();
+  isResizing.value = true;
+  emit("resizingChange", true);
+
+  startX = event.clientX;
+  startWidth = props.modelValue;
+
+  window.addEventListener("mousemove", onMouseMove);
+  window.addEventListener("mouseup", onMouseUp);
+}
+
+function onDoubleClick() {
+  if (props.defaultWidth !== undefined) {
+    emit("update:modelValue", props.defaultWidth);
+    emit("change", props.defaultWidth);
+  }
+}
+
+onUnmounted(() => {
+  removeListeners();
+});
+</script>
+
+<template>
+  <div
+    class="finder-split-resizer"
+    :class="{ 'is-resizing': isResizing }"
+    :title="title"
+    @mousedown="onMouseDown"
+    @dblclick="onDoubleClick"
+  >
+    <span class="resizer-line"></span>
+  </div>
+</template>
+
+<style scoped>
+.finder-split-resizer {
+  position: absolute;
+  top: 0;
+  right: -8px;
+  bottom: 0;
+  z-index: 50;
+  width: 8px;
+  cursor: col-resize;
+}
+
+.resizer-line {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: transparent;
+  transition: background-color 0.15s ease;
+  pointer-events: none;
+}
+
+.finder-split-resizer:hover .resizer-line,
+.finder-split-resizer.is-resizing .resizer-line {
+  background: var(--primary-color);
+}
+</style>

--- a/plugins/local-search-neo/src/Finder/composables/useEverything.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useEverything.ts
@@ -34,7 +34,6 @@ export function useEverything({ runSearch }: UseEverythingProps) {
     everythingPending,
     everythingReady,
     ensureEverythingReady,
-    startEverythingStatusPolling,
     stopEverythingStatusPolling,
   };
 }

--- a/plugins/local-search-neo/src/Finder/composables/useFileIcons.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useFileIcons.ts
@@ -3,7 +3,6 @@ import {
   getCachedFileIconUrl,
   getDisplayFileIconUrl,
   getFolderFileIconUrl,
-  getUnknownFileIconUrl,
   loadFileIconUrl,
   shouldLoadFileIcon,
 } from "../core/fileIconCache";
@@ -45,8 +44,6 @@ export function useFileIcons({ visibleResults, isFolderQuery }: UseFileIconsOpti
   });
 
   function iconFor(item: FinderResult) {
-    if (!item.fullPath) return getUnknownFileIconUrl();
-
     const loadedIconUrl = iconUrls.value[item.fullPath];
     if (loadedIconUrl) return loadedIconUrl;
 
@@ -54,7 +51,6 @@ export function useFileIcons({ visibleResults, isFolderQuery }: UseFileIconsOpti
   }
 
   function displayItem(item: FinderResult): FinderResult {
-    if (!item.fullPath) return item;
     if (isFolderQuery()) return { ...item, isDirectory: true };
 
     const fileInfo = fileInfoByPath.value[item.fullPath];
@@ -70,7 +66,7 @@ export function useFileIcons({ visibleResults, isFolderQuery }: UseFileIconsOpti
     }
 
     const queue = items.filter((item) => {
-      if (!item.fullPath || item.isDirectory !== undefined) return false;
+      if (item.isDirectory !== undefined) return false;
       if (hasResultExtension(item)) return false;
       if (loadedFileInfoPaths.has(item.fullPath)) return false;
       return true;
@@ -85,8 +81,6 @@ export function useFileIcons({ visibleResults, isFolderQuery }: UseFileIconsOpti
     const nextFileInfo = { ...fileInfoByPath.value };
 
     for (const item of items) {
-      if (!item.fullPath) continue;
-
       loadedFileInfoPaths.add(item.fullPath);
       loadedIconPaths.add(item.fullPath);
       nextFileInfo[item.fullPath] = { isDirectory: true };
@@ -115,8 +109,6 @@ export function useFileIcons({ visibleResults, isFolderQuery }: UseFileIconsOpti
   }
 
   async function loadFileInfo(item: FinderResult, generation: number) {
-    if (!item.fullPath) return;
-
     const fileInfo = await window.services.getFileInfo(item.fullPath);
     loadedFileInfoPaths.add(item.fullPath);
     if (generation !== fileInfoLoadGeneration) return;
@@ -149,8 +141,6 @@ export function useFileIcons({ visibleResults, isFolderQuery }: UseFileIconsOpti
     const queue: FinderResult[] = [];
 
     for (const item of items) {
-      if (!item.fullPath) continue;
-
       const display = displayItem(item);
       const cachedUrl = getCachedFileIconUrl(display);
       if (cachedUrl) {
@@ -192,8 +182,6 @@ export function useFileIcons({ visibleResults, isFolderQuery }: UseFileIconsOpti
   }
 
   function loadQueuedIcon(item: FinderResult, generation: number) {
-    if (!item.fullPath) return;
-
     const display = displayItem(item);
     const iconUrl = loadFileIconUrl(display);
     loadedIconPaths.add(item.fullPath);
@@ -211,8 +199,8 @@ export function useFileIcons({ visibleResults, isFolderQuery }: UseFileIconsOpti
   };
 }
 
-function hasResultExtension(file: Pick<FinderResult, "name" | "extension" | "fullPath">) {
-  return (file.extension || getExtension(file.name || file.fullPath || "")) !== "";
+function hasResultExtension(file: Pick<FinderResult, "name" | "extension">) {
+  return (file.extension || getExtension(file.name)) !== "";
 }
 
 function getExtension(name: string) {

--- a/plugins/local-search-neo/src/Finder/composables/useFilePreview.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useFilePreview.ts
@@ -1,6 +1,7 @@
 import { ref, watch, type ComputedRef } from "vue";
+import { formatBytes } from "../core/formatters";
+import type { FinderResult } from "../core/finderLogic";
 import {
-  formatBytes,
   getArchiveTreePreviewBlockedReason,
   getCodePreviewLanguage,
   isArchiveTreePreviewCandidate,
@@ -12,8 +13,8 @@ import {
   isPdfPreviewCandidate,
   isTextPreviewCandidate,
   isVideoPreviewCandidate,
-  type FinderResult,
-} from "../core/finderLogic";
+  type PreviewCandidate,
+} from "../core/previewCandidate";
 
 const PREVIEW_BYTES = 20 * 1024;
 const LOG_PREVIEW_BYTES = 10 * 1024;
@@ -50,12 +51,6 @@ export function useFilePreview({ activeItem }: UseFilePreviewOptions) {
     if (!item) {
       resetPreview();
       previewStatus.value = "选择文件后预览";
-      return;
-    }
-
-    if (!item.fullPath) {
-      resetPreview();
-      previewStatus.value = "缺少文件路径，无法预览";
       return;
     }
 
@@ -96,8 +91,6 @@ export function useFilePreview({ activeItem }: UseFilePreviewOptions) {
   }
 
   function loadMediaPreview(item: FinderResult) {
-    if (!item.fullPath) return false;
-
     if (isImagePreviewCandidate(item)) {
       setPreviewState({
         kind: "image",
@@ -134,8 +127,6 @@ export function useFilePreview({ activeItem }: UseFilePreviewOptions) {
   }
 
   function loadDirectoryTreePreview(item: FinderResult) {
-    if (!item.fullPath) return;
-
     try {
       const tree = window.services.printDirectoryTree(item.fullPath);
       setPreviewState({
@@ -151,8 +142,6 @@ export function useFilePreview({ activeItem }: UseFilePreviewOptions) {
   }
 
   function loadArchiveTreePreview(item: FinderResult) {
-    if (!item.fullPath) return false;
-
     const blockedReason = getArchiveTreePreviewBlockedReason(item);
     if (blockedReason) {
       resetPreview();
@@ -179,8 +168,6 @@ export function useFilePreview({ activeItem }: UseFilePreviewOptions) {
   }
 
   function loadTextLikePreview(item: FinderResult) {
-    if (!item.fullPath) return;
-
     const textPreviewKind = getTextPreviewKind(item);
     let shouldPreviewAsText = textPreviewKind !== undefined;
 
@@ -246,9 +233,7 @@ export function useFilePreview({ activeItem }: UseFilePreviewOptions) {
   };
 }
 
-function getTextPreviewKind(
-  item: Pick<FinderResult, "name" | "extension" | "size" | "isDirectory">,
-): PreviewKind | undefined {
+function getTextPreviewKind(item: PreviewCandidate): PreviewKind | undefined {
   if (isMarkdownPreviewCandidate(item)) return "markdown";
   if (isCodePreviewCandidate(item)) return "code";
   if (isTextPreviewCandidate(item)) return "text";

--- a/plugins/local-search-neo/src/Finder/composables/useFinderCategories.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useFinderCategories.ts
@@ -1,9 +1,17 @@
 import { computed, ref, watch } from "vue";
-import { DEFAULT_CATEGORIES, type FinderCategory } from "../core/finderLogic";
+import {
+  DEFAULT_CATEGORIES,
+  type FinderCategory,
+  normalizeCategoryOrder,
+  reorderArray,
+} from "../core/finderLogic";
 import { usePersistStorage } from "./usePersistStorage";
 
 const activeCategoryId = ref("all");
 const {
+  categoryOrder,
+  setCategoryOrder,
+  resetCategoryOrder,
   customCategories,
   addCustomCategory,
   updateCustomCategory,
@@ -12,12 +20,22 @@ const {
   setCategoryEnabled,
 } = usePersistStorage();
 
-const allCategories = computed(() =>
-  [...DEFAULT_CATEGORIES, ...customCategories.value].map((category) => ({
-    ...category,
-    enabled: isCategoryEnabled(category.id),
-  })),
-);
+const allCategories = computed(() => {
+  const allCategoryList = [...DEFAULT_CATEGORIES, ...customCategories.value];
+  const allCategoryMap = new Map(allCategoryList.map((cat) => [cat.id, cat]));
+  const orderedIds = normalizeCategoryOrder(
+    categoryOrder.value,
+    allCategoryList.map((c) => c.id),
+  );
+
+  return orderedIds
+    .map((id) => allCategoryMap.get(id))
+    .filter((category): category is FinderCategory => Boolean(category))
+    .map((category) => ({
+      ...category,
+      enabled: isCategoryEnabled(category.id),
+    }));
+});
 const enabledCategories = computed(() =>
   allCategories.value.filter((category) => category.enabled),
 );
@@ -38,6 +56,8 @@ export function useFinderCategories() {
     allCategories,
     selectCategory,
     resetActiveCategory,
+    handleReorderCategories,
+    handleResetCategoryOrder,
     handleAddCustomCategory,
     handleUpdateCustomCategory,
     handleRemoveCustomCategory,
@@ -51,6 +71,26 @@ function selectCategory(category: FinderCategory) {
 
 function resetActiveCategory() {
   activeCategoryId.value = "all";
+}
+
+function handleReorderCategories(fromIndex: number, toIndex: number) {
+  if (fromIndex === toIndex) return;
+  const currentIds = allCategories.value.map((c) => c.id);
+  const newOrder = reorderArray(currentIds, fromIndex, toIndex);
+  try {
+    setCategoryOrder(newOrder);
+  } catch (error) {
+    console.warn("[local-search-neo] 保存分组顺序失败:", error);
+  }
+}
+
+function handleResetCategoryOrder() {
+  try {
+    const allIds = [...DEFAULT_CATEGORIES, ...customCategories.value].map((c) => c.id);
+    resetCategoryOrder(allIds);
+  } catch (error) {
+    console.warn("[local-search-neo] 重置分组顺序失败:", error);
+  }
 }
 
 function handleAddCustomCategory(input: Pick<FinderCategory, "label" | "rule">) {

--- a/plugins/local-search-neo/src/Finder/composables/useFinderSearch.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useFinderSearch.ts
@@ -46,7 +46,7 @@ export function useFinderSearch({
       return activeItem.value ? [activeItem.value] : [];
     }
     const pathSet = new Set(selectedPaths.value);
-    return results.value.filter((item) => item.fullPath && pathSet.has(item.fullPath));
+    return results.value.filter((item) => pathSet.has(item.fullPath));
   });
 
   let searchTimer: number | undefined;
@@ -162,9 +162,7 @@ export function useFinderSearch({
         activePath.value = targetPath;
       }
     } else if (mode === "range") {
-      const visiblePaths = visibleResults.value
-        .map((r) => r.fullPath)
-        .filter((p): p is string => !!p);
+      const visiblePaths = visibleResults.value.map((r) => r.fullPath);
       const anchor = activePath.value || visiblePaths[0] || targetPath;
       selectedPaths.value = getRangeSelectedPaths(visiblePaths, anchor, targetPath);
     } else {
@@ -192,9 +190,7 @@ export function useFinderSearch({
   }
 
   function moveSelection(direction: -1 | 1) {
-    const paths = results.value
-      .map((item) => item.fullPath)
-      .filter((path): path is string => !!path);
+    const paths = results.value.map((item) => item.fullPath);
     const nextPath = getNextSelectedPath(paths, activePath.value, direction);
     if (!nextPath) return;
 

--- a/plugins/local-search-neo/src/Finder/composables/usePersistStorage.ts
+++ b/plugins/local-search-neo/src/Finder/composables/usePersistStorage.ts
@@ -1,12 +1,19 @@
 import { computed, shallowRef } from "vue";
-import type { FinderCategory, FinderSortMode } from "../core/finderLogic";
+import {
+  DEFAULT_CATEGORY_ORDER,
+  type FinderCategory,
+  type FinderSortMode,
+  normalizeCategoryOrder,
+} from "../core/finderLogic";
 
 interface FinderPreferences {
   previewEnabled: boolean;
   sortMode: FinderSortMode;
   matchPathEnabled: boolean;
   resultListWidth: number;
+  sidebarWidth: number;
   categoryEnabled: Record<string, boolean>;
+  categoryOrder: string[];
 }
 
 const PREFERENCES_STORAGE_KEY = "preferences";
@@ -17,7 +24,9 @@ const DEFAULT_PREFERENCES: FinderPreferences = {
   sortMode: "modified-desc",
   matchPathEnabled: true,
   resultListWidth: 315,
+  sidebarWidth: 64,
   categoryEnabled: {},
+  categoryOrder: [...DEFAULT_CATEGORY_ORDER],
 };
 
 const preferences = shallowRef<FinderPreferences>({ ...DEFAULT_PREFERENCES });
@@ -39,6 +48,11 @@ const resultListWidth = computed({
   get: () => preferences.value.resultListWidth,
   set: setResultListWidth,
 });
+const sidebarWidth = computed({
+  get: () => preferences.value.sidebarWidth,
+  set: setSidebarWidth,
+});
+const categoryOrder = computed(() => preferences.value.categoryOrder);
 
 let loaded = false;
 
@@ -50,6 +64,11 @@ export function usePersistStorage() {
     matchPathEnabled,
     resultListWidth,
     setResultListWidth,
+    sidebarWidth,
+    setSidebarWidth,
+    categoryOrder,
+    setCategoryOrder,
+    resetCategoryOrder,
     customCategories,
     addCustomCategory,
     updateCustomCategory,
@@ -124,10 +143,40 @@ function setMatchPathEnabled(value: boolean) {
   savePreferences();
 }
 
-function setResultListWidth(value: number) {
+function setResultListWidth(value: number, persist = true) {
+  if (typeof value !== "number" || Number.isNaN(value)) return;
   preferences.value = {
     ...preferences.value,
     resultListWidth: Math.round(value),
+  };
+  if (persist) {
+    savePreferences();
+  }
+}
+
+function setSidebarWidth(value: number, persist = true) {
+  if (typeof value !== "number" || Number.isNaN(value)) return;
+  preferences.value = {
+    ...preferences.value,
+    sidebarWidth: Math.round(value),
+  };
+  if (persist) {
+    savePreferences();
+  }
+}
+
+function setCategoryOrder(order: string[]) {
+  preferences.value = {
+    ...preferences.value,
+    categoryOrder: [...order],
+  };
+  savePreferences();
+}
+
+function resetCategoryOrder(allAvailableCategoryIds: string[]) {
+  preferences.value = {
+    ...preferences.value,
+    categoryOrder: normalizeCategoryOrder(DEFAULT_CATEGORY_ORDER, allAvailableCategoryIds),
   };
   savePreferences();
 }
@@ -141,7 +190,15 @@ function addCustomCategory(label: string, rule: string) {
   } satisfies FinderCategory;
 
   customCategories.value = [...customCategories.value, category];
-  setCategoryEnabled(category.id, true);
+  preferences.value = {
+    ...preferences.value,
+    categoryEnabled: {
+      ...preferences.value.categoryEnabled,
+      [category.id]: true,
+    },
+    categoryOrder: [...preferences.value.categoryOrder, category.id],
+  };
+  savePreferences();
   saveCustomCategories();
   return category;
 }
@@ -161,7 +218,13 @@ function updateCustomCategory(id: string, input: Pick<FinderCategory, "label" | 
 
 function removeCustomCategory(category: FinderCategory) {
   customCategories.value = customCategories.value.filter((item) => item.id !== category.id);
-  removeCategoryEnabledState(category.id);
+  const { [category.id]: _removed, ...categoryEnabled } = preferences.value.categoryEnabled;
+  preferences.value = {
+    ...preferences.value,
+    categoryEnabled,
+    categoryOrder: preferences.value.categoryOrder.filter((id) => id !== category.id),
+  };
+  savePreferences();
   saveCustomCategories();
 }
 
@@ -180,16 +243,11 @@ function setCategoryEnabled(categoryId: string, enabled: boolean) {
   savePreferences();
 }
 
-function removeCategoryEnabledState(categoryId: string) {
-  const { [categoryId]: _removed, ...categoryEnabled } = preferences.value.categoryEnabled;
-  preferences.value = {
-    ...preferences.value,
-    categoryEnabled,
-  };
-  savePreferences();
-}
-
 function normalizePreferences(stored: Partial<FinderPreferences>): FinderPreferences {
+  const rawOrder = Array.isArray(stored.categoryOrder)
+    ? stored.categoryOrder.filter((item): item is string => typeof item === "string")
+    : [...DEFAULT_CATEGORY_ORDER];
+
   return {
     previewEnabled: stored.previewEnabled ?? DEFAULT_PREFERENCES.previewEnabled,
     sortMode: stored.sortMode ?? DEFAULT_PREFERENCES.sortMode,
@@ -198,7 +256,12 @@ function normalizePreferences(stored: Partial<FinderPreferences>): FinderPrefere
       typeof stored.resultListWidth === "number" && stored.resultListWidth >= 200
         ? stored.resultListWidth
         : DEFAULT_PREFERENCES.resultListWidth,
+    sidebarWidth:
+      typeof stored.sidebarWidth === "number" && stored.sidebarWidth >= 48
+        ? stored.sidebarWidth
+        : DEFAULT_PREFERENCES.sidebarWidth,
     categoryEnabled: { ...DEFAULT_PREFERENCES.categoryEnabled, ...stored.categoryEnabled },
+    categoryOrder: rawOrder,
   };
 }
 

--- a/plugins/local-search-neo/src/Finder/composables/useResultActions.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useResultActions.ts
@@ -20,58 +20,52 @@ const { confirm } = useGlocalConfirmDialog();
 export function useResultActions({ onTrashed }: UseResultActionsOptions): ResultActions {
   function open(items: FinderResult[]) {
     for (const item of items) {
-      if (item.fullPath) window.ztools.shellOpenPath(item.fullPath);
+      window.ztools.shellOpenPath(item.fullPath);
     }
   }
 
   function showInFolder(items: FinderResult[]) {
     for (const item of items) {
-      if (item.fullPath) window.ztools.shellShowItemInFolder(item.fullPath);
+      window.ztools.shellShowItemInFolder(item.fullPath);
     }
   }
 
   function copyFullPath(items: FinderResult[]) {
-    const paths = items.map((item) => item.fullPath).filter((p): p is string => !!p);
+    const paths = items.map((item) => item.fullPath);
     if (paths.length > 0) window.ztools.copyText(paths.join("\r\n"));
   }
 
   function copyDirectoryPath(items: FinderResult[]) {
-    const directories = Array.from(
-      new Set(items.map((item) => item.path).filter((p): p is string => !!p)),
-    );
+    const directories = Array.from(new Set(items.map((item) => item.path)));
     if (directories.length > 0) window.ztools.copyText(directories.join("\r\n"));
   }
 
   function copyFile(items: FinderResult[]) {
-    const paths = items.map((item) => item.fullPath).filter((p): p is string => !!p);
+    const paths = items.map((item) => item.fullPath);
     if (paths.length > 0) window.ztools.copyFile(paths);
   }
 
   function startDrag(item: FinderResult, selectedPaths: string[]) {
-    if (!item.fullPath) return;
     const target = getDragTargetPaths(item.fullPath, selectedPaths);
     window.ztools.startDrag(target);
   }
 
   async function trash(items: FinderResult[]) {
-    const validItems = items.filter(
-      (item): item is FinderResult & { fullPath: string } => !!item.fullPath,
-    );
-    if (validItems.length === 0) return;
+    if (items.length === 0) return;
 
-    const isSingle = validItems.length === 1;
+    const isSingle = items.length === 1;
     const confirmed = await confirm({
-      title: isSingle ? "删除文件" : `删除 ${validItems.length} 个文件`,
+      title: isSingle ? "删除文件" : `删除 ${items.length} 个文件`,
       message: isSingle
-        ? `确定要将“${validItems[0].name}”移入回收站吗？`
-        : `确定要将选中的 ${validItems.length} 个文件移入回收站吗？`,
+        ? `确定要将“${items[0].name}”移入回收站吗？`
+        : `确定要将选中的 ${items.length} 个文件移入回收站吗？`,
       confirmText: "删除",
       danger: true,
     });
     if (!confirmed) return;
 
     const results = await Promise.allSettled(
-      validItems.map(async (item) => {
+      items.map(async (item) => {
         await window.ztools.shellTrashItem(item.fullPath);
         return item.fullPath;
       }),

--- a/plugins/local-search-neo/src/Finder/core/fileIconCache.ts
+++ b/plugins/local-search-neo/src/Finder/core/fileIconCache.ts
@@ -3,7 +3,6 @@ import type { FinderResult } from "./finderLogic";
 interface IconCacheEntry {
   hash: string;
   url: string;
-  dataUrl?: string;
 }
 
 type IconFile = Pick<FinderResult, "name" | "extension" | "fullPath" | "isDirectory">;
@@ -36,7 +35,7 @@ export function warmUpFileIconCache() {
   loadSharedIcon(FOLDER_CACHE_KEY, WINDOWS_FOLDER_ICON_PATH);
 }
 
-export function getUnknownFileIconUrl(): string {
+function getUnknownFileIconUrl(): string {
   return loadSharedIcon(UNKNOWN_CACHE_KEY, UNKNOWN_FILE_ICON_PATH)?.url ?? "";
 }
 
@@ -59,16 +58,12 @@ export function loadFileIconUrl(file: IconFile): string {
   return getFileIconEntry(file)?.url ?? getUnknownFileIconUrl();
 }
 
-export function getFileIconDataUrl(file: IconFile): string {
-  return getFileIconEntry(file)?.dataUrl ?? getSharedIconDataUrl(UNKNOWN_CACHE_KEY);
-}
-
 export function shouldLoadFileIcon(file: IconFile): boolean {
   if (file.isDirectory) return !sharedIconCache.has(FOLDER_CACHE_KEY);
 
   const extension = getResultExtension(file);
   if (!extension) return false;
-  if (PATH_DEPENDENT_EXTENSIONS.has(extension)) return !!file.fullPath;
+  if (PATH_DEPENDENT_EXTENSIONS.has(extension)) return true;
 
   return !sharedIconCache.has(getExtensionCacheKey(extension));
 }
@@ -80,7 +75,7 @@ function getFileIconEntry(file: IconFile): IconCacheEntry | null {
   if (!extension) return loadSharedIcon(UNKNOWN_CACHE_KEY, UNKNOWN_FILE_ICON_PATH);
 
   if (PATH_DEPENDENT_EXTENSIONS.has(extension)) {
-    return file.fullPath ? readIcon(file.fullPath) : null;
+    return readIcon(file.fullPath);
   }
 
   return loadSharedIcon(getExtensionCacheKey(extension), getExtensionIconPath(extension));
@@ -113,24 +108,19 @@ function loadSharedIcon(cacheKey: string, iconPath: string): IconCacheEntry | nu
   return fallback;
 }
 
-function getSharedIconDataUrl(cacheKey: string): string {
-  return sharedIconCache.get(cacheKey)?.dataUrl ?? "";
-}
-
 function readIcon(fullPath: string): IconCacheEntry | null {
   try {
     const icon = window.ztools.getFileIcon(fullPath);
     if (!icon) return null;
 
     const hash = hashIcon(icon);
-    const dataUrl = icon.startsWith("data:") ? icon : undefined;
     const existedUrl = iconUrlByHash.get(hash);
-    if (existedUrl) return { hash, url: existedUrl, dataUrl };
+    if (existedUrl) return { hash, url: existedUrl };
 
-    const url = dataUrl ? dataUrlToObjectUrl(dataUrl) : icon;
+    const url = icon.startsWith("data:") ? dataUrlToObjectUrl(icon) : icon;
     iconUrlByHash.set(hash, url);
 
-    return { hash, url, dataUrl };
+    return { hash, url };
   } catch {
     return null;
   }
@@ -174,8 +164,8 @@ function hashIcon(icon: string): string {
   return `${icon.length}:${(hash >>> 0).toString(16)}`;
 }
 
-function getResultExtension(file: Pick<FinderResult, "name" | "extension" | "fullPath">): string {
-  return (file.extension || getExtension(file.name || file.fullPath || "")).toLowerCase();
+function getResultExtension(file: Pick<FinderResult, "name" | "extension">): string {
+  return (file.extension || getExtension(file.name)).toLowerCase();
 }
 
 function getExtension(name: string): string {

--- a/plugins/local-search-neo/src/Finder/core/finderLogic.test.ts
+++ b/plugins/local-search-neo/src/Finder/core/finderLogic.test.ts
@@ -2,25 +2,17 @@
 
 import {
   DEFAULT_CATEGORIES,
+  DEFAULT_CATEGORY_ORDER,
   buildEverythingQuery,
   filterResultsExcludingPaths,
-  formatBytes,
-  getArchiveTreePreviewBlockedReason,
-  getCodePreviewLanguage,
   getDragTargetPaths,
   getNextSelectedPath,
   getNextVisibleCount,
   getRangeSelectedPaths,
   getRestoredSelectedPath,
-  isArchiveTreePreviewCandidate,
-  isAudioPreviewCandidate,
-  isCodePreviewCandidate,
-  isImagePreviewCandidate,
-  isMarkdownPreviewCandidate,
-  isPdfPreviewCandidate,
-  isTextPreviewCandidate,
-  isVideoPreviewCandidate,
   mergeResultsByMatchPathPriority,
+  normalizeCategoryOrder,
+  reorderArray,
   type FinderCategory,
   type FinderResult,
 } from "./finderLogic";
@@ -33,6 +25,9 @@ const sampleResults: FinderResult[] = [
     name: "b.txt",
     path: "C:\\beta",
     fullPath: "C:\\beta\\b.txt",
+    highlightedName: "b.txt",
+    highlightedPath: "C:\\beta",
+    extension: "txt",
     size: 10,
     modifiedAt: 200,
   },
@@ -40,6 +35,9 @@ const sampleResults: FinderResult[] = [
     name: "a.log",
     path: "C:\\alpha",
     fullPath: "C:\\alpha\\a.log",
+    highlightedName: "a.log",
+    highlightedPath: "C:\\alpha",
+    extension: "log",
     size: 30,
     modifiedAt: 100,
   },
@@ -47,7 +45,11 @@ const sampleResults: FinderResult[] = [
     name: "folder",
     path: "C:\\alpha",
     fullPath: "C:\\alpha\\folder",
+    highlightedName: "folder",
+    highlightedPath: "C:\\alpha",
+    extension: "",
     isDirectory: true,
+    size: 0,
     modifiedAt: 300,
   },
 ];
@@ -93,7 +95,7 @@ test("getNextVisibleCount grows by page size without exceeding total", () => {
 });
 
 test("getNextSelectedPath moves selection with arrow keys", () => {
-  const orderedPaths = sampleResults.map((item) => item.fullPath as string);
+  const orderedPaths = sampleResults.map((item) => item.fullPath);
 
   assert.equal(getNextSelectedPath(orderedPaths, "", 1), "C:\\beta\\b.txt");
   assert.equal(getNextSelectedPath(orderedPaths, "C:\\beta\\b.txt", 1), "C:\\alpha\\a.log");
@@ -111,14 +113,68 @@ test("getRestoredSelectedPath keeps existing visible selection or picks sorted f
 
 test("mergeResultsByMatchPathPriority keeps name matches first and removes duplicates", () => {
   const nameResults: FinderResult[] = [
-    { name: "name-a.txt", path: "C:\\demo", fullPath: "C:\\demo\\name-a.txt" },
-    { name: "shared.txt", path: "C:\\demo", fullPath: "C:\\demo\\shared.txt" },
-    { name: "name-b.txt", path: "D:\\demo", fullPath: "D:\\demo\\name-b.txt" },
+    {
+      name: "name-a.txt",
+      path: "C:\\demo",
+      fullPath: "C:\\demo\\name-a.txt",
+      highlightedName: "name-a.txt",
+      highlightedPath: "C:\\demo",
+      extension: "txt",
+      size: 100,
+      modifiedAt: 1,
+    },
+    {
+      name: "shared.txt",
+      path: "C:\\demo",
+      fullPath: "C:\\demo\\shared.txt",
+      highlightedName: "shared.txt",
+      highlightedPath: "C:\\demo",
+      extension: "txt",
+      size: 100,
+      modifiedAt: 1,
+    },
+    {
+      name: "name-b.txt",
+      path: "D:\\demo",
+      fullPath: "D:\\demo\\name-b.txt",
+      highlightedName: "name-b.txt",
+      highlightedPath: "D:\\demo",
+      extension: "txt",
+      size: 100,
+      modifiedAt: 1,
+    },
   ];
   const matchPathResults: FinderResult[] = [
-    { name: "shared.txt", path: "C:\\demo", fullPath: "c:\\demo\\shared.txt" },
-    { name: "path-a.txt", path: "C:\\demo", fullPath: "C:\\demo\\path-a.txt" },
-    { name: "path-b.txt", path: "D:\\demo", fullPath: "D:\\demo\\path-b.txt" },
+    {
+      name: "shared.txt",
+      path: "C:\\demo",
+      fullPath: "c:\\demo\\shared.txt",
+      highlightedName: "shared.txt",
+      highlightedPath: "C:\\demo",
+      extension: "txt",
+      size: 100,
+      modifiedAt: 1,
+    },
+    {
+      name: "path-a.txt",
+      path: "C:\\demo",
+      fullPath: "C:\\demo\\path-a.txt",
+      highlightedName: "path-a.txt",
+      highlightedPath: "C:\\demo",
+      extension: "txt",
+      size: 100,
+      modifiedAt: 1,
+    },
+    {
+      name: "path-b.txt",
+      path: "D:\\demo",
+      fullPath: "D:\\demo\\path-b.txt",
+      highlightedName: "path-b.txt",
+      highlightedPath: "D:\\demo",
+      extension: "txt",
+      size: 100,
+      modifiedAt: 1,
+    },
   ];
 
   assert.deepEqual(
@@ -131,87 +187,6 @@ test("mergeResultsByMatchPathPriority keeps name matches first and removes dupli
       "D:\\demo\\path-b.txt",
     ],
   );
-});
-
-test("preview candidate helpers detect supported file types", () => {
-  assert.equal(isTextPreviewCandidate({ name: "main.log", size: 1024 }), true);
-  assert.equal(isTextPreviewCandidate({ name: "notes.md", size: 1024 }), true);
-  assert.equal(isTextPreviewCandidate({ name: "image.png", size: 1024 }), false);
-  assert.equal(isTextPreviewCandidate({ name: "big.txt", size: 30 * 1024 * 1024 }), false);
-  assert.equal(isTextPreviewCandidate({ name: "folder", isDirectory: true }), false);
-
-  assert.equal(isImagePreviewCandidate({ name: "photo.webp" }), true);
-  assert.equal(isImagePreviewCandidate({ name: "movie.mp4" }), false);
-  assert.equal(isImagePreviewCandidate({ name: "Pictures", isDirectory: true }), false);
-
-  assert.equal(isVideoPreviewCandidate({ name: "movie.mp4" }), true);
-  assert.equal(isVideoPreviewCandidate({ name: "clip.webm" }), true);
-  assert.equal(isVideoPreviewCandidate({ name: "sound.ogg" }), false);
-  assert.equal(isVideoPreviewCandidate({ name: "photo.jpg" }), false);
-  assert.equal(isVideoPreviewCandidate({ name: "Videos", isDirectory: true }), false);
-
-  assert.equal(isAudioPreviewCandidate({ name: "sound.mp3" }), true);
-  assert.equal(isAudioPreviewCandidate({ name: "voice.ogg" }), true);
-  assert.equal(isAudioPreviewCandidate({ name: "track.flac" }), true);
-  assert.equal(isAudioPreviewCandidate({ name: "movie.mp4" }), false);
-  assert.equal(isAudioPreviewCandidate({ name: "Music", isDirectory: true }), false);
-
-  assert.equal(isPdfPreviewCandidate({ name: "document.pdf" }), true);
-  assert.equal(isPdfPreviewCandidate({ name: "PDFs", isDirectory: true }), false);
-
-  assert.equal(isArchiveTreePreviewCandidate({ name: "archive.zip" }), true);
-  assert.equal(isArchiveTreePreviewCandidate({ name: "source.tar" }), true);
-  assert.equal(isArchiveTreePreviewCandidate({ name: "source.tar.gz" }), true);
-  assert.equal(isArchiveTreePreviewCandidate({ name: "source.tgz" }), true);
-  assert.equal(
-    isArchiveTreePreviewCandidate({ name: "source.tar", size: 100 * 1024 * 1024 }),
-    true,
-  );
-  assert.equal(
-    isArchiveTreePreviewCandidate({ name: "source.tar", size: 100 * 1024 * 1024 + 1 }),
-    false,
-  );
-  assert.equal(
-    getArchiveTreePreviewBlockedReason({ name: "source.tar", size: 100 * 1024 * 1024 + 1 }),
-    "压缩包超过 100 MB，不提供预览",
-  );
-  assert.equal(
-    isArchiveTreePreviewCandidate({ name: "source.tar.gz", size: 100 * 1024 * 1024 + 1 }),
-    false,
-  );
-  assert.equal(
-    isArchiveTreePreviewCandidate({ name: "source.tgz", size: 100 * 1024 * 1024 + 1 }),
-    false,
-  );
-  assert.equal(
-    isArchiveTreePreviewCandidate({ name: "single-file.gz", size: 100 * 1024 * 1024 + 1 }),
-    true,
-  );
-  assert.equal(
-    getArchiveTreePreviewBlockedReason({
-      name: "single-file.gz",
-      size: 100 * 1024 * 1024 + 1,
-    }),
-    undefined,
-  );
-  assert.equal(isArchiveTreePreviewCandidate({ name: "archive.rar" }), false);
-  assert.equal(isArchiveTreePreviewCandidate({ name: "Archives", isDirectory: true }), false);
-
-  assert.equal(isMarkdownPreviewCandidate({ name: "README.md" }), true);
-  assert.equal(isMarkdownPreviewCandidate({ name: "notes.markdown" }), true);
-  assert.equal(isMarkdownPreviewCandidate({ name: "script.ts" }), false);
-
-  assert.equal(isCodePreviewCandidate({ name: "script.ts" }), true);
-  assert.equal(isCodePreviewCandidate({ name: "Component.vue" }), true);
-  assert.equal(isCodePreviewCandidate({ name: "README.md" }), false);
-  assert.equal(getCodePreviewLanguage({ name: "script.ts" }), "typescript");
-});
-
-test("formatBytes returns compact human-readable values", () => {
-  assert.equal(formatBytes(undefined), "");
-  assert.equal(formatBytes(512), "512 B");
-  assert.equal(formatBytes(1536), "1.5 KB");
-  assert.equal(formatBytes(5 * 1024 * 1024), "5 MB");
 });
 
 test("getRangeSelectedPaths calculates slice of items between anchor and target", () => {
@@ -258,4 +233,35 @@ test("filterResultsExcludingPaths removes specified paths and preserves others",
   ]);
   assert.deepEqual(filterResultsExcludingPaths(items, ["C:\\missing.txt"]), items);
   assert.deepEqual(filterResultsExcludingPaths(items, []), items);
+});
+
+test("normalizeCategoryOrder retains valid IDs, deduplicates, and appends missing IDs", () => {
+  const allIds = ["all", "folder", "excel", "custom-1", "custom-2"];
+  // Valid partial stored order with deleted ID and duplicates
+  const stored = ["custom-2", "folder", "custom-2", "deleted-id", "all"];
+  const result = normalizeCategoryOrder(stored, allIds);
+
+  assert.deepEqual(result, ["custom-2", "folder", "all", "excel", "custom-1"]);
+
+  // Undefined stored order falls back to natural order
+  assert.deepEqual(normalizeCategoryOrder(undefined, allIds), allIds);
+  assert.deepEqual(normalizeCategoryOrder([], allIds), allIds);
+  assert.deepEqual(
+    normalizeCategoryOrder(DEFAULT_CATEGORY_ORDER, DEFAULT_CATEGORY_ORDER),
+    DEFAULT_CATEGORY_ORDER,
+  );
+});
+
+test("reorderArray moves items correctly within bounds and handles invalid indices", () => {
+  const list = ["A", "B", "C", "D"];
+
+  // Move forward: 0 -> 2
+  assert.deepEqual(reorderArray(list, 0, 2), ["B", "C", "A", "D"]);
+  // Move backward: 3 -> 1
+  assert.deepEqual(reorderArray(list, 3, 1), ["A", "D", "B", "C"]);
+  // Same index
+  assert.deepEqual(reorderArray(list, 1, 1), ["A", "B", "C", "D"]);
+  // Out of bounds
+  assert.deepEqual(reorderArray(list, -1, 2), ["A", "B", "C", "D"]);
+  assert.deepEqual(reorderArray(list, 1, 10), ["A", "B", "C", "D"]);
 });

--- a/plugins/local-search-neo/src/Finder/core/finderLogic.ts
+++ b/plugins/local-search-neo/src/Finder/core/finderLogic.ts
@@ -12,13 +12,13 @@ export interface FinderCategory {
 
 export interface FinderResult {
   name: string;
-  path?: string;
-  fullPath?: string;
-  highlightedName?: string;
-  highlightedPath?: string;
-  extension?: string;
-  size?: number;
-  modifiedAt?: number;
+  path: string;
+  fullPath: string;
+  highlightedName: string;
+  highlightedPath: string;
+  extension: string;
+  size: number;
+  modifiedAt: number;
   isDirectory?: boolean;
 }
 
@@ -45,96 +45,50 @@ export const DEFAULT_CATEGORIES: FinderCategory[] = [
   { id: "archive", label: "压缩文件", kind: "extension", rule: "ext:zip;rar;7z;tar;gz;iso" },
 ];
 
-const IMAGE_PREVIEW_EXTENSIONS = new Set([
-  "jpg",
-  "jpeg",
-  "png",
-  "gif",
-  "webp",
-  "bmp",
-  "svg",
-  "ico",
-]);
+export const DEFAULT_CATEGORY_ORDER: string[] = DEFAULT_CATEGORIES.map((c) => c.id);
 
-const VIDEO_PREVIEW_EXTENSIONS = new Set(["mp4", "webm", "ogv", "mov", "m4v", "mkv", "avi"]);
+export function normalizeCategoryOrder(
+  storedOrder: string[] | undefined,
+  allCategoryIds: string[],
+): string[] {
+  const validIdSet = new Set(allCategoryIds);
+  const result: string[] = [];
+  const seen = new Set<string>();
 
-const AUDIO_PREVIEW_EXTENSIONS = new Set(["mp3", "wav", "flac", "aac", "ogg", "m4a", "opus"]);
+  if (Array.isArray(storedOrder)) {
+    for (const id of storedOrder) {
+      if (typeof id === "string" && validIdSet.has(id) && !seen.has(id)) {
+        seen.add(id);
+        result.push(id);
+      }
+    }
+  }
 
-const PDF_PREVIEW_EXTENSIONS = new Set(["pdf"]);
+  for (const id of allCategoryIds) {
+    if (!seen.has(id)) {
+      seen.add(id);
+      result.push(id);
+    }
+  }
 
-const ARCHIVE_TREE_PREVIEW_EXTENSIONS = new Set(["zip", "tar", "tgz", "gz"]);
+  return result;
+}
 
-const MARKDOWN_PREVIEW_EXTENSIONS = new Set(["md", "markdown", "mdown"]);
-
-const CODE_PREVIEW_LANGUAGE_BY_EXTENSION: Record<string, string> = {
-  bat: "bat",
-  c: "c",
-  cmd: "bat",
-  conf: "properties",
-  cpp: "cpp",
-  cs: "csharp",
-  css: "css",
-  go: "go",
-  h: "c",
-  html: "html",
-  ini: "ini",
-  java: "java",
-  js: "javascript",
-  json: "json",
-  jsx: "jsx",
-  ps1: "powershell",
-  py: "python",
-  rs: "rust",
-  sh: "bash",
-  sql: "sql",
-  toml: "toml",
-  ts: "typescript",
-  tsx: "tsx",
-  vue: "vue",
-  xml: "xml",
-  yaml: "yaml",
-  yml: "yaml",
-};
-
-const LOG_PREVIEW_EXTENSIONS = new Set(["log"]);
-
-const TEXT_PREVIEW_EXTENSIONS = new Set([
-  "bat",
-  "c",
-  "cmd",
-  "conf",
-  "cpp",
-  "cs",
-  "css",
-  "csv",
-  "go",
-  "h",
-  "html",
-  "ini",
-  "java",
-  "js",
-  "json",
-  "jsx",
-  "log",
-  "md",
-  "ps1",
-  "py",
-  "rs",
-  "sh",
-  "sql",
-  "text",
-  "toml",
-  "ts",
-  "tsx",
-  "txt",
-  "vue",
-  "xml",
-  "yaml",
-  "yml",
-]);
-
-const MAX_TEXT_PREVIEW_FILE_SIZE = 20 * 1024 * 1024;
-const MAX_TAR_ARCHIVE_TREE_PREVIEW_FILE_SIZE = 100 * 1024 * 1024;
+export function reorderArray<T>(list: T[], fromIndex: number, toIndex: number): T[] {
+  if (
+    fromIndex < 0 ||
+    fromIndex >= list.length ||
+    toIndex < 0 ||
+    toIndex >= list.length ||
+    fromIndex === toIndex
+  ) {
+    return [...list];
+  }
+  const result = [...list];
+  const [removed] = result.splice(fromIndex, 1);
+  result.splice(toIndex, 0, removed);
+  return result;
+}
 
 export function buildEverythingQuery(keyword: string, category: FinderCategory): string {
   const trimmedKeyword = keyword.trim();
@@ -167,7 +121,7 @@ export function getRestoredSelectedPath(results: FinderResult[], currentPath: st
   const exists = results.some((item) => item.fullPath === currentPath);
   if (exists) return currentPath;
 
-  return results[0]?.fullPath ?? "";
+  return results[0].fullPath;
 }
 
 export function getRangeSelectedPaths(
@@ -194,7 +148,7 @@ export function filterResultsExcludingPaths<T extends Pick<FinderResult, "fullPa
 ): T[] {
   if (pathsToRemove.length === 0) return results;
   const toRemove = new Set(pathsToRemove);
-  return results.filter((item) => !item.fullPath || !toRemove.has(item.fullPath));
+  return results.filter((item) => !toRemove.has(item.fullPath));
 }
 
 export function getDragTargetPaths(
@@ -208,9 +162,10 @@ export function getDragTargetPaths(
   return itemPath;
 }
 
-export function mergeResultsByMatchPathPriority<
-  T extends Pick<FinderResult, "name" | "path" | "fullPath">,
->(nameResults: T[], matchPathResults: T[]): T[] {
+export function mergeResultsByMatchPathPriority<T extends Pick<FinderResult, "fullPath">>(
+  nameResults: T[],
+  matchPathResults: T[],
+): T[] {
   const seen = new Set<string>();
   const merged: T[] = [];
 
@@ -225,105 +180,8 @@ export function mergeResultsByMatchPathPriority<
   return merged;
 }
 
-export function isImagePreviewCandidate(
-  file: Pick<FinderResult, "name" | "extension" | "isDirectory">,
-): boolean {
-  if (file.isDirectory) return false;
-  return IMAGE_PREVIEW_EXTENSIONS.has(getResultExtension(file));
-}
-
-export function isVideoPreviewCandidate(
-  file: Pick<FinderResult, "name" | "extension" | "isDirectory">,
-): boolean {
-  if (file.isDirectory) return false;
-  return VIDEO_PREVIEW_EXTENSIONS.has(getResultExtension(file));
-}
-
-export function isAudioPreviewCandidate(
-  file: Pick<FinderResult, "name" | "extension" | "isDirectory">,
-): boolean {
-  if (file.isDirectory) return false;
-  return AUDIO_PREVIEW_EXTENSIONS.has(getResultExtension(file));
-}
-
-export function isPdfPreviewCandidate(
-  file: Pick<FinderResult, "name" | "extension" | "isDirectory">,
-): boolean {
-  if (file.isDirectory) return false;
-  return PDF_PREVIEW_EXTENSIONS.has(getResultExtension(file));
-}
-
-export function isArchiveTreePreviewCandidate(
-  file: Pick<FinderResult, "name" | "extension" | "size" | "isDirectory">,
-): boolean {
-  if (file.isDirectory) return false;
-  return isArchiveTreePreviewSupported(file) && !getArchiveTreePreviewBlockedReason(file);
-}
-
-export function getArchiveTreePreviewBlockedReason(
-  file: Pick<FinderResult, "name" | "extension" | "size" | "isDirectory">,
-): string | undefined {
-  if (file.isDirectory || !isArchiveTreePreviewSupported(file)) return undefined;
-  if (isTarArchive(file) && (file.size ?? 0) > MAX_TAR_ARCHIVE_TREE_PREVIEW_FILE_SIZE) {
-    return `压缩包超过 ${formatBytes(MAX_TAR_ARCHIVE_TREE_PREVIEW_FILE_SIZE)}，不提供预览`;
-  }
-  return undefined;
-}
-
-export function isMarkdownPreviewCandidate(
-  file: Pick<FinderResult, "name" | "extension" | "isDirectory">,
-): boolean {
-  if (file.isDirectory) return false;
-  return MARKDOWN_PREVIEW_EXTENSIONS.has(getResultExtension(file));
-}
-
-export function getCodePreviewLanguage(
-  file: Pick<FinderResult, "name" | "extension" | "isDirectory">,
-): string | undefined {
-  if (file.isDirectory) return undefined;
-  return CODE_PREVIEW_LANGUAGE_BY_EXTENSION[getResultExtension(file)];
-}
-
-export function isCodePreviewCandidate(
-  file: Pick<FinderResult, "name" | "extension" | "isDirectory">,
-): boolean {
-  return getCodePreviewLanguage(file) !== undefined;
-}
-
-export function isLogPreviewCandidate(
-  file: Pick<FinderResult, "name" | "extension" | "isDirectory">,
-): boolean {
-  if (file.isDirectory) return false;
-  return LOG_PREVIEW_EXTENSIONS.has(getResultExtension(file));
-}
-
-export function isTextPreviewCandidate(
-  file: Pick<FinderResult, "name" | "extension" | "size" | "isDirectory">,
-): boolean {
-  if (file.isDirectory) return false;
-  if ((file.size ?? 0) > MAX_TEXT_PREVIEW_FILE_SIZE) return false;
-
-  return TEXT_PREVIEW_EXTENSIONS.has(getResultExtension(file));
-}
-
-export function formatBytes(bytes?: number): string {
-  if (bytes === undefined || Number.isNaN(bytes)) return "";
-  if (bytes < 1024) return `${bytes} B`;
-
-  const units = ["KB", "MB", "GB", "TB"];
-  let value = bytes / 1024;
-  let unitIndex = 0;
-
-  while (value >= 1024 && unitIndex < units.length - 1) {
-    value /= 1024;
-    unitIndex += 1;
-  }
-
-  return `${formatNumber(value)} ${units[unitIndex]}`;
-}
-
-function getResultDedupeKey(item: Pick<FinderResult, "name" | "path" | "fullPath">): string {
-  return (item.fullPath || `${item.path ?? ""}\\${item.name}`).toLowerCase();
+function getResultDedupeKey(item: Pick<FinderResult, "fullPath">): string {
+  return item.fullPath.toLowerCase();
 }
 
 function normalizeCategoryRule(rule: string): string {
@@ -337,28 +195,4 @@ function normalizeCategoryRule(rule: string): string {
     .filter(Boolean);
 
   return extensions.length > 0 ? `ext:${extensions.join(";")}` : "";
-}
-
-function isArchiveTreePreviewSupported(file: Pick<FinderResult, "name" | "extension">): boolean {
-  const ext = getResultExtension(file);
-  return ARCHIVE_TREE_PREVIEW_EXTENSIONS.has(ext) || file.name.toLowerCase().endsWith(".tar.gz");
-}
-
-function isTarArchive(file: Pick<FinderResult, "name" | "extension">): boolean {
-  const ext = getResultExtension(file);
-  const normalizedName = file.name.toLowerCase();
-  return ext === "tar" || ext === "tgz" || normalizedName.endsWith(".tar.gz");
-}
-
-function getResultExtension(file: Pick<FinderResult, "name" | "extension">): string {
-  return (file.extension || getExtension(file.name)).toLowerCase();
-}
-
-function getExtension(name: string): string {
-  const index = name.lastIndexOf(".");
-  return index >= 0 ? name.slice(index + 1).toLowerCase() : "";
-}
-
-function formatNumber(value: number): string {
-  return Number.isInteger(value) ? value.toString() : value.toFixed(1);
 }

--- a/plugins/local-search-neo/src/Finder/core/formatters.ts
+++ b/plugins/local-search-neo/src/Finder/core/formatters.ts
@@ -1,0 +1,31 @@
+/**
+ * 格式化文件字节大小为人类易读的字符串（如：0 B、512 B、1.5 KB、20 MB 等）
+ *
+ * @param bytes - 文件大小字节数
+ * @returns 带有最适合单位（B, KB, MB, GB, TB）的人类可读字符串
+ */
+export function formatBytes(bytes: number): string {
+  if (Number.isNaN(bytes) || bytes <= 0) return "0 B";
+  if (bytes < 1024) return `${bytes} B`;
+
+  const units = ["KB", "MB", "GB", "TB"];
+  let value = bytes / 1024;
+  let unitIndex = 0;
+
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+
+  return `${formatNumber(value)} ${units[unitIndex]}`;
+}
+
+/**
+ * 格式化数值输出，整数保留整数字符串，小数则固定保留一位小数
+ *
+ * @param value - 待格式化的数字
+ * @returns 格式化后的数字字符串
+ */
+export function formatNumber(value: number): string {
+  return Number.isInteger(value) ? value.toString() : value.toFixed(1);
+}

--- a/plugins/local-search-neo/src/Finder/core/previewCandidate.test.ts
+++ b/plugins/local-search-neo/src/Finder/core/previewCandidate.test.ts
@@ -1,0 +1,101 @@
+/// <reference types="node" />
+
+import { formatBytes } from "./formatters";
+import {
+  getArchiveTreePreviewBlockedReason,
+  getCodePreviewLanguage,
+  isArchiveTreePreviewCandidate,
+  isAudioPreviewCandidate,
+  isCodePreviewCandidate,
+  isImagePreviewCandidate,
+  isMarkdownPreviewCandidate,
+  isPdfPreviewCandidate,
+  isTextPreviewCandidate,
+  isVideoPreviewCandidate,
+} from "./previewCandidate";
+
+declare const test: (name: string, fn: () => void) => void;
+declare const assert: typeof import("node:assert/strict");
+
+test("preview candidate helpers detect supported file types", () => {
+  assert.equal(isTextPreviewCandidate({ name: "main.log", size: 1024 }), true);
+  assert.equal(isTextPreviewCandidate({ name: "notes.md", size: 1024 }), true);
+  assert.equal(isTextPreviewCandidate({ name: "image.png", size: 1024 }), false);
+  assert.equal(isTextPreviewCandidate({ name: "big.txt", size: 30 * 1024 * 1024 }), false);
+  assert.equal(isTextPreviewCandidate({ name: "folder", isDirectory: true }), false);
+
+  assert.equal(isImagePreviewCandidate({ name: "photo.webp" }), true);
+  assert.equal(isImagePreviewCandidate({ name: "movie.mp4" }), false);
+  assert.equal(isImagePreviewCandidate({ name: "Pictures", isDirectory: true }), false);
+
+  assert.equal(isVideoPreviewCandidate({ name: "movie.mp4" }), true);
+  assert.equal(isVideoPreviewCandidate({ name: "clip.webm" }), true);
+  assert.equal(isVideoPreviewCandidate({ name: "sound.ogg" }), false);
+  assert.equal(isVideoPreviewCandidate({ name: "photo.jpg" }), false);
+  assert.equal(isVideoPreviewCandidate({ name: "Videos", isDirectory: true }), false);
+
+  assert.equal(isAudioPreviewCandidate({ name: "sound.mp3" }), true);
+  assert.equal(isAudioPreviewCandidate({ name: "voice.ogg" }), true);
+  assert.equal(isAudioPreviewCandidate({ name: "track.flac" }), true);
+  assert.equal(isAudioPreviewCandidate({ name: "movie.mp4" }), false);
+  assert.equal(isAudioPreviewCandidate({ name: "Music", isDirectory: true }), false);
+
+  assert.equal(isPdfPreviewCandidate({ name: "document.pdf" }), true);
+  assert.equal(isPdfPreviewCandidate({ name: "PDFs", isDirectory: true }), false);
+
+  assert.equal(isArchiveTreePreviewCandidate({ name: "archive.zip" }), true);
+  assert.equal(isArchiveTreePreviewCandidate({ name: "source.tar" }), true);
+  assert.equal(isArchiveTreePreviewCandidate({ name: "source.tar.gz" }), true);
+  assert.equal(isArchiveTreePreviewCandidate({ name: "source.tgz" }), true);
+  assert.equal(
+    isArchiveTreePreviewCandidate({ name: "source.tar", size: 100 * 1024 * 1024 }),
+    true,
+  );
+  assert.equal(
+    isArchiveTreePreviewCandidate({ name: "source.tar", size: 100 * 1024 * 1024 + 1 }),
+    false,
+  );
+  assert.equal(
+    getArchiveTreePreviewBlockedReason({ name: "source.tar", size: 100 * 1024 * 1024 + 1 }),
+    "压缩包超过 100 MB，不提供预览",
+  );
+  assert.equal(
+    isArchiveTreePreviewCandidate({ name: "source.tar.gz", size: 100 * 1024 * 1024 + 1 }),
+    false,
+  );
+  assert.equal(
+    isArchiveTreePreviewCandidate({ name: "source.tgz", size: 100 * 1024 * 1024 + 1 }),
+    false,
+  );
+  assert.equal(
+    isArchiveTreePreviewCandidate({ name: "single-file.gz", size: 100 * 1024 * 1024 + 1 }),
+    true,
+  );
+  assert.equal(
+    getArchiveTreePreviewBlockedReason({
+      name: "single-file.gz",
+      size: 100 * 1024 * 1024 + 1,
+    }),
+    undefined,
+  );
+  assert.equal(isArchiveTreePreviewCandidate({ name: "archive.rar" }), false);
+  assert.equal(isArchiveTreePreviewCandidate({ name: "Archives", isDirectory: true }), false);
+
+  assert.equal(isMarkdownPreviewCandidate({ name: "README.md" }), true);
+  assert.equal(isMarkdownPreviewCandidate({ name: "notes.markdown" }), true);
+  assert.equal(isMarkdownPreviewCandidate({ name: "script.ts" }), false);
+
+  assert.equal(isCodePreviewCandidate({ name: "script.ts" }), true);
+  assert.equal(isCodePreviewCandidate({ name: "Component.vue" }), true);
+  assert.equal(isCodePreviewCandidate({ name: "README.md" }), false);
+  assert.equal(getCodePreviewLanguage({ name: "script.ts" }), "typescript");
+});
+
+test("formatBytes returns compact human-readable values", () => {
+  assert.equal(formatBytes(0), "0 B");
+  assert.equal(formatBytes(-10), "0 B");
+  assert.equal(formatBytes(Number.NaN), "0 B");
+  assert.equal(formatBytes(512), "512 B");
+  assert.equal(formatBytes(1536), "1.5 KB");
+  assert.equal(formatBytes(5 * 1024 * 1024), "5 MB");
+});

--- a/plugins/local-search-neo/src/Finder/core/previewCandidate.ts
+++ b/plugins/local-search-neo/src/Finder/core/previewCandidate.ts
@@ -1,0 +1,178 @@
+import { formatBytes } from "./formatters";
+
+export interface PreviewCandidate {
+  name: string;
+  extension?: string;
+  size?: number;
+  isDirectory?: boolean;
+}
+
+const IMAGE_PREVIEW_EXTENSIONS = new Set([
+  "jpg",
+  "jpeg",
+  "png",
+  "gif",
+  "webp",
+  "bmp",
+  "svg",
+  "ico",
+]);
+
+const VIDEO_PREVIEW_EXTENSIONS = new Set(["mp4", "webm", "ogv", "mov", "m4v", "mkv", "avi"]);
+
+const AUDIO_PREVIEW_EXTENSIONS = new Set(["mp3", "wav", "flac", "aac", "ogg", "m4a", "opus"]);
+
+const PDF_PREVIEW_EXTENSIONS = new Set(["pdf"]);
+
+const ARCHIVE_TREE_PREVIEW_EXTENSIONS = new Set(["zip", "tar", "tgz", "gz"]);
+
+const MARKDOWN_PREVIEW_EXTENSIONS = new Set(["md", "markdown", "mdown"]);
+
+const CODE_PREVIEW_LANGUAGE_BY_EXTENSION: Record<string, string> = {
+  bat: "bat",
+  c: "c",
+  cmd: "bat",
+  conf: "properties",
+  cpp: "cpp",
+  cs: "csharp",
+  css: "css",
+  go: "go",
+  h: "c",
+  html: "html",
+  ini: "ini",
+  java: "java",
+  js: "javascript",
+  json: "json",
+  jsx: "jsx",
+  ps1: "powershell",
+  py: "python",
+  rs: "rust",
+  sh: "bash",
+  sql: "sql",
+  toml: "toml",
+  ts: "typescript",
+  tsx: "tsx",
+  vue: "vue",
+  xml: "xml",
+  yaml: "yaml",
+  yml: "yaml",
+};
+
+const LOG_PREVIEW_EXTENSIONS = new Set(["log"]);
+
+const TEXT_PREVIEW_EXTENSIONS = new Set([
+  "bat",
+  "c",
+  "cmd",
+  "conf",
+  "cpp",
+  "cs",
+  "css",
+  "csv",
+  "go",
+  "h",
+  "html",
+  "ini",
+  "java",
+  "js",
+  "json",
+  "jsx",
+  "log",
+  "md",
+  "ps1",
+  "py",
+  "rs",
+  "sh",
+  "sql",
+  "text",
+  "toml",
+  "ts",
+  "tsx",
+  "txt",
+  "vue",
+  "xml",
+  "yaml",
+  "yml",
+]);
+
+const MAX_TEXT_PREVIEW_FILE_SIZE = 20 * 1024 * 1024;
+const MAX_TAR_ARCHIVE_TREE_PREVIEW_FILE_SIZE = 100 * 1024 * 1024;
+
+export function isImagePreviewCandidate(file: PreviewCandidate): boolean {
+  if (file.isDirectory) return false;
+  return IMAGE_PREVIEW_EXTENSIONS.has(getResultExtension(file));
+}
+
+export function isVideoPreviewCandidate(file: PreviewCandidate): boolean {
+  if (file.isDirectory) return false;
+  return VIDEO_PREVIEW_EXTENSIONS.has(getResultExtension(file));
+}
+
+export function isAudioPreviewCandidate(file: PreviewCandidate): boolean {
+  if (file.isDirectory) return false;
+  return AUDIO_PREVIEW_EXTENSIONS.has(getResultExtension(file));
+}
+
+export function isPdfPreviewCandidate(file: PreviewCandidate): boolean {
+  if (file.isDirectory) return false;
+  return PDF_PREVIEW_EXTENSIONS.has(getResultExtension(file));
+}
+
+export function isArchiveTreePreviewCandidate(file: PreviewCandidate): boolean {
+  if (file.isDirectory) return false;
+  return isArchiveTreePreviewSupported(file) && !getArchiveTreePreviewBlockedReason(file);
+}
+
+export function getArchiveTreePreviewBlockedReason(file: PreviewCandidate): string | undefined {
+  if (file.isDirectory || !isArchiveTreePreviewSupported(file)) return undefined;
+  if (isTarArchive(file) && (file.size ?? 0) > MAX_TAR_ARCHIVE_TREE_PREVIEW_FILE_SIZE) {
+    return `压缩包超过 ${formatBytes(MAX_TAR_ARCHIVE_TREE_PREVIEW_FILE_SIZE)}，不提供预览`;
+  }
+  return undefined;
+}
+
+export function isMarkdownPreviewCandidate(file: PreviewCandidate): boolean {
+  if (file.isDirectory) return false;
+  return MARKDOWN_PREVIEW_EXTENSIONS.has(getResultExtension(file));
+}
+
+export function getCodePreviewLanguage(file: PreviewCandidate): string | undefined {
+  if (file.isDirectory) return undefined;
+  return CODE_PREVIEW_LANGUAGE_BY_EXTENSION[getResultExtension(file)];
+}
+
+export function isCodePreviewCandidate(file: PreviewCandidate): boolean {
+  return getCodePreviewLanguage(file) !== undefined;
+}
+
+export function isLogPreviewCandidate(file: PreviewCandidate): boolean {
+  if (file.isDirectory) return false;
+  return LOG_PREVIEW_EXTENSIONS.has(getResultExtension(file));
+}
+
+export function isTextPreviewCandidate(file: PreviewCandidate): boolean {
+  if (file.isDirectory) return false;
+  if ((file.size ?? 0) > MAX_TEXT_PREVIEW_FILE_SIZE) return false;
+
+  return TEXT_PREVIEW_EXTENSIONS.has(getResultExtension(file));
+}
+
+function isArchiveTreePreviewSupported(file: PreviewCandidate): boolean {
+  const ext = getResultExtension(file);
+  return ARCHIVE_TREE_PREVIEW_EXTENSIONS.has(ext) || file.name.toLowerCase().endsWith(".tar.gz");
+}
+
+function isTarArchive(file: PreviewCandidate): boolean {
+  const ext = getResultExtension(file);
+  const normalizedName = file.name.toLowerCase();
+  return ext === "tar" || ext === "tgz" || normalizedName.endsWith(".tar.gz");
+}
+
+function getResultExtension(file: PreviewCandidate): string {
+  return (file.extension || getExtension(file.name)).toLowerCase();
+}
+
+function getExtension(name: string): string {
+  const index = name.lastIndexOf(".");
+  return index >= 0 ? name.slice(index + 1).toLowerCase() : "";
+}

--- a/plugins/local-search-neo/src/Finder/index.vue
+++ b/plugins/local-search-neo/src/Finder/index.vue
@@ -4,6 +4,7 @@ import ConfirmDialog from "../components/ConfirmDialog.vue";
 import FloatingZoom from "../components/FloatingZoom.vue";
 import { useGlocalConfirmDialog } from "../components/useGlocalConfirmDialog";
 
+import SplitResizer from "./components/SplitResizer.vue";
 import ContextMenu from "./components/ContextMenu.vue";
 import FinderFooter from "./components/FinderFooter.vue";
 import FinderResultList from "./components/FinderResultList.vue";
@@ -35,47 +36,53 @@ const {
   everythingReady,
   everythingPending,
   ensureEverythingReady,
-  startEverythingStatusPolling,
   stopEverythingStatusPolling,
 } = useEverything({ runSearch: () => finderSearch.runSearch() });
 
-const { previewEnabled, sortMode, matchPathEnabled, resultListWidth, setResultListWidth } =
-  usePersistStorage();
+const {
+  previewEnabled,
+  sortMode,
+  matchPathEnabled,
+  resultListWidth,
+  setResultListWidth,
+  sidebarWidth,
+  setSidebarWidth,
+} = usePersistStorage();
+
+const MIN_SIDEBAR_WIDTH = 48;
+const DEFAULT_SIDEBAR_WIDTH = 64;
+const isResizingSidebar = ref(false);
 
 const MIN_LIST_WIDTH = 220;
 const DEFAULT_LIST_WIDTH = 315;
 const isResizingList = ref(false);
 
-function onResizerMouseDown(event: MouseEvent) {
-  if (event.button !== 0) return;
-  event.preventDefault();
-  isResizingList.value = true;
-  const startX = event.clientX;
-  const startWidth = resultListWidth.value;
-
-  function onMouseMove(moveEvent: MouseEvent) {
-    const deltaX = moveEvent.clientX - startX;
-    const maxAllowedWidth = Math.max(MIN_LIST_WIDTH, window.innerWidth - 64 - 260);
-    const targetWidth = Math.min(maxAllowedWidth, Math.max(MIN_LIST_WIDTH, startWidth + deltaX));
-    resultListWidth.value = targetWidth;
-  }
-
-  function onMouseUp() {
-    isResizingList.value = false;
-    window.removeEventListener("mousemove", onMouseMove);
-    window.removeEventListener("mouseup", onMouseUp);
-    setResultListWidth(resultListWidth.value);
-  }
-
-  window.addEventListener("mousemove", onMouseMove);
-  window.addEventListener("mouseup", onMouseUp);
+function onSidebarWidthUpdate(width: number) {
+  setSidebarWidth(width, false);
 }
 
-function onResizerDoubleClick() {
-  setResultListWidth(DEFAULT_LIST_WIDTH);
+function onSidebarWidthChange(width: number) {
+  setSidebarWidth(width, true);
 }
 
-const { bindSubInput, syncSubInputValue, focusSubInput } = useSubInput({
+function getSidebarMaxWidth(): number {
+  const minMainSpace = previewEnabled.value ? resultListWidth.value + 160 : 200;
+  return Math.max(MIN_SIDEBAR_WIDTH, Math.min(260, window.innerWidth - minMainSpace));
+}
+
+function onResultListWidthUpdate(width: number) {
+  setResultListWidth(width, false);
+}
+
+function onResultListWidthChange(width: number) {
+  setResultListWidth(width, true);
+}
+
+function getResultListMaxWidth(): number {
+  return Math.max(MIN_LIST_WIDTH, window.innerWidth - sidebarWidth.value - 260);
+}
+
+const { bindSubInput, focusSubInput } = useSubInput({
   onInput: queueSearch,
 });
 
@@ -86,6 +93,8 @@ const {
   enabledCategories,
   allCategories,
   selectCategory,
+  handleReorderCategories,
+  handleResetCategoryOrder,
   handleAddCustomCategory,
   handleUpdateCustomCategory,
   handleRemoveCustomCategory,
@@ -198,15 +207,30 @@ function setActiveCategory(category: FinderCategory) {
 <template>
   <main
     class="finder-shell"
-    :class="{ 'preview-open': previewEnabled, 'is-resizing': isResizingList }"
-    :style="{ '--result-list-width': `${resultListWidth}px` }"
+    :class="{ 'preview-open': previewEnabled, 'is-resizing': isResizingList || isResizingSidebar }"
+    :style="{
+      '--sidebar-width': `${sidebarWidth}px`,
+      '--result-list-width': `${resultListWidth}px`,
+    }"
   >
-    <FinderSidebar
-      :categories="enabledCategories"
-      :active-category-id="activeCategoryId"
-      @select="setActiveCategory"
-      @open-settings="openSettingsDrawer"
-    />
+    <div class="finder-sidebar-pane">
+      <FinderSidebar
+        :categories="enabledCategories"
+        :active-category-id="activeCategoryId"
+        @select="setActiveCategory"
+        @open-settings="openSettingsDrawer"
+      />
+      <SplitResizer
+        :model-value="sidebarWidth"
+        :min="MIN_SIDEBAR_WIDTH"
+        :max="getSidebarMaxWidth"
+        :default-width="DEFAULT_SIDEBAR_WIDTH"
+        title="拖动调整侧边栏宽度，双击恢复默认"
+        @update:model-value="onSidebarWidthUpdate"
+        @change="onSidebarWidthChange"
+        @resizing-change="isResizingSidebar = $event"
+      />
+    </div>
 
     <section class="finder-main">
       <FinderResultList
@@ -224,16 +248,17 @@ function setActiveCategory(category: FinderCategory) {
         @context-menu="contextMenu.open"
         @open="(item) => resultActions.open([item])"
       />
-      <div
+      <SplitResizer
         v-if="previewEnabled"
-        class="finder-split-resizer"
-        :class="{ 'is-resizing': isResizingList }"
+        :model-value="resultListWidth"
+        :min="MIN_LIST_WIDTH"
+        :max="getResultListMaxWidth"
+        :default-width="DEFAULT_LIST_WIDTH"
         title="拖动调整列表宽度，双击恢复默认"
-        @mousedown="onResizerMouseDown"
-        @dblclick="onResizerDoubleClick"
-      >
-        <span class="resizer-line"></span>
-      </div>
+        @update:model-value="onResultListWidthUpdate"
+        @change="onResultListWidthChange"
+        @resizing-change="isResizingList = $event"
+      />
     </section>
 
     <FinderFooter
@@ -264,6 +289,8 @@ function setActiveCategory(category: FinderCategory) {
       @remove-category="handleRemoveCustomCategory"
       @set-category-enabled="handleSetCategoryEnabled"
       @set-match-path-enabled="matchPathEnabled = $event"
+      @reorder-categories="handleReorderCategories"
+      @reset-category-order="handleResetCategoryOrder"
     />
 
     <ContextMenu
@@ -289,10 +316,11 @@ function setActiveCategory(category: FinderCategory) {
 
 <style scoped>
 .finder-shell {
+  --sidebar-width: 64px;
   --result-list-width: 315px;
 
   display: grid;
-  grid-template-columns: 64px minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
   grid-template-rows: minmax(0, 1fr) 32px;
   height: 100vh;
   min-height: 0;
@@ -310,11 +338,25 @@ function setActiveCategory(category: FinderCategory) {
 }
 
 .finder-shell.preview-open {
-  grid-template-columns: 64px var(--result-list-width) minmax(0, 1fr);
+  grid-template-columns: var(--sidebar-width) var(--result-list-width) minmax(0, 1fr);
 }
 
-.finder-sidebar {
+.finder-sidebar-pane {
+  position: relative;
+  z-index: 20;
+  grid-column: 1;
   grid-row: 1 / -1;
+  min-width: 0;
+  min-height: 0;
+  max-height: 100%;
+  overflow: visible;
+  display: flex;
+}
+
+.finder-sidebar-pane :deep(.finder-sidebar) {
+  flex: 1;
+  min-width: 0;
+  width: 100%;
 }
 
 .finder-main {
@@ -326,33 +368,6 @@ function setActiveCategory(category: FinderCategory) {
   min-height: 0;
   max-height: 100%;
   overflow: visible;
-}
-
-.finder-split-resizer {
-  position: absolute;
-  top: 0;
-  right: -5px;
-  bottom: 0;
-  z-index: 50;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 10px;
-  cursor: col-resize;
-}
-
-.resizer-line {
-  width: 2px;
-  height: 100%;
-  border-radius: 1px;
-  background: transparent;
-  transition: background-color 0.15s ease;
-  pointer-events: none;
-}
-
-.finder-split-resizer:hover .resizer-line,
-.finder-split-resizer.is-resizing .resizer-line {
-  background: var(--primary-color);
 }
 
 .finder-preview-zoom {
@@ -369,7 +384,7 @@ function setActiveCategory(category: FinderCategory) {
 }
 
 .preview-open .finder-main {
-  border-right: 1px solid #1f2022;
+  border-right: 1px solid #47494c;
 }
 
 @media (prefers-color-scheme: light) {
@@ -385,21 +400,21 @@ function setActiveCategory(category: FinderCategory) {
 
 @media (max-width: 760px) {
   .finder-shell {
-    grid-template-columns: 60px minmax(0, 1fr);
+    grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
   }
 
   .finder-shell.preview-open {
-    grid-template-columns: 60px var(--result-list-width) minmax(0, 1fr);
+    grid-template-columns: var(--sidebar-width) var(--result-list-width) minmax(0, 1fr);
   }
 }
 
 @media (max-width: 560px) {
   .finder-shell {
-    grid-template-columns: 56px minmax(0, 1fr);
+    grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
   }
 
   .finder-shell.preview-open {
-    grid-template-columns: 56px minmax(0, 1fr);
+    grid-template-columns: var(--sidebar-width) minmax(0, 1fr);
   }
 }
 </style>

--- a/plugins/local-search-neo/src/Finder/preview/ImagePreview.vue
+++ b/plugins/local-search-neo/src/Finder/preview/ImagePreview.vue
@@ -15,7 +15,6 @@ const MAX_ZOOM = 5;
 const ZOOM_STEP = 0.25;
 
 const shellRef = shallowRef<HTMLElement | null>(null);
-const imageEl = shallowRef<HTMLImageElement | null>(null);
 const imageNaturalSize = shallowRef<{ width: number; height: number } | null>(null);
 const viewportSize = shallowRef<{ width: number; height: number } | null>(null);
 const zoomLevel = shallowRef(1);
@@ -174,6 +173,8 @@ let scrollTopStart = 0;
 
 function handleMouseDown(event: MouseEvent) {
   if (event.button !== 0 || !shellRef.value) return;
+  if (zoomLevel.value === 1) return;
+
   checkOverflow();
   if (!hasOverflow.value) return;
 
@@ -185,6 +186,12 @@ function handleMouseDown(event: MouseEvent) {
   scrollTopStart = shellRef.value.scrollTop;
   window.addEventListener("mousemove", handleMouseMove);
   window.addEventListener("mouseup", handleMouseUp);
+}
+
+function handleImageDragStart(event: DragEvent) {
+  if (zoomLevel.value !== 1) {
+    event.preventDefault();
+  }
 }
 
 function handleMouseMove(event: MouseEvent) {
@@ -265,7 +272,7 @@ onBeforeUnmount(() => {
       ref="shellRef"
       class="preview-media-shell"
       :class="{
-        'has-overflow': hasOverflow,
+        'has-overflow': hasOverflow && zoomLevel !== 1,
         'is-panning': isPanning,
         'is-zoomed': zoomLevel !== 1,
       }"
@@ -275,13 +282,13 @@ onBeforeUnmount(() => {
     >
       <div class="image-stage-wrap">
         <img
-          ref="imageEl"
           class="preview-image"
           :class="{ 'svg-image': isSvg }"
           :src="source"
           :style="imageStyle"
           alt=""
-          draggable="false"
+          :draggable="zoomLevel === 1"
+          @dragstart="handleImageDragStart"
           @load="updateImageSize"
         />
       </div>
@@ -296,7 +303,7 @@ onBeforeUnmount(() => {
   min-width: 0;
   min-height: 0;
   background: #0f1012;
-  user-select: none;
+  user-select: auto;
 }
 
 .image-info-bar {
@@ -309,6 +316,7 @@ onBeforeUnmount(() => {
   color: #c3c8cf;
   border-bottom: 1px solid #282a2d;
   font-size: 12px;
+  user-select: none;
 }
 
 .image-size-label {
@@ -382,13 +390,16 @@ onBeforeUnmount(() => {
 .preview-media-shell.is-zoomed {
   overflow: auto;
   display: block;
+  user-select: none;
 }
 
-.preview-media-shell.has-overflow {
+.preview-media-shell.has-overflow,
+.preview-media-shell.is-zoomed {
   cursor: grab;
 }
 
-.preview-media-shell.is-panning {
+.preview-media-shell.is-panning,
+.preview-media-shell.is-panning * {
   cursor: grabbing !important;
   user-select: none;
 }
@@ -425,6 +436,9 @@ onBeforeUnmount(() => {
   height: auto;
   object-fit: contain;
   flex-shrink: 0;
+  user-select: auto;
+  -webkit-user-drag: auto;
+  cursor: default;
   background-color: #ffffff;
   background-image: conic-gradient(
     #e5e5e5 0 25%,
@@ -434,6 +448,12 @@ onBeforeUnmount(() => {
   );
   background-size: 16px 16px;
   box-shadow: 0 2px 14px rgb(0 0 0 / 18%);
+}
+
+.preview-media-shell.is-zoomed .preview-image {
+  user-select: none;
+  -webkit-user-drag: none;
+  cursor: grab;
 }
 
 .svg-image {

--- a/plugins/local-search-neo/src/components/FloatingZoom.vue
+++ b/plugins/local-search-neo/src/components/FloatingZoom.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Maximize2, Minimize2 } from "@lucide/vue";
-import { onBeforeUnmount, ref, watch } from "vue";
+import { nextTick, onBeforeUnmount, ref, shallowRef, watch } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -17,22 +17,144 @@ const props = withDefaults(
   },
 );
 
-const expanded = ref(false);
+const hostRef = shallowRef<HTMLElement | null>(null);
+const surfaceRef = shallowRef<HTMLElement | null>(null);
 
-function toggleExpanded() {
-  expanded.value = !expanded.value;
+const isTeleported = ref(false);
+const isFloating = ref(false);
+const isAnimating = ref(false);
+const backdropVisible = ref(false);
+
+const surfaceStyle = ref<Record<string, string>>({});
+
+function getTargetFloatingRect() {
+  const vh = window.innerHeight;
+  const vw = window.innerWidth;
+  const padY = Math.max(12, Math.min(32, Math.round(vh * 0.03)));
+  const padX = Math.max(12, Math.min(40, Math.round(vw * 0.03)));
+
+  return {
+    top: padY,
+    left: padX,
+    width: vw - padX * 2,
+    height: vh - padY * 2,
+  };
+}
+
+function expand() {
+  if (isTeleported.value || isAnimating.value || !hostRef.value) return;
+
+  const startRect = hostRef.value.getBoundingClientRect();
+  const targetRect = getTargetFloatingRect();
+
+  surfaceStyle.value = {
+    position: "fixed",
+    top: `${startRect.top}px`,
+    left: `${startRect.left}px`,
+    width: `${startRect.width}px`,
+    height: `${startRect.height}px`,
+    zIndex: "900",
+    transition: "none",
+  };
+
+  isTeleported.value = true;
+  isAnimating.value = true;
+  backdropVisible.value = false;
+
+  void nextTick(() => {
+    if (surfaceRef.value) {
+      void surfaceRef.value.offsetHeight;
+    }
+
+    backdropVisible.value = true;
+    isFloating.value = true;
+
+    surfaceStyle.value = {
+      position: "fixed",
+      top: `${targetRect.top}px`,
+      left: `${targetRect.left}px`,
+      width: `${targetRect.width}px`,
+      height: `${targetRect.height}px`,
+      zIndex: "900",
+      transition:
+        "top 0.28s cubic-bezier(0.16, 1, 0.3, 1), left 0.28s cubic-bezier(0.16, 1, 0.3, 1), width 0.28s cubic-bezier(0.16, 1, 0.3, 1), height 0.28s cubic-bezier(0.16, 1, 0.3, 1)",
+    };
+
+    setTimeout(() => {
+      if (isFloating.value) {
+        surfaceStyle.value = {};
+        isAnimating.value = false;
+      }
+    }, 290);
+  });
 }
 
 function collapse() {
-  expanded.value = false;
+  if (!isTeleported.value || isAnimating.value || !hostRef.value || !surfaceRef.value) {
+    isTeleported.value = false;
+    isFloating.value = false;
+    surfaceStyle.value = {};
+    return;
+  }
+
+  const currentRect = surfaceRef.value.getBoundingClientRect();
+  const returnRect = hostRef.value.getBoundingClientRect();
+
+  surfaceStyle.value = {
+    position: "fixed",
+    top: `${currentRect.top}px`,
+    left: `${currentRect.left}px`,
+    width: `${currentRect.width}px`,
+    height: `${currentRect.height}px`,
+    zIndex: "900",
+    transition: "none",
+  };
+
+  isAnimating.value = true;
+  isFloating.value = false;
+
+  void nextTick(() => {
+    if (surfaceRef.value) {
+      void surfaceRef.value.offsetHeight;
+    }
+
+    backdropVisible.value = false;
+
+    surfaceStyle.value = {
+      position: "fixed",
+      top: `${returnRect.top}px`,
+      left: `${returnRect.left}px`,
+      width: `${returnRect.width}px`,
+      height: `${returnRect.height}px`,
+      zIndex: "900",
+      transition:
+        "top 0.28s cubic-bezier(0.16, 1, 0.3, 1), left 0.28s cubic-bezier(0.16, 1, 0.3, 1), width 0.28s cubic-bezier(0.16, 1, 0.3, 1), height 0.28s cubic-bezier(0.16, 1, 0.3, 1)",
+    };
+
+    setTimeout(() => {
+      isTeleported.value = false;
+      isAnimating.value = false;
+      surfaceStyle.value = {};
+    }, 290);
+  });
+}
+
+function toggleExpanded() {
+  if (isFloating.value) {
+    collapse();
+  } else {
+    expand();
+  }
 }
 
 function handleKeydown(event: KeyboardEvent) {
-  if (event.key === "Escape") collapse();
+  if (event.key === "Escape" && isTeleported.value) {
+    collapse();
+  }
 }
 
-watch(expanded, (isExpanded) => {
-  if (isExpanded) {
+watch(isTeleported, (teleported) => {
+  if (teleported) {
     window.addEventListener("keydown", handleKeydown);
   } else {
     window.removeEventListener("keydown", handleKeydown);
@@ -45,35 +167,42 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="floating-zoom" :class="{ 'is-expanded': expanded }">
-    <div v-if="expanded" class="floating-zoom-placeholder">{{ props.placeholder }}</div>
+  <div ref="hostRef" class="floating-zoom" :class="{ 'is-expanded': isTeleported }">
+    <div v-if="isTeleported" class="floating-zoom-placeholder">{{ props.placeholder }}</div>
 
-    <Teleport to="body" :disabled="!expanded">
+    <Teleport to="body" :disabled="!isTeleported">
       <section
+        ref="surfaceRef"
         class="floating-zoom-surface"
-        :class="{ 'is-floating': expanded }"
-        :role="expanded ? 'dialog' : undefined"
-        :aria-modal="expanded ? 'true' : undefined"
-        :aria-label="expanded ? props.floatingLabel : undefined"
+        :class="{ 'is-floating': isFloating && !isAnimating, 'is-animating': isAnimating }"
+        :style="surfaceStyle"
+        :role="isTeleported ? 'dialog' : undefined"
+        :aria-modal="isTeleported ? 'true' : undefined"
+        :aria-label="isTeleported ? props.floatingLabel : undefined"
       >
         <button
           type="button"
           class="floating-zoom-toggle"
-          :title="expanded ? props.collapseLabel : props.expandLabel"
-          :aria-label="expanded ? props.collapseLabel : props.expandLabel"
-          :aria-pressed="expanded"
+          :title="isFloating ? props.collapseLabel : props.expandLabel"
+          :aria-label="isFloating ? props.collapseLabel : props.expandLabel"
+          :aria-pressed="isFloating"
           @click.stop="toggleExpanded"
         >
-          <Minimize2 v-if="expanded" aria-hidden="true" :size="14" :stroke-width="1.8" />
+          <Minimize2 v-if="isFloating" aria-hidden="true" :size="14" :stroke-width="1.8" />
           <Maximize2 v-else aria-hidden="true" :size="14" :stroke-width="1.8" />
         </button>
 
-        <slot :expanded="expanded" :collapse="collapse" :toggle="toggleExpanded"></slot>
+        <slot :expanded="isTeleported" :collapse="collapse" :toggle="toggleExpanded"></slot>
       </section>
     </Teleport>
 
     <Teleport to="body">
-      <div v-if="expanded" class="floating-zoom-backdrop" @click="collapse"></div>
+      <div
+        v-if="isTeleported"
+        class="floating-zoom-backdrop"
+        :class="{ 'is-visible': backdropVisible }"
+        @click="collapse"
+      ></div>
     </Teleport>
   </div>
 </template>
@@ -105,6 +234,15 @@ onBeforeUnmount(() => {
   height: 100%;
   min-width: 0;
   min-height: 0;
+}
+
+.floating-zoom-surface.is-animating {
+  box-sizing: border-box;
+  overflow: hidden;
+  background: #121315;
+  border: 1px solid rgb(255 255 255 / 12%);
+  border-radius: 4px;
+  box-shadow: 0 24px 80px rgb(0 0 0 / 48%);
 }
 
 .floating-zoom-surface.is-floating {
@@ -155,6 +293,13 @@ onBeforeUnmount(() => {
   inset: 0;
   z-index: 880;
   background: rgb(0 0 0 / 34%);
+  opacity: 0;
+  transition: opacity 0.28s cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: opacity;
+}
+
+.floating-zoom-backdrop.is-visible {
+  opacity: 1;
 }
 
 @media (prefers-color-scheme: light) {
@@ -163,7 +308,8 @@ onBeforeUnmount(() => {
     background: #edf1f6;
   }
 
-  .floating-zoom-surface.is-floating {
+  .floating-zoom-surface.is-floating,
+  .floating-zoom-surface.is-animating {
     background: #ffffff;
     border-color: rgb(15 23 42 / 14%);
     box-shadow: 0 24px 80px rgb(15 23 42 / 22%);

--- a/plugins/local-search-neo/src/env.d.ts
+++ b/plugins/local-search-neo/src/env.d.ts
@@ -78,5 +78,3 @@ declare global {
     services: Services;
   }
 }
-
-export {};


### PR DESCRIPTION
## 插件信息

- **名称**: 本地搜索Neo
- **插件ID**: local-search-neo
- **版本**: 1.1.1
- **描述**: 借助 Everything 来进行文件搜索
- **作者**: the_tree
- **类型**: 更新

## 本次变更

本次更新主要包含侧边栏调宽与分组排序功能支持、图片预览及动效优化，以及核心逻辑代码拆分与重构。

### Key Changes
- **Features**:
  - 新增侧边栏宽度拖拽调节及配置持久化 (`SplitResizer`)。
  - 设置面板支持分组拖拽排序并持久化。
- **UI & UX**:
  - 优化图片预览交互（支持 1x 比例下拖拽）与浮动缩放动效 (`FloatingZoom`)。
  - 优化底栏排序菜单样式，修复侧边栏布局展示问题。
- **Refactoring & Code Quality**:
  - 拆分 `finderLogic.ts` 为 `formatters.ts` 和 `previewCandidate.ts`，完善对应单测。
  - 修复相关 TypeScript 类型问题。
  - 补充 Rust 代码格式化配置。
 
## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/local-search-neo/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
