### PR TITLE
Update plugin 自动化助手 v1.0.0

### DIFF
--- a/plugins/automatic-assistant/src/App.vue
+++ b/plugins/automatic-assistant/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, nextTick, onMounted, reactive, ref } from 'vue'
 import type { CategoryDoc, Feature, ScriptDoc } from './types'
 import { INSET_SCRIPTS } from './insets'
 import {
@@ -86,7 +86,10 @@ const stringifyResult = (value: unknown) => {
 //   有返回值 / 抛错     → 重新显示主窗口并展示结果面板
 //   结果出来后 print 的内容不再追加
 
-function runScript(script: string, action: Record<string, unknown>) {
+// mainHide 为 true 时，在运行页挂载后隐藏主窗口，再开始执行脚本
+// （对齐原版 componentDidMount 里先 hideMainWindow、再 setTimeout(run) 的时序；
+//   在 onPluginEnter 回调里同步隐藏会被宿主随后的显示/聚焦覆盖）
+function runScript(script: string, action: Record<string, unknown>, mainHide = false) {
   runInfo.script = script
   runInfo.action = action
   view.value = 'run'
@@ -95,6 +98,13 @@ function runScript(script: string, action: Record<string, unknown>) {
   runInfo.error = null
   runInfo.running = true
 
+  nextTick(() => {
+    if (mainHide) window.ztools.hideMainWindow()
+    window.setTimeout(() => execScript(script, action), 0)
+  })
+}
+
+function execScript(script: string, action: Record<string, unknown>) {
   const print = (msg: unknown) => {
     if (runInfo.result !== null || runInfo.error !== null) return
     runInfo.logs = [...runInfo.logs, stringify(msg)]
@@ -126,7 +136,7 @@ function rerun() {
   runInfo.logs = []
   runInfo.result = null
   runInfo.error = null
-  window.setTimeout(() => runScript(script, action), 50)
+  window.setTimeout(() => runScript(script, action, false), 50)
 }
 
 function handleEnter(action: { code: string; type: string; payload: unknown; option: unknown; from?: string }) {
@@ -144,18 +154,20 @@ function handleEnter(action: { code: string; type: string; payload: unknown; opt
     window.ztools.removeFeature(code)
     window.ztools.outPlugin()
   }
+  // ZTools 的 action.from 为可选字段，未提供时按主输入框入口处理，
+  // 否则 mainHide 会因判断恒为假而完全失效
+  const fromMain = (action.from || 'main') === 'main'
+  const enter = action as unknown as Record<string, unknown>
   const inset = INSET_SCRIPTS.find((x) => x.id === action.code)
   if (inset) {
     const script = window.services.getInsetScript(inset.id)
     if (!script) return bail(action.code)
-    if (insetFeature(inset.id)?.mainHide && action.from === 'main') window.ztools.hideMainWindow()
-    runScript(script, action as unknown as Record<string, unknown>)
+    runScript(script, enter, !!insetFeature(inset.id)?.mainHide && fromMain)
     return
   }
   const doc = scripts.value.find((s) => s.feature.code === action.code)
   if (!doc) return bail(action.code)
-  if (doc.feature.mainHide && action.from === 'main') window.ztools.hideMainWindow()
-  runScript(doc.script, action as unknown as Record<string, unknown>)
+  runScript(doc.script, enter, !!doc.feature.mainHide && fromMain)
 }
 
 onMounted(() => {


### PR DESCRIPTION
## 插件信息

- **名称**: 自动化助手
- **插件ID**: automatic-assistant
- **版本**: 1.0.0
- **描述**: 自动化助手，让繁琐的步骤一步到位。自定义指令 + JavaScript 脚本，一条指令完成一串操作
- **作者**: lee
- **类型**: 更新

## 本次变更

- 首个版本
- 自定义自动化脚本：功能说明 + 触发指令 + JavaScript 脚本，保存后自动注册为指令
- 支持六种指令类型：功能指令（关键字）与【任意文本】【特定文本】【文件】【图像】【系统窗口】
  匹配指令，含排除正则、最少/最多字符数、文件类型与数量、窗口应用名/标题正则等配置项
- 脚本在 Node `vm` 沙箱中隔离执行，可使用 `ENTER`、`print`、`ztools` API、`require`、
  `sleep`、`runAppleScript`
- 运行结果面板展示返回值与日志输出，支持「再次运行」；报错时展示错误信息
- 「脚本隐藏后台运行」：进入时先隐藏主窗口，脚本无返回值则静默退出，
  有返回值或抛错才唤回窗口展示结果
- 分类管理：新建 / 重命名 / 删除分类（分类下有脚本时拒绝删除），
  脚本支持移动到其它分类、拷贝创建
- 内置脚本 7 个，可只读查看源码或拷贝为自定义脚本后修改：
  - 本地系统：WiFi 密码、Ping 一下、内网 IP
  - 文本处理：今天、英文大写、英文小写、首字母大写
- 内网 IP 通过 UDP 路由探测选出承载默认路由的网卡，
  自动避开 VMware / VirtualBox / Hyper-V / WSL / Docker 等虚拟网卡

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [ ] plugin.json 的 name / title / version / description / author 字段均已检查
- [ ] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [ ] 本次 PR 的 diff 仅涉及 `plugins/automatic-assistant/` 目录
- [ ] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [ ] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
