### PR TITLE
Update plugin zashboard 面板 v2.1.1

### DIFF
--- a/plugins/zashboard-panel/CHANGELOG.md
+++ b/plugins/zashboard-panel/CHANGELOG.md
@@ -1,11 +1,18 @@
 # Changelog
 
-## [2.1.0] - 2026-08-28
+## \[2.1.1\] - 2026-09-03
 
 ### Added
+
+- 新增 README.md，修复插件市场详情页 README 404 问题
+
+## \[2.1.0\] - 2026-08-28
+
+### Added
+
 - 本地内置 zashboard v3.23.0（MIT, Zephyruso），打开即用，无需在线版
-- 发布物料整理：作者署名、CHANGELOG
 
 ### Fixed
+
 - 修复在线版 https 页面无法访问内网 http 后端导致连接失败的问题
 - 移除 file:// 环境下会报错的 service worker 引用

--- a/plugins/zashboard-panel/README.md
+++ b/plugins/zashboard-panel/README.md
@@ -1,0 +1,39 @@
+# zashboard 面板
+
+在 ZTools 面板内直接打开 **zashboard**（Clash / mihomo 代理控制面板），本地内置 zashboard，无需在线版，打开即用。
+
+## 功能
+
+- 🚀 本地内置 zashboard v3.23.0，打开即用，不依赖外网
+- 🔌 支持连接 Clash / mihomo（Clash.Meta）内核，包括路由器上部署的实例
+- 📊 代理节点切换、连接管理、规则查看、流量统计、日志等完整功能
+- 🔒 本地运行，配置保存在本机，不上传任何数据
+
+## 使用方法
+
+1. 在 ZTools 输入框输入 `zash`（或 `zashboard` / `代理面板`）回车；
+2. 首次打开会进入 zashboard 的连接设置页，填写你的 Clash 后端信息：
+   - **主机 Host**：例如 `127.0.0.1`（本机）或 `192.168.31.1`（路由器）
+   - **端口 Port**：Clash 的 external-controller 端口，例如 `9090` 或 `9999`
+   - **密码 Secret**：如果 Clash 配置了 secret 就填写，没有就留空
+3. 点击连接，进入 zashboard 主面板；
+4. 之后打开插件会自动记住后端并直达主面板，要改地址在 zashboard 设置里修改即可。
+
+## 如何确认 Clash 的 API 地址
+
+在浏览器访问 `http://<主机>:<端口>/version`，如果返回类似 `{"meta":true,"version":"v1.19.28"}` 的 JSON，说明该地址就是正确的 API 地址。
+
+## 常见问题
+
+**Q：连接失败怎么办？**
+A：检查主机和端口是否正确、Clash 内核是否在运行、密码是否填写正确。可以先用浏览器访问 `http://<主机>:<端口>/version` 验证 API 是否可达。
+
+**Q：支持路由器上的 Clash 吗？**
+A：支持。只要你的电脑能访问到路由器的 Clash API 端口（external-controller），填写路由器 IP 和对应端口即可。
+
+**Q：需要联网吗？**
+A：zashboard 本体已内置在插件里，打开不需要联网；但连接和控制 Clash 内核需要你的电脑能访问到 Clash API 地址。
+
+## 致谢
+
+- [zashboard](https://github.com/Zephyruso/zashboard)（MIT License，作者 Zephyruso）—— 本插件内置的控制面板本体

--- a/plugins/zashboard-panel/plugin.json
+++ b/plugins/zashboard-panel/plugin.json
@@ -2,9 +2,8 @@
   "name": "zashboard-panel",
   "title": "zashboard 面板",
   "author": "ScottLim",
-  "homepage": "https://github.com/Zephyruso/zashboard",
   "description": "在 ZTools 面板内直接打开 zashboard（Clash/mihomo 代理控制面板）。本地内置 zashboard，打开后在连接设置页填写地址和端口即可使用",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "logo": "logo.png",
   "main": "zashboard/index.html",
   "pluginSetting": {


### PR DESCRIPTION
## 插件信息

- **名称**: zashboard 面板
- **插件ID**: zashboard-panel
- **版本**: 2.1.1
- **描述**: 在 ZTools 面板内直接打开 zashboard（Clash/mihomo 代理控制面板）。本地内置 zashboard，打开后在连接设置页填写地址和端口即可使用
- **作者**: ScottLim
- **类型**: 更新

## 本次变更

### Added

- 新增 README.md，修复插件市场详情页 README 404 问题

## 截图 / 演示

<!-- 如果是新插件或包含界面变化，请附 1-2 张截图或 GIF -->

## 自检清单

- [x] plugin.json 的 name / title / version / description / author 字段均已检查
- [x] 已移除调试日志、未使用文件、敏感信息（.env、token、密钥等）
- [x] 本次 PR 的 diff 仅涉及 `plugins/zashboard-panel/` 目录
- [x] 已在本地 ZTools 客户端实际加载并测试过此插件，主要功能正常
- [x] 同意以仓库声明的开源协议发布此插件

---
*此 PR 由 ztools-plugin-cli 自动管理：每次 `ztools publish` 在分支上追加一个 commit，PR 链接保持不变。*
