### PR TITLE
Update plugin 隐阅盒 v1.4.1

### DIFF
--- a/plugins/hushreader/.gitignore
+++ b/plugins/hushreader/.gitignore
@@ -4,3 +4,5 @@ dist
 test
 功能说明文档.md
 docs/
+reference_docs
+.codefree

--- a/plugins/hushreader/CHANGELOG.md
+++ b/plugins/hushreader/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1](https://github.com/me1dlinger/hushreader/releases/tag/v1.4.1) - 2026-09-01
+
+### Added
+- **关闭隐阅窗口指令**：新增 `hushreader-close` 指令，支持通过 ZTools 平台快捷键绑定直接关闭隐阅窗口，无需鼠标移动到窗口上即可触发（需升级 ZTools 至最新版以支持 `mainHide` 特性）
+
 ## [1.4.0](https://github.com/me1dlinger/hushreader/releases/tag/v1.4.0) - 2026-06-23
 
 ### Added

--- a/plugins/hushreader/package.json
+++ b/plugins/hushreader/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hushreader",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/plugins/hushreader/public/plugin.json
+++ b/plugins/hushreader/public/plugin.json
@@ -4,7 +4,7 @@
   "title": "隐阅盒",
   "description": "ZTools自己的摸鱼阅读，支持TXT/EPUB/MOBI格式，沉浸式阅读",
   "author": "meidlinger",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "main": "index.html",
   "preload": "preload/services.js",
   "logo": "logo.png",
@@ -49,6 +49,13 @@
           "maxLength": 1,
           "label": "导入到 隐阅盒"
         }
+      ]
+    },
+    {
+      "code": "hushreader-close",
+      "mainHide": true,
+      "cmds": [
+        "关闭隐阅窗口"
       ]
     }
   ],

--- a/plugins/hushreader/src/App.vue
+++ b/plugins/hushreader/src/App.vue
@@ -779,6 +779,15 @@ onMounted(async () => {
   await configStore.load()
   await bookStore.load()
     ; (window as any).ztools?.onPluginEnter?.((action: any) => {
+      if (action?.code === 'hushreader-close') {
+        saveReadingProgress()
+        hushreaderActivated.value = false
+        stopReadingTimer()
+        hushreaderWindow?.close?.()
+        hushreaderWindow = null
+        try { (window as any).ztools?.outPlugin?.() } catch { }
+        return
+      }
       route.value = action.code
       enterAction.value = action
     })


### PR DESCRIPTION
## 插件信息

- **名称**: 隐阅盒
- **插件ID**: hushreader
- **版本**: 1.4.1
- **描述**: ZTools自己的摸鱼阅读，支持TXT/EPUB/MOBI格式，沉浸式阅读
- **作者**: meidlinger
- **类型**: 更新

## 本次变更

### Added
- **关闭隐阅窗口指令**：新增 `hushreader-close` 指令，支持通过 ZTools 平台快捷键绑定直接关闭隐阅窗口，无需鼠标移动到窗口上即可触发（需升级 ZTools 至最新版以支持 `mainHide` 特性）

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/hushreader/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
