### PR TITLE
Update plugin 本地搜索Neo v1.2.0

### DIFF
--- a/plugins/local-search-neo/AGENTS.md
+++ b/plugins/local-search-neo/AGENTS.md
@@ -29,6 +29,7 @@
 - `npm --prefix addon test`：Rust addon 测试。
 - `npm --prefix addon run build-release`：构建 release addon。
 - `npm run build`：完整构建，会先准备 pdfjs 和 addon。
+- `npm run version:set -- <version|patch|minor|major>`：统一修改 `plugin.json`、`package.json` 和 `package-lock.json` 的版本号。
 - `node scripts/test-everything-addon.cjs`：简单验证 addon 导出、Everything 状态、版本和查询结果。
 - `node scripts/benchmark-everything-addon.cjs`：压测/对比 Everything addon 查询性能。
 

--- a/plugins/local-search-neo/addon/README.md
+++ b/plugins/local-search-neo/addon/README.md
@@ -23,10 +23,10 @@ const { everything } = require("./index.node");
 
 - `inspectTextFile(file, maxBytes?)`
 - `readTextPreview(file, maxBytes?, direction?)`
-- `printDirectoryTree(directory, options?)`
+- `printDirectoryTree(directory, options?)`（异步，返回 `Promise<FileTreeResult>`）
 - `printArchiveTree(file, options?)`
 
-`printDirectoryTree()` / `printArchiveTree()` 默认打印 2 层，第一层最多 50 项，第二层最多 20 项，超出时使用 `...` 表示。压缩包树当前支持 `.zip`、`.tar`、`.tar.gz`、`.tgz`。
+`printDirectoryTree()` / `printArchiveTree()` 默认打印 2 层，第一层最多 50 项，第二层最多 20 项，超出时使用 `...` 表示。`printDirectoryTree()` 在后台线程池异步执行目录扫描，不阻塞主线程。压缩包树当前支持 `.zip`、`.tar`、`.tar.gz`、`.tgz`。
 
 `query()` 的 `matchPath` 参数未传入时默认 `false`。前端偏好设置默认开启“同时搜索路径”，开启后会传入 `true` 并使用 Everything 的 `SearchFlags::MatchPath`，让普通关键字同时匹配路径和文件名。
 

--- a/plugins/local-search-neo/addon/index.d.ts
+++ b/plugins/local-search-neo/addon/index.d.ts
@@ -81,5 +81,8 @@ export function readTextPreview(
   maxBytes?: number,
   direction?: TextPreviewDirection,
 ): TextPreviewResult;
-export function printDirectoryTree(directory: string, options?: FileTreeOptions): FileTreeResult;
+export function printDirectoryTree(
+  directory: string,
+  options?: FileTreeOptions,
+): Promise<FileTreeResult>;
 export function printArchiveTree(file: string, options?: FileTreeOptions): FileTreeResult;

--- a/plugins/local-search-neo/addon/src/file_tree.rs
+++ b/plugins/local-search-neo/addon/src/file_tree.rs
@@ -40,14 +40,24 @@ struct RenderedTree {
     truncated: bool,
 }
 
-pub fn print_directory_tree(mut cx: FunctionContext) -> JsResult<JsObject> {
+pub fn print_directory_tree(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let path = required_string_arg(&mut cx, 0, "directory")?;
     let options = parse_tree_options(&mut cx, 1)?;
-    let root =
-        read_directory_tree(Path::new(&path), &options).or_else(|error| cx.throw_error(error))?;
-    let rendered = render_tree(&root, &options);
 
-    rendered_tree_to_js(&mut cx, rendered)
+    let promise = cx
+        .task(move || {
+            let root = read_directory_tree(Path::new(&path), &options)?;
+            let rendered = render_tree(&root, &options);
+            Ok(rendered)
+        })
+        .promise(
+            move |mut cx, result: Result<RenderedTree, String>| match result {
+                Ok(rendered) => rendered_tree_to_js(&mut cx, rendered),
+                Err(error) => cx.throw_error(error),
+            },
+        );
+
+    Ok(promise)
 }
 
 pub fn print_archive_tree(mut cx: FunctionContext) -> JsResult<JsObject> {
@@ -457,8 +467,8 @@ fn level_limit(options: &TreeOptions, level: usize) -> usize {
         .unwrap_or(DEFAULT_LEVEL_LIMITS[DEFAULT_LEVEL_LIMITS.len() - 1])
 }
 
-fn rendered_tree_to_js<'a>(
-    cx: &mut FunctionContext<'a>,
+fn rendered_tree_to_js<'a, C: Context<'a>>(
+    cx: &mut C,
     rendered: RenderedTree,
 ) -> JsResult<'a, JsObject> {
     let object = cx.empty_object();

--- a/plugins/local-search-neo/package-lock.json
+++ b/plugins/local-search-neo/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "local-search-neo",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "local-search-neo",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "dependencies": {
         "@lucide/vue": "^1.17.0",
         "markdown-it": "^14.2.0",

--- a/plugins/local-search-neo/package.json
+++ b/plugins/local-search-neo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-search-neo",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "借助 Everything 来进行文件搜索",
   "type": "module",
   "scripts": {
@@ -19,7 +19,8 @@
     "dev": "vite",
     "prebuild": "npm run prepare:pdfjs && npm run build:addon",
     "build": "vue-tsc && vite build",
-    "postbuild": "node scripts/prepare-dist.cjs"
+    "postbuild": "node scripts/prepare-dist.cjs",
+    "version:set": "node scripts/set-version.cjs"
   },
   "dependencies": {
     "@lucide/vue": "^1.17.0",

--- a/plugins/local-search-neo/public/plugin.json
+++ b/plugins/local-search-neo/public/plugin.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/guopenghui/local-search-neo",
   "title": "本地搜索Neo",
   "description": "借助 Everything 来进行文件搜索",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "main": "index.html",
   "preload": "preload/services.js",
   "unpack": "Everything.*",
@@ -33,6 +33,42 @@
           "maxLength": 40,
           "exclude": "/[\\\\\\/\\t\\n]/",
           "label": "文件搜索"
+        }
+      ]
+    },
+    {
+      "code": "explorerfind",
+      "explain": "「文件资源管理器」窗口所在目录内搜索",
+      "platform": ["win32"],
+      "icon": "logo.png",
+      "cmds": [
+        {
+          "type": "window",
+          "match": {
+            "app": [
+              "explorer.exe",
+              "SearchApp.exe",
+              "SearchHost.exe",
+              "FESearchHost.exe",
+              "prevhost.exe"
+            ],
+            "class": ["CabinetWClass", "ExploreWClass"]
+          },
+          "label": "窗口目录内搜索"
+        }
+      ]
+    },
+    {
+      "code": "folderfind",
+      "explain": "选中的文件夹内搜索",
+      "platform": ["win32"],
+      "icon": "logo.png",
+      "cmds": [
+        {
+          "type": "files",
+          "fileType": "directory",
+          "maxLength": 1,
+          "label": "文件夹内搜索"
         }
       ]
     }

--- a/plugins/local-search-neo/scripts/set-version.cjs
+++ b/plugins/local-search-neo/scripts/set-version.cjs
@@ -1,0 +1,172 @@
+/**
+ * 统一插件版本修改脚本
+ *
+ * 功能：
+ * 同步更新 package.json、package-lock.json（包含顶层及 packages[""]）和 public/plugin.json（及根目录 plugin.json）中的插件版本号，
+ * 并自动调用 npm run format 完成标准格式化。
+ *
+ * 使用方法：
+ * 1. 查看当前版本及帮助：
+ *    node scripts/set-version.cjs
+ *
+ * 2. 直接指定新版本号：
+ *    npm run version:set -- 1.2.0
+ *    # 或
+ *    node scripts/set-version.cjs 1.2.0
+ *
+ * 3. 使用 SemVer 自动递增：
+ *    npm run version:set -- patch   # 补丁更新：如 1.1.1 -> 1.1.2
+ *    npm run version:set -- minor   # 特性更新：如 1.1.1 -> 1.2.0
+ *    npm run version:set -- major   # 主版本更新：如 1.1.1 -> 2.0.0
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { execSync } = require("node:child_process");
+
+const rootDir = path.resolve(__dirname, "..");
+const packageJsonPath = path.join(rootDir, "package.json");
+const packageLockJsonPath = path.join(rootDir, "package-lock.json");
+const publicPluginJsonPath = path.join(rootDir, "public", "plugin.json");
+const rootPluginJsonPath = path.join(rootDir, "plugin.json");
+
+const SEMVER_REGEX = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/;
+
+function readJson(filePath) {
+  const content = fs.readFileSync(filePath, "utf8");
+  return JSON.parse(content);
+}
+
+function writeJson(filePath, data) {
+  const content = `${JSON.stringify(data, null, 2)}\n`;
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function runFormatter() {
+  try {
+    console.log("\n正在自动执行代码格式化 (npm run format)...");
+    execSync("npm run format", { cwd: rootDir, stdio: "inherit" });
+  } catch {
+    console.warn("⚠️ 自动格式化执行失败，请后续手动运行 npm run format");
+  }
+}
+
+function computeNextVersion(currentVersion, bumpTypeOrVersion) {
+  const arg = (bumpTypeOrVersion || "").trim();
+
+  if (SEMVER_REGEX.test(arg)) {
+    return arg;
+  }
+
+  const match = currentVersion.match(SEMVER_REGEX);
+  if (!match) {
+    throw new Error(`当前 package.json 版本号 "${currentVersion}" 不符合 SemVer 格式`);
+  }
+
+  let major = parseInt(match[1], 10);
+  let minor = parseInt(match[2], 10);
+  let patch = parseInt(match[3], 10);
+
+  switch (arg.toLowerCase()) {
+    case "patch":
+      patch += 1;
+      return `${major}.${minor}.${patch}`;
+    case "minor":
+      minor += 1;
+      patch = 0;
+      return `${major}.${minor}.${patch}`;
+    case "major":
+      major += 1;
+      minor = 0;
+      patch = 0;
+      return `${major}.${minor}.${patch}`;
+    default:
+      throw new Error(
+        `无效的版本号或递增类型: "${arg}"。支持: <具体版本号如 1.2.0> | patch | minor | major`,
+      );
+  }
+}
+
+function main() {
+  const targetArg = process.argv[2];
+
+  if (!fs.existsSync(packageJsonPath)) {
+    console.error("错误: 未找到 package.json 文件");
+    process.exit(1);
+  }
+
+  const packageJson = readJson(packageJsonPath);
+  const currentVersion = packageJson.version || "0.0.0";
+
+  if (!targetArg) {
+    console.log(`当前插件版本: ${currentVersion}`);
+    console.log("\n用法:");
+    console.log("  node scripts/set-version.cjs <新版本号 | patch | minor | major>");
+    console.log("\n示例:");
+    console.log("  node scripts/set-version.cjs 1.2.0");
+    console.log("  node scripts/set-version.cjs patch  # 1.1.1 -> 1.1.2");
+    console.log("  node scripts/set-version.cjs minor  # 1.1.1 -> 1.2.0");
+    console.log("  node scripts/set-version.cjs major  # 1.1.1 -> 2.0.0");
+    console.log("  npm run version:set -- 1.2.0");
+    process.exit(0);
+  }
+
+  let newVersion;
+  try {
+    newVersion = computeNextVersion(currentVersion, targetArg);
+  } catch (err) {
+    console.error(`错误: ${err.message}`);
+    process.exit(1);
+  }
+
+  if (newVersion === currentVersion) {
+    console.log(`版本号未发生变化，保持: ${currentVersion}`);
+    process.exit(0);
+  }
+
+  console.log(`\n准备更新插件版本: ${currentVersion} -> ${newVersion}\n`);
+  const updatedFiles = [];
+
+  // 1. 更新 package.json
+  packageJson.version = newVersion;
+  writeJson(packageJsonPath, packageJson);
+  updatedFiles.push("package.json");
+
+  // 2. 更新 package-lock.json (如果存在)
+  if (fs.existsSync(packageLockJsonPath)) {
+    const lockJson = readJson(packageLockJsonPath);
+    lockJson.version = newVersion;
+    if (lockJson.packages && lockJson.packages[""]) {
+      lockJson.packages[""].version = newVersion;
+    }
+    writeJson(packageLockJsonPath, lockJson);
+    updatedFiles.push("package-lock.json");
+  }
+
+  // 3. 更新 public/plugin.json (如果存在)
+  if (fs.existsSync(publicPluginJsonPath)) {
+    const pluginJson = readJson(publicPluginJsonPath);
+    pluginJson.version = newVersion;
+    writeJson(publicPluginJsonPath, pluginJson);
+    updatedFiles.push("public/plugin.json");
+  }
+
+  // 4. 更新根目录 plugin.json (如果存在)
+  if (fs.existsSync(rootPluginJsonPath)) {
+    const rootPluginJson = readJson(rootPluginJsonPath);
+    rootPluginJson.version = newVersion;
+    writeJson(rootPluginJsonPath, rootPluginJson);
+    updatedFiles.push("plugin.json");
+  }
+
+  for (const file of updatedFiles) {
+    console.log(`  [OK] ${file}`);
+  }
+
+  // 5. 自动执行格式化
+  runFormatter();
+
+  console.log(`\n🎉 版本号已成功统一更新为 ${newVersion} 并完成格式化！\n`);
+}
+
+main();

--- a/plugins/local-search-neo/src/App.vue
+++ b/plugins/local-search-neo/src/App.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { onMounted } from "vue";
 import Finder from "./Finder/index.vue";
-import { useFinderEnterAction } from "./Finder/composables/useFinderEnterAction";
+import {
+  useFinderEnterAction,
+  type FinderEnterAction,
+} from "./Finder/composables/useFinderEnterAction";
 import { warmUpFileIconCache } from "./Finder/core/fileIconCache";
 import {
   DEFAULT_CATEGORIES,
@@ -24,18 +27,62 @@ const { handleEnterAction } = useFinderEnterAction();
 const { syncSubInputValue } = useSubInput();
 loadPersistStorage();
 
+/**
+ * 根据 ZTools 插件进入事件（PluginEnterAction）构建 Finder 初始化动作。
+ *
+ * 支持的模式：
+ * 1. `oversearch`：全局搜索，携带搜索词。
+ * 2. `explorerfind`：读取当前活动资源管理器窗口所在路径，限定在该目录下搜索；
+ *    - 增加 try-catch 防护：在快速访问、此电脑等特殊命名空间下读取可能抛错，失败时安全降级为全盘搜索。
+ * 3. `folderfind`：在用户选中的文件夹内搜索，对 payload 进行防御性数组和路径有效性检查。
+ */
+async function buildEnterAction(action: PluginEnterAction): Promise<FinderEnterAction> {
+  if (action.code === "oversearch") {
+    return {
+      query: typeof action.payload === "string" ? action.payload : "",
+    };
+  } else if (action.code === "explorerfind") {
+    let path = "";
+    try {
+      path = (await window.ztools.readCurrentFolderPath()) || "";
+    } catch {
+      // 在「快速访问」或不支持读取路径的特殊窗口下，静默降级为常规全盘搜索
+      path = "";
+    }
+    const trimmedPath = path.trim();
+    if (!trimmedPath) {
+      return {};
+    }
+    const name = trimmedPath.split(/[\\/]/).filter(Boolean).pop() || trimmedPath;
+    return {
+      prefix: trimmedPath,
+      placeholder: `在"${name}"中查找`,
+    };
+  } else if (action.code === "folderfind") {
+    const files = Array.isArray(action.payload) ? action.payload : [];
+    const target = files[0];
+    if (!target || !target.path) {
+      return {};
+    }
+    const name = target.name || target.path.split(/[\\/]/).filter(Boolean).pop() || target.path;
+    return {
+      prefix: target.path,
+      placeholder: `在"${name}"中查找`,
+    };
+  } else {
+    return {};
+  }
+}
+
 onMounted(() => {
   warmUpFileIconCache();
 
-  window.ztools.onPluginEnter<string, Partial<MainPushSearchResult> | undefined>((action) => {
+  window.ztools.onPluginEnter<any, Partial<MainPushSearchResult> | undefined>(async (action) => {
     if (action.from === "main") {
       syncSubInputValue();
     } else {
       resetActiveCategory();
-      handleEnterAction({
-        payload: action.code === "oversearch" ? action.payload : "",
-        option: action.option,
-      });
+      handleEnterAction(await buildEnterAction(action as any));
     }
 
     window.ztools.subInputFocus();
@@ -94,9 +141,10 @@ onMounted(() => {
     },
     (action) => {
       resetActiveCategory();
+      const option = action.option as MainPushSearchResult | undefined;
       handleEnterAction({
-        payload: action.payload,
-        option: action.option as MainPushSearchResult,
+        query: typeof action.payload === "string" ? action.payload : "",
+        fullPath: option?.fullPath,
       });
       return true;
     },

--- a/plugins/local-search-neo/src/Finder/components/FinderResultList.vue
+++ b/plugins/local-search-neo/src/Finder/components/FinderResultList.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
   isLoading: boolean;
   statusText: string;
   previewOpen: boolean;
+  prefix: string;
   isFolderQuery: boolean;
   actions: ResultActions;
 }>();
@@ -84,19 +85,66 @@ function formatModified(value?: number) {
   )}:${pad(date.getSeconds())}`;
 }
 
-function highlightSegments(value: string | undefined, fallback = ""): HighlightSegment[] {
+/**
+ * 判断当前高亮片段是否属于搜索前缀目录本身。
+ *
+ * 背景与原理：
+ * 在「文件夹内搜索」模式下，前缀目录路径（如 "D:\Projects\App"）会被拼入 Everything 查询语句。
+ * Everything 会将前缀路径视作匹配项，导致返回的 `highlightedPath` 中前缀目录被包裹 `*...*` 高亮标记。
+ *
+ * 为消除前缀高亮并保留子路径中用户真实搜索词的高亮：
+ * 1. 在当前结果的所有路径中，前 [0, cleanPrefix.length] 字符区间物理上必定属于前缀目录；
+ * 2. 若当前片段的结束位置 `plainOffset + text.length` 未超出前缀目录长度，说明其纯粹由前缀匹配引起，应消除高亮；
+ * 3. `normText === normPrefix` 作为后备兜底，防止极端斜杠或分词切分差异。
+ */
+function isPrefixSegment(text: string, plainOffset: number, prefix: string): boolean {
+  if (!prefix) return false;
+  const cleanPrefix = prefix
+    .replace(/^"|"$/g, "")
+    .trim()
+    .replace(/[\\/]+$/, "");
+  if (!cleanPrefix) return false;
+
+  // 片段结束位置在前缀长度范围内（+1 兼容尾部路径分隔符 \），属于前缀路径
+  if (plainOffset + text.length <= cleanPrefix.length + 1) {
+    return true;
+  }
+
+  // 兜底：忽略大小写与斜杠差异的全等比对
+  const normText = text.replace(/\\+/g, "/").replace(/\/+$/, "").toLowerCase();
+  const normPrefix = cleanPrefix.replace(/\\+/g, "/").replace(/\/+$/, "").toLowerCase();
+  return normText === normPrefix;
+}
+
+/**
+ * 解析 Everything 返回的高亮标记字符串（成对的 `*` 包裹匹配项），拆分为片段列表供模板渲染。
+ *
+ * @param value Everything 返回的含 `*` 高亮标记文本（如 `*C:\path*\*file*.txt`）
+ * @param fallback 无高亮标记时的回退纯文本
+ * @param isPath 是否为路径字段；为 true 时会结合 props.prefix 消除前缀目录的高亮
+ */
+function highlightSegments(
+  value: string | undefined,
+  fallback = "",
+  isPath = false,
+): HighlightSegment[] {
   const source = value || fallback;
   if (!source) return [];
 
   const segments: HighlightSegment[] = [];
   let highlighted = false;
   let start = 0;
+  let plainOffset = 0;
 
   for (let index = 0; index < source.length; index += 1) {
     if (source[index] !== "*") continue;
 
     if (index > start) {
-      segments.push({ text: source.slice(start, index), highlighted });
+      const text = source.slice(start, index);
+      // 路径字段需检测是否为前缀目录本身；若为前缀匹配则消除高亮
+      const isPrefix = isPath && props.prefix && isPrefixSegment(text, plainOffset, props.prefix);
+      segments.push({ text, highlighted: !isPrefix && highlighted });
+      plainOffset += text.length;
     }
 
     highlighted = !highlighted;
@@ -192,7 +240,11 @@ function openResultMenu(event: MouseEvent, item: FinderResult) {
         </span>
         <span class="file-path" :title="item.fullPath">
           <span
-            v-for="(segment, segmentIndex) in highlightSegments(item.highlightedPath, item.path)"
+            v-for="(segment, segmentIndex) in highlightSegments(
+              item.highlightedPath,
+              item.path,
+              true,
+            )"
             :key="segmentIndex"
             :class="{ 'highlight-match': segment.highlighted }"
             >{{ segment.text }}</span

--- a/plugins/local-search-neo/src/Finder/components/FinderSidebar.vue
+++ b/plugins/local-search-neo/src/Finder/components/FinderSidebar.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
+import { nextTick, ref, watch } from "vue";
 import { Settings } from "@lucide/vue";
 import type { FinderCategory } from "../core/finderLogic";
 
-defineProps<{
+const props = defineProps<{
   categories: FinderCategory[];
   activeCategoryId: string;
 }>();
@@ -11,11 +12,25 @@ const emit = defineEmits<{
   select: [category: FinderCategory];
   openSettings: [];
 }>();
+
+const categoryListRef = ref<HTMLElement | null>(null);
+
+watch(
+  () => props.activeCategoryId,
+  () => {
+    nextTick(() => {
+      const activeBtn = categoryListRef.value?.querySelector(".category-button.active");
+      if (activeBtn instanceof HTMLElement) {
+        activeBtn.scrollIntoView({ block: "nearest" });
+      }
+    });
+  },
+);
 </script>
 
 <template>
   <aside class="finder-sidebar">
-    <div class="sidebar-category-list">
+    <div ref="categoryListRef" class="sidebar-category-list">
       <button
         v-for="category in categories"
         :key="category.id"

--- a/plugins/local-search-neo/src/Finder/composables/useFilePreview.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useFilePreview.ts
@@ -65,7 +65,7 @@ export function useFilePreview({ activeItem }: UseFilePreviewOptions) {
 
     const previewItem = { ...item, ...fileInfo };
     if (previewItem.isDirectory) {
-      loadDirectoryTreePreview(previewItem);
+      await loadDirectoryTreePreview(previewItem, sequence);
       return;
     }
 
@@ -126,9 +126,10 @@ export function useFilePreview({ activeItem }: UseFilePreviewOptions) {
     return false;
   }
 
-  function loadDirectoryTreePreview(item: FinderResult) {
+  async function loadDirectoryTreePreview(item: FinderResult, sequence: number) {
     try {
-      const tree = window.services.printDirectoryTree(item.fullPath);
+      const tree = await window.services.printDirectoryTree(item.fullPath);
+      if (sequence !== previewLoadSequence) return;
       setPreviewState({
         kind: "tree",
         content: tree.text,
@@ -136,6 +137,7 @@ export function useFilePreview({ activeItem }: UseFilePreviewOptions) {
         status: tree.truncated ? "目录结构 · 已截断" : "目录结构",
       });
     } catch (error: unknown) {
+      if (sequence !== previewLoadSequence) return;
       resetPreview();
       previewStatus.value = error instanceof Error ? error.message : "目录预览失败";
     }

--- a/plugins/local-search-neo/src/Finder/composables/useFinderCategories.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useFinderCategories.ts
@@ -2,6 +2,7 @@ import { computed, ref, watch } from "vue";
 import {
   DEFAULT_CATEGORIES,
   type FinderCategory,
+  getNextCyclicCategory,
   normalizeCategoryOrder,
   reorderArray,
 } from "../core/finderLogic";
@@ -56,6 +57,7 @@ export function useFinderCategories() {
     allCategories,
     selectCategory,
     resetActiveCategory,
+    cycleCategory,
     handleReorderCategories,
     handleResetCategoryOrder,
     handleAddCustomCategory,
@@ -67,6 +69,13 @@ export function useFinderCategories() {
 
 function selectCategory(category: FinderCategory) {
   activeCategoryId.value = category.id;
+}
+
+function cycleCategory(direction: -1 | 1) {
+  const next = getNextCyclicCategory(enabledCategories.value, activeCategoryId.value, direction);
+  if (next) {
+    selectCategory(next);
+  }
 }
 
 function resetActiveCategory() {

--- a/plugins/local-search-neo/src/Finder/composables/useFinderEnterAction.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useFinderEnterAction.ts
@@ -3,12 +3,12 @@ import type { RunSearchOptions } from "./useFinderSearch";
 import { useFinderQuery } from "./useFinderQuery";
 import { useSubInput } from "./useSubInput";
 
-export interface FinderEnterAction {
-  payload: string;
-  option?: {
-    fullPath?: string;
-  };
-}
+export type FinderEnterAction = {
+  prefix?: string;
+  query?: string;
+  placeholder?: string;
+  fullPath?: string;
+};
 
 interface UseFinderEnterActionOptions {
   activePath: Ref<string>;
@@ -21,14 +21,16 @@ let activeHandler: EnterActionHandler | undefined;
 let pendingAction: FinderEnterAction | undefined;
 
 export function useFinderEnterAction(options?: UseFinderEnterActionOptions) {
-  const { setQueryText } = useFinderQuery();
-  const { syncSubInputValue } = useSubInput();
+  const { setQueryText, prefixFilter } = useFinderQuery();
+  const { syncSubInputValue, bindSubInput } = useSubInput();
 
   if (options) {
     const handler: EnterActionHandler = (action) => {
-      const fullPath = action.option?.fullPath;
+      const fullPath = action.fullPath;
 
-      setQueryText(action.payload);
+      prefixFilter.value = action.prefix ?? "";
+      bindSubInput(action.placeholder);
+      setQueryText(action.query ?? "");
       syncSubInputValue();
       options.activePath.value = fullPath ?? "";
       options.search({ preserveSelection: !!fullPath });
@@ -51,7 +53,7 @@ export function useFinderEnterAction(options?: UseFinderEnterActionOptions) {
     }
 
     pendingAction = action;
-    setQueryText(action.payload);
+    setQueryText(action.query ?? "");
     syncSubInputValue();
   }
 

--- a/plugins/local-search-neo/src/Finder/composables/useFinderKeyboard.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useFinderKeyboard.ts
@@ -5,6 +5,7 @@ interface UseFinderKeyboardOptions {
   closeTransientOverlays: () => void;
   focusSubInput: () => void;
   moveSelection: (direction: -1 | 1) => void;
+  cycleCategory: (direction: -1 | 1) => void;
   openSelection: () => void;
   showSelectionInFolder: () => void;
   scrollSelectedIntoView: () => void;
@@ -15,6 +16,7 @@ export function useFinderKeyboard({
   closeTransientOverlays,
   focusSubInput,
   moveSelection,
+  cycleCategory,
   openSelection,
   showSelectionInFolder,
   scrollSelectedIntoView,
@@ -27,6 +29,13 @@ export function useFinderKeyboard({
       event.preventDefault();
       moveSelection(event.key === "ArrowDown" ? 1 : -1);
       nextTick(() => scrollSelectedIntoView());
+      return;
+    }
+
+    if (event.key === "Tab" && !event.ctrlKey && !event.metaKey && !event.altKey) {
+      if (isNavigationBlocked()) return;
+      event.preventDefault();
+      cycleCategory(event.shiftKey ? -1 : 1);
       return;
     }
 

--- a/plugins/local-search-neo/src/Finder/composables/useFinderQuery.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useFinderQuery.ts
@@ -1,8 +1,9 @@
-import { shallowRef } from "vue";
+import { ref } from "vue";
 import { buildEverythingQuery } from "../core/finderLogic";
 import { useFinderCategories } from "./useFinderCategories";
 
-const queryText = shallowRef("");
+const queryText = ref("");
+const prefixFilter = ref("");
 
 export function useFinderQuery() {
   const { activeCategory } = useFinderCategories();
@@ -12,10 +13,11 @@ export function useFinderQuery() {
   }
 
   function buildFilteredEverythingQuery() {
-    return buildEverythingQuery(queryText.value, activeCategory.value);
+    return buildEverythingQuery(queryText.value, activeCategory.value, prefixFilter.value);
   }
 
   return {
+    prefixFilter,
     queryText,
     setQueryText,
     buildFilteredEverythingQuery,

--- a/plugins/local-search-neo/src/Finder/composables/useFinderSearch.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useFinderSearch.ts
@@ -1,6 +1,7 @@
 import { computed, nextTick, onUnmounted, ref, type Ref } from "vue";
 import {
   filterResultsExcludingPaths,
+  getMatchPathQueryPlan,
   getNextSelectedPath,
   getNextVisibleCount,
   getRangeSelectedPaths,
@@ -10,11 +11,13 @@ import {
   type FinderSortMode,
   type SelectionMode,
 } from "../core/finderLogic";
+import { logger } from "../core/logger";
 
 interface UseFinderSearchOptions {
   pageSize: number;
   maxResults: number;
   buildQuery: () => string;
+  queryKeyword?: () => string;
   sortMode: Ref<FinderSortMode>;
   matchPathEnabled: Ref<boolean>;
 }
@@ -27,6 +30,7 @@ export function useFinderSearch({
   pageSize,
   maxResults,
   buildQuery,
+  queryKeyword,
   sortMode,
   matchPathEnabled,
 }: UseFinderSearchOptions) {
@@ -75,7 +79,8 @@ export function useFinderSearch({
     searchSequence += 1;
     const everythingQuery = buildQuery();
     const currentSortMode = sortMode.value;
-    const currentMatchPathEnabled = matchPathEnabled.value;
+    const currentKeyword = queryKeyword ? queryKeyword() : "";
+    const queryPlan = getMatchPathQueryPlan(matchPathEnabled.value, currentKeyword);
 
     if (!window.services.everything.isAvailable()) {
       results.value = [];
@@ -88,14 +93,14 @@ export function useFinderSearch({
     visibleCount.value = pageSize;
 
     try {
-      const nameResult = window.services.everything.query(
-        everythingQuery,
-        maxResults,
-        currentSortMode,
-        false,
-      );
-
-      if (currentMatchPathEnabled) {
+      const searchStart = performance.now();
+      if (queryPlan.mode === "dual") {
+        const nameResult = window.services.everything.query(
+          everythingQuery,
+          maxResults,
+          currentSortMode,
+          false,
+        );
         const matchPathResult = window.services.everything.query(
           everythingQuery,
           maxResults,
@@ -108,12 +113,25 @@ export function useFinderSearch({
         ).slice(0, maxResults);
         everythingTotal.value = matchPathResult.total;
       } else {
-        results.value = nameResult.items;
-        everythingTotal.value = nameResult.total;
+        const queryResult = window.services.everything.query(
+          everythingQuery,
+          maxResults,
+          currentSortMode,
+          queryPlan.matchPath,
+        );
+        results.value = queryResult.items;
+        everythingTotal.value = queryResult.total;
       }
+      logger.perf("Everything 检索", performance.now() - searchStart, {
+        query: everythingQuery,
+        mode: queryPlan.mode,
+        total: everythingTotal.value,
+        loaded: results.value.length,
+      });
       updateResultStatus();
       restoreSelection(options);
     } catch (error: unknown) {
+      logger.warn("Everything 检索失败:", error);
       results.value = [];
       everythingTotal.value = 0;
       statusText.value = error instanceof Error ? error.message : "搜索失败";

--- a/plugins/local-search-neo/src/Finder/composables/useSubInput.ts
+++ b/plugins/local-search-neo/src/Finder/composables/useSubInput.ts
@@ -3,31 +3,25 @@ import { useFinderQuery } from "./useFinderQuery";
 
 interface UseSubInputOptions {
   onInput?: () => void;
-  placeholder?: string;
 }
 
 const inputListeners = new Set<() => void>();
 let subInputReady = false;
 let programmaticInputValue: string | undefined;
-let activePlaceholder = "全盘搜索";
 
-export function useSubInput({ onInput, placeholder = "全盘搜索" }: UseSubInputOptions = {}) {
+export function useSubInput({ onInput }: UseSubInputOptions = {}) {
   const { queryText, setQueryText } = useFinderQuery();
 
   if (onInput) {
     inputListeners.add(onInput);
+    onUnmounted(() => {
+      if (onInput) {
+        inputListeners.delete(onInput);
+      }
+    });
   }
 
-  onUnmounted(() => {
-    if (onInput) {
-      inputListeners.delete(onInput);
-    }
-  });
-
-  function bindSubInput() {
-    activePlaceholder = placeholder;
-    if (subInputReady) return;
-
+  function bindSubInput(placeholder: string = "全盘搜索") {
     window.ztools.setSubInput(
       ({ text }) => {
         if (programmaticInputValue === text) {
@@ -39,7 +33,7 @@ export function useSubInput({ onInput, placeholder = "全盘搜索" }: UseSubInp
         setQueryText(text);
         notifyInputListeners();
       },
-      activePlaceholder,
+      placeholder,
       true,
     );
     subInputReady = true;

--- a/plugins/local-search-neo/src/Finder/core/finderLogic.test.ts
+++ b/plugins/local-search-neo/src/Finder/core/finderLogic.test.ts
@@ -6,6 +6,8 @@ import {
   buildEverythingQuery,
   filterResultsExcludingPaths,
   getDragTargetPaths,
+  getMatchPathQueryPlan,
+  getNextCyclicCategory,
   getNextSelectedPath,
   getNextVisibleCount,
   getRangeSelectedPaths,
@@ -88,6 +90,31 @@ test("buildEverythingQuery supports custom Everything rules and extension shorth
   );
 });
 
+test("buildEverythingQuery handles folder prefix and paths with spaces", () => {
+  const pdfCategory = DEFAULT_CATEGORIES.find(
+    (category) => category.id === "pdf",
+  ) as FinderCategory;
+
+  assert.equal(
+    buildEverythingQuery("report", pdfCategory, "D:\\workspace"),
+    "D:\\workspace report ext:pdf",
+  );
+  assert.equal(
+    buildEverythingQuery("report", pdfCategory, "C:\\Program Files\\App"),
+    '"C:\\Program Files\\App" report ext:pdf',
+  );
+  assert.equal(
+    buildEverythingQuery("report", pdfCategory, '"C:\\Program Files\\App"'),
+    '"C:\\Program Files\\App" report ext:pdf',
+  );
+  assert.equal(buildEverythingQuery("", DEFAULT_CATEGORIES[0], "D:\\workspace"), "D:\\workspace");
+  assert.equal(
+    buildEverythingQuery("", DEFAULT_CATEGORIES[0], "D:\\My Documents"),
+    '"D:\\My Documents"',
+  );
+  assert.equal(buildEverythingQuery("test", DEFAULT_CATEGORIES[0], "   "), "test");
+});
+
 test("getNextVisibleCount grows by page size without exceeding total", () => {
   assert.equal(getNextVisibleCount(0, 100, 40), 40);
   assert.equal(getNextVisibleCount(40, 100, 40), 80);
@@ -102,6 +129,31 @@ test("getNextSelectedPath moves selection with arrow keys", () => {
   assert.equal(getNextSelectedPath(orderedPaths, "C:\\alpha\\a.log", -1), "C:\\beta\\b.txt");
   assert.equal(getNextSelectedPath(orderedPaths, "C:\\alpha\\folder", 1), "C:\\alpha\\folder");
   assert.equal(getNextSelectedPath(orderedPaths, "C:\\beta\\b.txt", -1), "C:\\beta\\b.txt");
+});
+
+test("getNextCyclicCategory cycles category forward and backward with wrap-around", () => {
+  const categories = [
+    { id: "all", label: "全部" },
+    { id: "folder", label: "文件夹" },
+    { id: "pdf", label: "PDF" },
+  ];
+
+  // Tab: 向下切换，最后一个回到第一个
+  assert.equal(getNextCyclicCategory(categories, "all", 1)?.id, "folder");
+  assert.equal(getNextCyclicCategory(categories, "folder", 1)?.id, "pdf");
+  assert.equal(getNextCyclicCategory(categories, "pdf", 1)?.id, "all");
+
+  // Shift+Tab: 向上切换，第一个回到最后一个
+  assert.equal(getNextCyclicCategory(categories, "all", -1)?.id, "pdf");
+  assert.equal(getNextCyclicCategory(categories, "pdf", -1)?.id, "folder");
+  assert.equal(getNextCyclicCategory(categories, "folder", -1)?.id, "all");
+
+  // 当前分类不存在时回退
+  assert.equal(getNextCyclicCategory(categories, "unknown", 1)?.id, "all");
+  assert.equal(getNextCyclicCategory(categories, "unknown", -1)?.id, "pdf");
+
+  // 空列表
+  assert.equal(getNextCyclicCategory([], "all", 1), undefined);
 });
 
 test("getRestoredSelectedPath keeps existing visible selection or picks sorted first item", () => {
@@ -264,4 +316,27 @@ test("reorderArray moves items correctly within bounds and handles invalid indic
   // Out of bounds
   assert.deepEqual(reorderArray(list, -1, 2), ["A", "B", "C", "D"]);
   assert.deepEqual(reorderArray(list, 1, 10), ["A", "B", "C", "D"]);
+});
+
+test("getMatchPathQueryPlan optimizes search execution based on keyword and matchPathEnabled", () => {
+  // 1. matchPathEnabled 关闭时，始终单次查询
+  assert.deepEqual(getMatchPathQueryPlan(false, ""), { mode: "single", matchPath: false });
+  assert.deepEqual(getMatchPathQueryPlan(false, "test"), { mode: "single", matchPath: false });
+  assert.deepEqual(getMatchPathQueryPlan(false, "src/components"), {
+    mode: "single",
+    matchPath: false,
+  });
+
+  // 2. keyword 为空或全空格（如纯分类切换），只执行单次 matchPath: false 查询
+  assert.deepEqual(getMatchPathQueryPlan(true, ""), { mode: "single", matchPath: false });
+  assert.deepEqual(getMatchPathQueryPlan(true, "   "), { mode: "single", matchPath: false });
+
+  // 3. keyword 包含路径分隔符（/ 或 \），直接单次 matchPath: true 查询
+  assert.deepEqual(getMatchPathQueryPlan(true, "src/main"), { mode: "single", matchPath: true });
+  assert.deepEqual(getMatchPathQueryPlan(true, "app\\assets"), { mode: "single", matchPath: true });
+  assert.deepEqual(getMatchPathQueryPlan(true, "C:\\Users"), { mode: "single", matchPath: true });
+
+  // 4. keyword 为普通纯词，执行双阶段查询
+  assert.deepEqual(getMatchPathQueryPlan(true, "report"), { mode: "dual" });
+  assert.deepEqual(getMatchPathQueryPlan(true, "test.pdf"), { mode: "dual" });
 });

--- a/plugins/local-search-neo/src/Finder/core/finderLogic.ts
+++ b/plugins/local-search-neo/src/Finder/core/finderLogic.ts
@@ -90,11 +90,32 @@ export function reorderArray<T>(list: T[], fromIndex: number, toIndex: number): 
   return result;
 }
 
-export function buildEverythingQuery(keyword: string, category: FinderCategory): string {
-  const trimmedKeyword = keyword.trim();
+/**
+ * 构建发送给 Everything 搜索引擎的最终查询语句。
+ *
+ * 组合逻辑：
+ * 1. `prefix`（可选）：限制搜索的目标前缀目录。
+ *    - 若前缀包含空格（如 `C:\Program Files\App`），根据 Everything 语法规则必须用双引号包裹 `"${prefix}"`，
+ *      否则空格会被解析为 AND 运算符导致拆词检索失效；若已有双引号则保留。
+ * 2. `keyword`：用户在输入框中键入的搜索词。
+ * 3. `category.rule`：当前分类的筛选规则（如 `ext:pdf`、`folder:` 等）。
+ */
+export function buildEverythingQuery(
+  keyword: string,
+  category: FinderCategory,
+  prefix: string = "",
+): string {
   const rule = normalizeCategoryRule(category.rule);
+  const trimmedPrefix = prefix.trim();
+  const formattedPrefix = trimmedPrefix
+    ? trimmedPrefix.startsWith('"') && trimmedPrefix.endsWith('"')
+      ? trimmedPrefix
+      : /\s/.test(trimmedPrefix)
+        ? `"${trimmedPrefix}"`
+        : trimmedPrefix
+    : "";
 
-  return [trimmedKeyword, rule].filter(Boolean).join(" ");
+  return [formattedPrefix, keyword.trim(), rule].filter(Boolean).join(" ");
 }
 
 export function getNextVisibleCount(current: number, total: number, pageSize: number): number {
@@ -113,6 +134,30 @@ export function getNextSelectedPath(
 
   const nextIndex = Math.max(0, Math.min(paths.length - 1, currentIndex + direction));
   return paths[nextIndex];
+}
+
+/**
+ * 循环切换分类列表。
+ *
+ * @param categories 启用的分类列表
+ * @param currentCategoryId 当前激活的分类 ID
+ * @param direction 切换方向：1 为向下切换（末尾循环至首项），-1 为向上切换（首项循环至末尾）
+ * @returns 切换后的目标分类对象，列表为空时返回 undefined
+ */
+export function getNextCyclicCategory<T extends { id: string }>(
+  categories: T[],
+  currentCategoryId: string,
+  direction: -1 | 1,
+): T | undefined {
+  if (categories.length === 0) return undefined;
+
+  const currentIndex = categories.findIndex((category) => category.id === currentCategoryId);
+  if (currentIndex === -1) {
+    return direction === 1 ? categories[0] : categories[categories.length - 1];
+  }
+
+  const nextIndex = (currentIndex + direction + categories.length) % categories.length;
+  return categories[nextIndex];
 }
 
 export function getRestoredSelectedPath(results: FinderResult[], currentPath: string): string {
@@ -195,4 +240,41 @@ function normalizeCategoryRule(rule: string): string {
     .filter(Boolean);
 
   return extensions.length > 0 ? `ext:${extensions.join(";")}` : "";
+}
+
+export type MatchPathQueryPlan =
+  | { mode: "single"; matchPath: false }
+  | { mode: "single"; matchPath: true }
+  | { mode: "dual" };
+
+/**
+ * 决定当前查询是否需要 MatchPath 以及具体的执行计划。
+ *
+ * 优化策略：
+ * 1. 若用户禁用了 matchPathEnabled，始终单次查询（matchPath: false）。
+ * 2. 若用户输入的关键词为空（例如仅点击切换分类，无 keyword）：
+ *    此时 matchPath=true 与 matchPath=false 的 Everything 返回结果严格一致，执行单次查询（matchPath: false）即可，
+ *    避免无意义的双重 IPC 检索与数百个重复对象的序列化。
+ * 3. 若用户输入的关键词包含路径分隔符（`\` 或 `/`）：
+ *    因为纯文件名中不可能包含路径字符，直接单次查询（matchPath: true），免去一次注定命中为空的 matchPath: false 查询。
+ * 4. 普通纯词搜索：执行两阶段双重查询并合并，优先呈现文件名命中的项。
+ */
+export function getMatchPathQueryPlan(
+  matchPathEnabled: boolean,
+  keyword: string,
+): MatchPathQueryPlan {
+  if (!matchPathEnabled) {
+    return { mode: "single", matchPath: false };
+  }
+
+  const trimmed = keyword.trim();
+  if (!trimmed) {
+    return { mode: "single", matchPath: false };
+  }
+
+  if (trimmed.includes("\\") || trimmed.includes("/")) {
+    return { mode: "single", matchPath: true };
+  }
+
+  return { mode: "dual" };
 }

--- a/plugins/local-search-neo/src/Finder/core/logger.ts
+++ b/plugins/local-search-neo/src/Finder/core/logger.ts
@@ -1,0 +1,52 @@
+/**
+ * local-search-neo 统一轻量日志工具
+ */
+const PREFIX = "[local-search-neo]";
+
+function isDebugEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  return Boolean(
+    import.meta.env.DEV ||
+    (window as unknown as { __LOCAL_SEARCH_DEBUG__?: boolean }).__LOCAL_SEARCH_DEBUG__,
+  );
+}
+
+export const logger = {
+  debug(...args: unknown[]): void {
+    if (isDebugEnabled()) {
+      console.debug(PREFIX, ...args);
+    }
+  },
+
+  info(...args: unknown[]): void {
+    console.info(PREFIX, ...args);
+  },
+
+  warn(...args: unknown[]): void {
+    console.warn(PREFIX, ...args);
+  },
+
+  error(...args: unknown[]): void {
+    console.error(PREFIX, ...args);
+  },
+
+  /**
+   * 性能打点（仅在开发/调试模式下输出）
+   */
+  perf(label: string, durationMs: number, extra?: Record<string, unknown>): void {
+    if (!isDebugEnabled()) return;
+
+    if (extra) {
+      console.debug(
+        `%c${PREFIX} [Perf] ${label}: ${durationMs.toFixed(2)}ms`,
+        "color: #409EFF; font-weight: bold;",
+        extra,
+      );
+    } else {
+      console.debug(
+        `%c${PREFIX} [Perf] ${label}: ${durationMs.toFixed(2)}ms`,
+        "color: #409EFF; font-weight: bold;",
+      );
+    }
+  },
+};

--- a/plugins/local-search-neo/src/Finder/index.vue
+++ b/plugins/local-search-neo/src/Finder/index.vue
@@ -93,6 +93,7 @@ const {
   enabledCategories,
   allCategories,
   selectCategory,
+  cycleCategory,
   handleReorderCategories,
   handleResetCategoryOrder,
   handleAddCustomCategory,
@@ -103,7 +104,7 @@ const {
 const { showSettingsDrawer, openSettingsDrawer, closeSettingsDrawer } = useFinderSettings({
   focusSubInput,
 });
-const { buildFilteredEverythingQuery } = useFinderQuery();
+const { buildFilteredEverythingQuery, prefixFilter, queryText } = useFinderQuery();
 const isFolderQuery = computed(() => /(?:^|\s)folder:/i.test(buildFilteredEverythingQuery()));
 const finderSearch = useFinderSearch({
   pageSize: PAGE_SIZE,
@@ -111,6 +112,7 @@ const finderSearch = useFinderSearch({
   sortMode,
   matchPathEnabled,
   buildQuery: buildFilteredEverythingQuery,
+  queryKeyword: () => queryText.value,
 });
 
 const resultStatusText = computed(() => {
@@ -146,6 +148,10 @@ useFinderKeyboard({
   closeTransientOverlays: contextMenu.close,
   focusSubInput,
   moveSelection: finderSearch.moveSelection,
+  cycleCategory: (direction) => {
+    cycleCategory(direction);
+    releaseFinderFocus();
+  },
   openSelection: () => resultActions.open(finderSearch.selectedItems.value),
   showSelectionInFolder: () => resultActions.showInFolder(finderSearch.selectedItems.value),
   scrollSelectedIntoView: finderSearch.scrollSelectedIntoView,
@@ -240,6 +246,7 @@ function setActiveCategory(category: FinderCategory) {
         :selected-items="finderSearch.selectedItems.value"
         :is-loading="resultLoading"
         :status-text="resultStatusText"
+        :prefix="prefixFilter"
         :preview-open="previewEnabled"
         :is-folder-query="isFolderQuery"
         :actions="resultActions"

--- a/plugins/local-search-neo/src/env.d.ts
+++ b/plugins/local-search-neo/src/env.d.ts
@@ -66,7 +66,7 @@ interface Services {
     maxBytes?: number,
     direction?: TextPreviewDirection,
   ) => TextPreviewResult;
-  printDirectoryTree: (directory: string, options?: FileTreeOptions) => FileTreeResult;
+  printDirectoryTree: (directory: string, options?: FileTreeOptions) => Promise<FileTreeResult>;
   printArchiveTree: (file: string, options?: FileTreeOptions) => FileTreeResult;
 }
 
@@ -76,5 +76,35 @@ declare global {
   }
   interface Window {
     services: Services;
+  }
+
+  interface PluginEnterAction {
+    code: string;
+    type: "text" | "img" | "files" | "regex" | "over" | "window";
+    payload: string | MatchFile[] | MatchWindow;
+    from: "main" | "panel" | "hotkey" | "redirect";
+    option?: {
+      fullPath?: string;
+    };
+  }
+
+  interface MatchFile {
+    isFile: boolean;
+    isDirectory: boolean;
+    name: string;
+    path: string;
+  }
+
+  interface MatchWindow {
+    id: number;
+    class: string;
+    title: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    appPath: string;
+    pid: number;
+    app: string;
   }
 }


### PR DESCRIPTION
## 插件信息

- **名称**: 本地搜索Neo
- **插件ID**: local-search-neo
- **版本**: 1.2.0
- **描述**: 借助 Everything 来进行文件搜索
- **作者**: the_tree
- **类型**: 更新

## 本次变更

- **资源管理器与目录内搜索**：支持从当前文件资源管理器窗口或选中文件夹直接调起局部范围搜索。
- **稳定性与边界处理**：修复空选择、异常路径及文件不存在时的边界问题，增强列表操作健壮性。
- **快捷键分组切换**：支持使用 `Tab` / `Shift+Tab` 循环切换左侧文件分类。
- **性能优化与工具完善**：
  - 将目录树预览（`printDirectoryTree`）改造为异步线程池执行，消除主线程卡顿与占位闪烁；
  - 优化 MatchPath 查询逻辑，避免分类切换时的冗余双重 IPC 请求，大幅提升“文件夹”等分组的响应速度；

## 截图 / 演示
<img width="987" height="472" alt="image" src="https://github.com/user-attachments/assets/c0c95bcf-6269-400a-b2c5-47e24951ef4a" />

<img width="986" height="734" alt="image" src="https://github.com/user-attachments/assets/4817d2e5-1839-4357-baeb-4069f7c1f2c9" />


<img width="468" height="514" alt="image" src="https://github.com/user-attachments/assets/05325832-bc02-458a-90a8-61d8395b894a" />

## 相关 issue
+ closes https://github.com/guopenghui/local-search-neo/issues/1
+ closes https://github.com/guopenghui/local-search-neo/issues/2


## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/local-search-neo/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
